### PR TITLE
人物のtypeおよびその他の修正

### DIFF
--- a/ACaseOfIdentity.ttl
+++ b/ACaseOfIdentity.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -5124,15 +5124,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 #Objectとして参照されているリソースの定義
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/left_shes_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの左右の靴"@ja;
     rdfs:label     "left shes of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/left_shes>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/others>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "他人"@ja;
-    rdfs:label     "others"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "others"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notThink>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5151,9 +5152,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "近眼である"@ja;
     rdfs:label     "close eye"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Scarf>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "襟巻き"@ja;
-    rdfs:label     "Scarf"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Scarf"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland>
     rdfs:label     "mother of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -5173,6 +5174,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Eyes"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/house_of_Holmes>
+    rdf:type    kgc:Place;
     rdfs:label     "ホームズの家"@ja;
     rdfs:label     "house of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -5185,13 +5187,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "nose glasses"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Small_black_ball_ornament>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "小粒の黒玉の飾り"@ja;
-    rdfs:label     "Small black ball ornament"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Small black ball ornament"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Handle>
     rdfs:label     "Handle"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_type>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプ打ちの手紙"@ja;
     rdfs:label     "letter of type"@en;
     rdf:type    kgc:OFobj;
@@ -5218,13 +5221,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "simply"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Crime>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "犯罪"@ja;
-    rdfs:label     "Crime"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Crime"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Other_carriages>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "他の馬車"@ja;
-    rdfs:label     "Other carriages"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Other carriages"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/tightly>
     rdf:type    kgc:Property;
     rdfs:label     "きっちりしている"@ja;
@@ -5234,10 +5237,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Romance"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/black_mustache>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "黒い頬髯口髭"@ja;
-    rdfs:label     "black mustache"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "black mustache"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Post_Office_of_Redon_Hall_Street>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レドンホール街郵便局"@ja;
     rdfs:label     "Post Office of Redon Hall Street"@en;
     rdf:type    kgc:OFobj;
@@ -5248,25 +5252,26 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "握る"@ja;
     rdfs:label     "hold"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/police>
+    rdf:type    kgc:Person;
     rdfs:label     "警察"@ja;
     rdfs:label     "police"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/advice_of_Holmes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホームズの助言"@ja;
     rdfs:label     "advice of Holmes"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/advice>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_2>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙2"@ja;
-    rdfs:label     "letter 2"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "letter 2"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/appear>
     rdf:type    kgc:Action;
     rdfs:label     "現れる"@ja;
     rdfs:label     "appear"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_return_of_father_of_Sutherland>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "サザランドの父の帰国前"@ja;
     rdfs:label     "Before return of father of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -5283,10 +5288,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "sad"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Saint_St_Pancras_Hotel>
+    rdf:type    kgc:Place;
     rdfs:label     "聖セントパンクラス・ホテル"@ja;
-    rdfs:label     "Saint St Pancras Hotel"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Saint St Pancras Hotel"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Wrist_double_wire_of_Plush_weave>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "フラシ織の手首の二重線"@ja;
     rdfs:label     "Wrist double wire of Plush weave"@en;
     rdf:type    kgc:OFobj;
@@ -5297,9 +5303,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "会話をする"@ja;
     rdfs:label     "talk"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Incident>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件"@ja;
-    rdfs:label     "Incident"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Incident"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notSend>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5307,6 +5313,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "送らない"@ja;
     rdfs:label     "notSend"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dividend_of_heritage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "遺産の配当"@ja;
     rdfs:label     "dividend of heritage"@en;
     rdf:type    kgc:OFobj;
@@ -5324,6 +5331,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "熱心だ"@ja;
     rdfs:label     "enthusiastic"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの声"@ja;
     rdfs:label     "voice of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -5342,34 +5350,35 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "見ていない"@ja;
     rdfs:label     "notSee"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Letter_1>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙1"@ja;
-    rdfs:label     "Letter 1"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Letter 1"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/detail>
     rdfs:label     "細部"@ja;
     rdfs:label     "detail"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Letter_2>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙2"@ja;
-    rdfs:label     "Letter 2"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Letter 2"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Left_wrist_double_wire_of_Plush_weave>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "左のフラシ織の手首の二重線"@ja;
     rdfs:label     "Left wrist double wire of Plush weave"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Left_wrist_double_wire>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Plush_weave>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Big_problem>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "大問題"@ja;
-    rdfs:label     "Big problem"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Big problem"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/someone>
     rdfs:label     "someone"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Auckland>
+    rdf:type    kgc:Place;
     rdfs:label     "オークランド"@ja;
-    rdfs:label     "Auckland"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Auckland"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/carry>
     rdf:type    kgc:Action;
     rdfs:label     "運ぶ"@ja;
@@ -5401,13 +5410,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Solve"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Street>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "通り"@ja;
-    rdfs:label     "Street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Street"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Dance_Party>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "舞踏会"@ja;
-    rdfs:label     "Dance Party"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dance Party"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death>
     rdfs:label     "death"@en;
     rdf:type    kgc:Object.
@@ -5420,9 +5429,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "確認する"@ja;
     rdfs:label     "confirm"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Redon_Hall_Street>
+    rdf:type    kgc:Place;
     rdfs:label     "レドンホール街"@ja;
-    rdfs:label     "Redon Hall Street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Redon Hall Street"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/West_House&Marbank>
     rdfs:label     "West House&Marbank"@en;
     rdf:type    kgc:Object.
@@ -5435,6 +5444,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "食べる"@ja;
     rdfs:label     "eat"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの職場"@ja;
     rdfs:label     "workplace of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -5445,6 +5455,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "茶褐色だ"@ja;
     rdfs:label     "brown"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sleeve_of_Jacket>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "上着の袖"@ja;
     rdfs:label     "sleeve of Jacket"@en;
     rdf:type    kgc:OFobj;
@@ -5456,6 +5467,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/father>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance_of_Gas_Industry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ガス工組合の舞踏会"@ja;
     rdfs:label     "dance of Gas Industry"@en;
     rdf:type    kgc:OFobj;
@@ -5465,13 +5477,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "neck"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Villain>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "悪党"@ja;
-    rdfs:label     "Villain"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Villain"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes_s_office>
+    rdf:type    kgc:Place;
     rdfs:label     "ホームズの事務所"@ja;
-    rdfs:label     "Holmes's office"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Holmes's office"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/14th_Monday>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "14日朝"@ja;
@@ -5480,9 +5492,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Gas Industry"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Last_Friday>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "先週金曜日"@ja;
-    rdfs:label     "Last Friday"@en.
+    rdfs:label     "Last Friday"@en;
+    rdf:type    kgc:AbstractTime.
 <http://kgc.knowledge-graph.jp/data/predicate/lock>
     rdf:type    kgc:Action;
     rdfs:label     "施錠する"@ja;
@@ -5492,9 +5504,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "怒る"@ja;
     rdfs:label     "angry"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/footsteps>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "足音"@ja;
-    rdfs:label     "footsteps"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "footsteps"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notForget>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5526,7 +5538,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cannotCome"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/disguise>
     rdf:type    kgc:Action;
-    rdfs:label     "せいにする"@ja;
+    rdfs:label     "変装する"@ja;
     rdfs:label     "disguise"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior>
     rdfs:label     "behavior"@en;
@@ -5539,27 +5551,28 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Sutherland's thoughts"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの振る舞い"@ja;
     rdfs:label     "behavior of Hozma"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Purple_plush>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "紫のフラシ天"@ja;
     rdfs:label     "Purple plush"@en;
-    rdfs:label     "紫色のフラシ天"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "紫色のフラシ天"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/date>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "日付"@ja;
-    rdfs:label     "date"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "date"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip>
     rdfs:label     "lip"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hat>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "帽子"@ja;
-    rdfs:label     "hat"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "hat"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/left_shes>
     rdfs:label     "left shes"@en;
     rdf:type    kgc:Object.
@@ -5575,17 +5588,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "husband"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Time_wasted>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "無駄な時間"@ja;
-    rdfs:label     "Time wasted"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Time wasted"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/earn>
     rdf:type    kgc:Action;
     rdfs:label     "稼ぐ"@ja;
     rdfs:label     "earn"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Office>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事務所"@ja;
-    rdfs:label     "Office"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Office"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Break>
     rdfs:label     "Break"@en;
     rdf:type    kgc:Object.
@@ -5593,12 +5606,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "income"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/husband_of_Etheridge>
+    rdf:type    kgc:Person;
     rdfs:label     "エサリッジの夫"@ja;
     rdfs:label     "husband of Etheridge"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/husband>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Etheridge>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/income_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの収入"@ja;
     rdfs:label     "income of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -5641,9 +5656,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "存在する"@ja;
     rdfs:label     "exist"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1877>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "1877年"@ja;
-    rdfs:label     "1877"@en.
+    rdfs:label     "1877"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair>
     rdfs:label     "hair"@en;
     rdf:type    kgc:Object.
@@ -5662,13 +5677,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "そわそわする"@ja;
     rdfs:label     "feelRestless"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Bowler_hat>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "山高帽"@ja;
-    rdfs:label     "Bowler hat"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bowler hat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/New_Zealand>
     rdfs:label     "New Zealand"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Right_wrist_double_wire_of_Plush_weave>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "右のフラシ織の手首の二重線"@ja;
     rdfs:label     "Right wrist double wire of Plush weave"@en;
     rdf:type    kgc:OFobj;
@@ -5678,26 +5694,27 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Like"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Danger>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "危険"@ja;
-    rdfs:label     "Danger"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Danger"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの筆跡"@ja;
     rdfs:label     "handwriting of Windybank"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heritage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "遺産"@ja;
-    rdfs:label     "heritage"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "heritage"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/ice>
     rdfs:label     "ice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/less_than_60_GBP>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "60ポンド以下の収入で"@ja;
-    rdfs:label     "less than 60 GBP"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "less than 60 GBP"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Love>
     rdfs:label     "Love"@en;
     rdf:type    kgc:Object.
@@ -5706,46 +5723,47 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "最大のクラレット輸入業者"@ja;
     rdfs:label     "largest claret importer"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/West_House&Marbank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウェストハウス＆マーバンク"@ja;
-    rdfs:label     "West House&Marbank"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "West House&Marbank"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Thumb_nail>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "親指の爪"@ja;
-    rdfs:label     "Thumb nail"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Thumb nail"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Redon_Hall_Street>
     rdfs:label     "Redon Hall Street"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Typewriter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプライター"@ja;
-    rdfs:label     "Typewriter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Typewriter"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Saint_St._Savior_Church>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "聖セントセイヴィア教会"@ja;
-    rdfs:label     "Saint St. Savior Church"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Saint St. Savior Church"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Terrible_things>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ひどい目に"@ja;
-    rdfs:label     "Terrible things"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Terrible things"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/overlook>
     rdf:type    kgc:Action;
-    rdfs:label     "見落としている"@ja;
+    rdfs:label     "見落とす"@ja;
     rdfs:label     "overlook"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/road>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "道"@ja;
-    rdfs:label     "road"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "road"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/relation_of_Hosma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドとホズマとの関係"@ja;
     rdfs:label     "relation of Hosma"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/relation>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Near_sight>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "近眼"@ja;
-    rdfs:label     "Near sight"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Near sight"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/praise>
     rdfs:label     "praise"@en;
     rdf:type    kgc:Object.
@@ -5756,9 +5774,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hem"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Plush_weave>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "フラシ織"@ja;
-    rdfs:label     "Plush weave"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Plush weave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notRelyOn>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5769,7 +5787,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/like>;
-    rdfs:label     "嫌がる"@ja;
+    rdfs:label     "嫌いである"@ja;
     rdfs:label     "notLike"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/this_morning>
     rdf:type    kgc:AbstractTime;
@@ -5785,22 +5803,23 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Escape"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/brother_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの兄弟親友"@ja;
     rdfs:label     "brother of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/brother>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/twice>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "二度"@ja;
-    rdfs:label     "twice"@en.
+    rdfs:label     "twice"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/Hesitate>
     rdfs:label     "Hesitate"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Same_incident>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "同一の事件"@ja;
-    rdfs:label     "Same incident"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Same incident"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/heritage>
     rdfs:label     "heritage"@en;
     rdf:type    kgc:Object.
@@ -5810,12 +5829,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "imply"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
-    rdfs:label     "会う"@ja;
-    rdfs:label     "meet"@en.
+    rdfs:label     "出会う"@ja;
+    rdfs:label     "meet"@en;
+    rdfs:label     "会う"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/type>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプ"@ja;
-    rdfs:label     "type"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "type"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/examine>
     rdf:type    kgc:Action;
     rdfs:label     "調べる"@ja;
@@ -5829,17 +5849,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "取り除く"@ja;
     rdfs:label     "remove"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/At_last>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "最後"@ja;
-    rdfs:label     "At last"@en.
+    rdfs:label     "At last"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sunday_school_events>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "日曜学校の催し"@ja;
-    rdfs:label     "Sunday school events"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Sunday school events"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Shoelaces>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "靴ひも"@ja;
-    rdfs:label     "Shoelaces"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Shoelaces"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/people>
     rdfs:label     "people"@en;
     rdf:type    kgc:Object.
@@ -5848,13 +5868,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "賛成する"@ja;
     rdfs:label     "agree"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Andova>
+    rdf:type    kgc:Place;
     rdfs:label     "アンドーヴァ"@ja;
-    rdfs:label     "Andova"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Andova"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace>
     rdfs:label     "workplace"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/eyes_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの灰色の瞳"@ja;
     rdfs:label     "eyes of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -5870,9 +5891,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Face value"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Personal_statement>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "人相書"@ja;
-    rdfs:label     "Personal statement"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Personal statement"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/encounter>
     rdf:type    kgc:Action;
     rdfs:label     "遭う"@ja;
@@ -5881,6 +5902,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "friend"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland>
+    rdf:type    kgc:Person;
     rdfs:label     "サザランドの母"@ja;
     rdfs:label     "mother of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -5897,6 +5919,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "love"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの顔色"@ja;
     rdfs:label     "color of face of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -5909,23 +5932,24 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "束縛する"@ja;
     rdfs:label     "bind"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/disguise>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "変装"@ja;
-    rdfs:label     "disguise"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "disguise"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Moth>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鞭"@ja;
     rdfs:label     "Moth"@en;
-    rdfs:label     "髯"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "髯"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/bePleased>
     rdf:type    kgc:Action;
     rdfs:label     "喜ぶ"@ja;
     rdfs:label     "bePleased"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/more_than_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランド"@ja;
-    rdfs:label     "more than Sutherland"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "more than Sutherland"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの住所"@ja;
     rdfs:label     "Address of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -5944,11 +5968,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "一致する"@ja;
     rdfs:label     "match"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Red_feather>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "赤い羽根"@ja;
-    rdfs:label     "Red feather"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Red feather"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/morning_of_wedding_day>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "結婚式の当日の朝"@ja;
     rdfs:label     "morning of wedding day"@en;
     rdf:type    kgc:OFobj;
@@ -5964,10 +5987,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "BeUsed"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Bible>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "聖書"@ja;
-    rdfs:label     "Bible"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bible"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/age_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの年"@ja;
     rdfs:label     "age of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -5977,15 +6001,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Stop"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/thumb_of_Right_glove>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "右手袋の親指"@ja;
     rdfs:label     "thumb of Right glove"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/thumb>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Right_glove>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/black_whisker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "黒い頬髯口髭"@ja;
-    rdfs:label     "black whisker"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "black whisker"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotStop>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -5999,20 +6024,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "信じない"@ja;
     rdfs:label     "notBelieve"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/law>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "法律"@ja;
-    rdfs:label     "law"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "law"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotFind>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つからない"@ja;
+    rdfs:label     "見つけられない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/blurred>
     rdf:type    kgc:Property;
     rdfs:label     "不鮮明である"@ja;
     rdfs:label     "blurred"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの顔"@ja;
     rdfs:label     "face of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -6029,15 +6055,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Throw"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの体格"@ja;
     rdfs:label     "body of Hozma"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/paper>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "論文"@ja;
-    rdfs:label     "paper"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "paper"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/wedding_day>
     rdfs:label     "wedding day"@en;
     rdf:type    kgc:Object.
@@ -6045,15 +6072,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "personalities"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの唇"@ja;
     rdfs:label     "lip of Windybank"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Weak_throat>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "弱い喉"@ja;
-    rdfs:label     "Weak throat"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Weak throat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/getOn>
     rdf:type    kgc:Action;
     rdfs:label     "乗る"@ja;
@@ -6066,17 +6094,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notThrow"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/jumpUp>
     rdf:type    kgc:Action;
-    rdfs:label     "飛び上がる"@ja;
+    rdfs:label     "跳び上がる"@ja;
     rdfs:label     "jumpUp"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/gloves>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手袋"@ja;
-    rdfs:label     "gloves"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "gloves"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/drop>
     rdf:type    kgc:Action;
     rdfs:label     "落とす"@ja;
     rdfs:label     "drop"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの髪"@ja;
     rdfs:label     "hair of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -6087,19 +6116,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "お人好しである"@ja;
     rdfs:label     "good-natured"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Coworker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "同僚"@ja;
-    rdfs:label     "Coworker"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Coworker"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/button>
     rdfs:label     "button"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Church>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "教会"@ja;
-    rdfs:label     "Church"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Church"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/surprise>
     rdf:type    kgc:Action;
-    rdfs:label     "驚く"@ja;
+    rdfs:label     "驚かせる"@ja;
     rdfs:label     "surprise"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/absent>
     rdf:type    kgc:Property;
@@ -6113,6 +6142,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "typewritter"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの会社"@ja;
     rdfs:label     "company of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -6138,13 +6168,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "怒っていない"@ja;
     rdfs:label     "notAngry"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Fengchurch_Street>
+    rdf:type    kgc:Place;
     rdfs:label     "フェンチャーチ街"@ja;
-    rdfs:label     "Fengchurch Street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Fengchurch Street"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance>
     rdfs:label     "appearance"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/friend_of_father_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの父の友人"@ja;
     rdfs:label     "friend of father of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -6181,6 +6212,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "5 years 2 months"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドのお金"@ja;
     rdfs:label     "money of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -6213,14 +6245,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "思う"@ja;
     rdfs:label     "think"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_Hozma>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "ホズマより先"@ja;
-    rdfs:label     "Before Hozma"@en.
+    rdfs:label     "Before Hozma"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/know>
     rdf:type    kgc:Action;
     rdfs:label     "知る"@ja;
     rdfs:label     "know"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/feature_of_type>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプの特徴"@ja;
     rdfs:label     "feature of type"@en;
     rdf:type    kgc:OFobj;
@@ -6231,6 +6264,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "入ってくる"@ja;
     rdfs:label     "comeIn"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/head_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの頭頂"@ja;
     rdfs:label     "head of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -6241,10 +6275,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着る"@ja;
+    rdfs:label     "着ている"@ja;
     rdfs:label     "wear"@en;
-    rdf:type    kgc:Action.
+    rdf:type    kgc:Action;
+    rdfs:label     "着る"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appeal_of_breach_of_pledge>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "誓約不履行の訴え"@ja;
     rdfs:label     "Appeal of breach of pledge"@en;
     rdf:type    kgc:OFobj;
@@ -6253,13 +6289,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/breach>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/pledge>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/gavel>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "小禿"@ja;
-    rdfs:label     "gavel"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "gavel"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Current>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "現在"@ja;
-    rdfs:label     "Current"@en.
+    rdfs:label     "Current"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger>
     rdfs:label     "danger"@en;
     rdf:type    kgc:Object.
@@ -6271,9 +6307,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "愛する"@ja;
     rdfs:label     "love"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Pavement_opposite>
+    rdf:type    kgc:Place;
     rdfs:label     "向かいの舗道"@ja;
-    rdfs:label     "Pavement opposite"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Pavement opposite"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/jumpOut>
     rdf:type    kgc:Action;
     rdfs:label     "飛び出す"@ja;
@@ -6286,34 +6322,37 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Like handwriting"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mark_of_nose_glasses>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鼻眼鏡の跡"@ja;
     rdfs:label     "mark of nose glasses"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mark>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/nose_glasses>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/value>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "価値"@ja;
-    rdfs:label     "value"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "value"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Single_women>
+    rdf:type    kgc:Person;
     rdfs:label     "独身女性"@ja;
-    rdfs:label     "Single women"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Single women"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/lead>
     rdf:type    kgc:Action;
-    rdfs:label     "率いる"@ja;
+    rdfs:label     "導く"@ja;
     rdfs:label     "lead"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/expensive_cloth>
     rdf:type    kgc:Property;
     rdfs:label     "高価な生地である"@ja;
     rdfs:label     "expensive cloth"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/relation_of_same-aged_people>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "同年代の人間との交際"@ja;
     rdfs:label     "relation of same-aged people"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/relation>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/same-aged_people>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Treatment_of_serious_patients>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "重篤な患者の治療"@ja;
     rdfs:label     "Treatment of serious patients"@en;
     rdf:type    kgc:OFobj;
@@ -6332,24 +6371,26 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "毎日"@ja;
     rdfs:label     "every day"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Last_Satuaday>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "先週土曜日"@ja;
-    rdfs:label     "Last Satuaday"@en.
+    rdfs:label     "Last Satuaday"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "顔"@ja;
-    rdfs:label     "face"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "face"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Less_than>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "以下"@ja;
-    rdfs:label     "Less than"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Less than"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heart_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの心"@ja;
     rdfs:label     "heart of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heart>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Eyes_of_hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの目"@ja;
     rdfs:label     "Eyes of hozma"@en;
     rdf:type    kgc:OFobj;
@@ -6364,13 +6405,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "正しい"@ja;
     rdfs:label     "correct"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Gallow>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "絞首台"@ja;
-    rdfs:label     "Gallow"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Gallow"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/glasses>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "眼鏡"@ja;
-    rdfs:label     "glasses"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "glasses"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/engage>
     rdf:type    kgc:Action;
     rdfs:label     "婚約する"@ja;
@@ -6379,28 +6420,29 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "characteristics"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Late>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "遅刻"@ja;
-    rdfs:label     "Late"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Late"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/type>
     rdfs:label     "type"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/worry>
     rdf:type    kgc:Action;
     rdfs:label     "悩む"@ja;
-    rdfs:label     "worry"@en.
+    rdfs:label     "worry"@en;
+    rdfs:label     "心配する"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/one_quarter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "四分の一"@ja;
-    rdfs:label     "one quarter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "one quarter"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/whiskers>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "頬髯"@ja;
-    rdfs:label     "whiskers"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "whiskers"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "椅子"@ja;
-    rdfs:label     "Chair"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Chair"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/selfish>
     rdfs:label     "残酷で身勝手な"@ja;
     rdfs:label     "selfish"@en;
@@ -6422,17 +6464,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Red_brick_feather>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "赤煉瓦色の羽根"@ja;
-    rdfs:label     "Red brick feather"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Red brick feather"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/puzzled>
     rdf:type    kgc:Action;
     rdfs:label     "戸惑っている"@ja;
     rdfs:label     "puzzled"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/cold_sweat>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "冷や汗"@ja;
-    rdfs:label     "cold sweat"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cold sweat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/come>
     rdf:type    kgc:Action;
     rdfs:label     "来る"@ja;
@@ -6448,13 +6490,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/predicate/pullOut>
     rdf:type    kgc:Action;
-    rdfs:label     "引きだす"@ja;
+    rdfs:label     "引き出す"@ja;
     rdfs:label     "pullOut"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/mess>
     rdf:type    kgc:Action;
     rdfs:label     "いじる"@ja;
     rdfs:label     "mess"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger_of_hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの危険"@ja;
     rdfs:label     "danger of hozma"@en;
     rdf:type    kgc:OFobj;
@@ -6478,6 +6521,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "眠っている"@ja;
     rdfs:label     "asleep"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/meaning_of_word_of_Holmes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホームズの言葉の意味に"@ja;
     rdfs:label     "meaning of word of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -6499,13 +6543,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "beBeaten"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "集中している"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "focus"@en;
     rdf:type    kgc:Property;
     rdfs:label     "目ざとい"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/lookAround>
     rdf:type    kgc:Action;
-    rdfs:label     "ながめ回す"@ja;
+    rdfs:label     "見まわす"@ja;
     rdfs:label     "lookAround"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/After_a_week>
     rdf:type    kgc:AbstractTime;
@@ -6515,9 +6559,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "handwriting"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Inquirer_advertisement>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "尋ね人広告"@ja;
-    rdfs:label     "Inquirer advertisement"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Inquirer advertisement"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/edge>
     rdfs:label     "edge"@en;
     rdf:type    kgc:Object.
@@ -6579,10 +6623,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "感じる"@ja;
     rdfs:label     "feel"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Tonsillitis>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "扁桃炎"@ja;
-    rdfs:label     "Tonsillitis"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Tonsillitis"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/coat_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの上着"@ja;
     rdfs:label     "coat of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -6597,7 +6642,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/Have>
     rdfs:label     "Have"@en;
-    rdfs:label     "持つ"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotHandle>
     rdf:type    kgc:Action;
@@ -6617,13 +6661,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Illegally"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
     rdfs:label     "Holmes"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/respect>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "敬意"@ja;
-    rdfs:label     "respect"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "respect"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/husband_of_Etheridge>
     rdfs:label     "husband of Etheridge"@en;
     rdf:type    kgc:OFobj;
@@ -6646,9 +6691,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "訴えない"@ja;
     rdfs:label     "notComplain"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/window>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓"@ja;
-    rdfs:label     "window"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "window"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/approach>
     rdf:type    kgc:Action;
     rdfs:label     "近寄る"@ja;
@@ -6661,14 +6706,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "serious patients"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Small_round_gold_earring>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "小振りの丸い金の耳飾り"@ja;
-    rdfs:label     "Small round gold earring"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Small round gold earring"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/stand>
     rdf:type    kgc:Action;
     rdfs:label     "立つ"@ja;
     rdfs:label     "stand"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/gloves_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの手袋"@ja;
     rdfs:label     "gloves of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -6686,6 +6732,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "right shoes"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Method_of_Watson>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ワトソンの方法"@ja;
     rdfs:label     "Method of Watson"@en;
     rdf:type    kgc:OFobj;
@@ -6693,28 +6740,28 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson>.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
-    rdfs:label     "開く"@ja;
+    rdfs:label     "開ける"@ja;
     rdfs:label     "open"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/father_of_Sutherland>
+    rdf:type    kgc:Person;
     rdfs:label     "サザランドの父"@ja;
     rdfs:label     "father of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/father>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Earning>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "稼ぎ"@ja;
-    rdfs:label     "Earning"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Earning"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Etheridge>
+    rdf:type    kgc:Person;
     rdfs:label     "エサリッジ"@ja;
-    rdfs:label     "Etheridge"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Etheridge"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Many_times>
     rdfs:label     "何度も"@ja;
     rdfs:label     "Many times"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/existence_of_Windybank>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "ウィンディバンクがいる間"@ja;
     rdfs:label     "existence of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -6734,19 +6781,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "shoes"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hague>
+    rdf:type    kgc:Place;
     rdfs:label     "ハーグ"@ja;
-    rdfs:label     "Hague"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Hague"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/yield_of_heritage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "利回り"@ja;
     rdfs:label     "yield of heritage"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/yield>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heritage>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/reply>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "返事"@ja;
-    rdfs:label     "reply"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "reply"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/thinking>
     rdf:type    kgc:Action;
     rdfs:label     "思っている"@ja;
@@ -6771,9 +6819,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "悪い"@ja;
     rdfs:label     "bad"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/parent>
+    rdf:type    kgc:Person;
     rdfs:label     "親"@ja;
-    rdfs:label     "parent"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "parent"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Sutherland>
     rdfs:label     "Sutherland"@en;
     rdf:type    kgc:Object.
@@ -6781,20 +6829,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Address"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Up_to_20_sheets>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "最大20枚"@ja;
-    rdfs:label     "Up to 20 sheets"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Up to 20 sheets"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/breakfast>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "朝食"@ja;
-    rdfs:label     "breakfast"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "breakfast"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Appear>
     rdfs:label     "Appear"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Ned>
+    rdf:type    kgc:Person;
     rdfs:label     "ネッド"@ja;
-    rdfs:label     "Ned"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Ned"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/breach_of_pledge>
     rdfs:label     "breach of pledge"@en;
     rdf:type    kgc:OFobj;
@@ -6805,29 +6853,29 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "否定する"@ja;
     rdfs:label     "deny"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/margin>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "余裕"@ja;
-    rdfs:label     "margin"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "margin"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/signature>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "署名"@ja;
-    rdfs:label     "signature"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "signature"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/inform>
     rdf:type    kgc:Action;
     rdfs:label     "知らせる"@ja;
     rdfs:label     "inform"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "椅子"@ja;
-    rdfs:label     "chair"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "chair"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/say>
     rdf:type    kgc:Action;
     rdfs:label     "言う"@ja;
     rdfs:label     "say"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Important_point>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "大事な点"@ja;
-    rdfs:label     "Important point"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Important point"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/easygoing>
     rdf:type    kgc:Property;
     rdfs:label     "のんきである"@ja;
@@ -6837,6 +6885,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "誓う"@ja;
     rdfs:label     "swear"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/door_of_Room_of_Holmes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "部屋の扉"@ja;
     rdfs:label     "door of Room of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -6845,9 +6894,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Room>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Typing>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "タイプ打ち"@ja;
-    rdfs:label     "Typing"@en.
+    rdfs:label     "Typing"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/Think>
     rdfs:label     "Think"@en;
     rdf:type    kgc:Object.
@@ -6867,9 +6916,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Say"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Clothes_to_wear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "着る服"@ja;
-    rdfs:label     "Clothes to wear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Clothes to wear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/letter>
     rdfs:label     "letter"@en;
     rdf:type    kgc:Object.
@@ -6880,6 +6929,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "clue"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Oversight_of_others>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "他人の見落とし"@ja;
     rdfs:label     "Oversight of others"@en;
     rdf:type    kgc:OFobj;
@@ -6893,6 +6943,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "呑気である"@ja;
     rdfs:label     "careless"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clue_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの手がかり"@ja;
     rdfs:label     "clue of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -6905,27 +6956,28 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "訴えることができる"@ja;
     rdfs:label     "canSue"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家"@ja;
     rdfs:label     "House of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Pledge>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "誓約"@ja;
-    rdfs:label     "Pledge"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Pledge"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "失踪時"@ja;
-    rdfs:label     "missing"@en.
+    rdfs:label     "missing"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Customer>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "客"@ja;
-    rdfs:label     "Customer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Customer"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/home>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家庭"@ja;
-    rdfs:label     "home"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "home"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Treatment>
     rdfs:label     "Treatment"@en;
     rdf:type    kgc:Object.
@@ -6944,10 +6996,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "迎える"@ja;
     rdfs:label     "welcome"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland_House>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの家"@ja;
-    rdfs:label     "Sutherland House"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Sutherland House"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの体格"@ja;
     rdfs:label     "body of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -6958,12 +7011,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "行きたくない"@ja;
     rdfs:label     "unwillingToGo"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの服装"@ja;
     rdfs:label     "clothes of Hozma"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Important_of_minor>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "細事の大事"@ja;
     rdfs:label     "Important of minor"@en;
     rdf:type    kgc:OFobj;
@@ -6987,7 +7042,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/close>
     rdf:type    kgc:Action;
     rdfs:label     "閉める"@ja;
-    rdfs:label     "close"@en.
+    rdfs:label     "close"@en;
+    rdfs:label     "閉じる"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/need>
     rdf:type    kgc:Action;
     rdfs:label     "必要とする"@ja;
@@ -7018,14 +7074,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/shares>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/New_Zealand>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "呼び鈴"@ja;
-    rdfs:label     "bell"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bell"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hardy>
+    rdf:type    kgc:Person;
     rdfs:label     "ハーディ"@ja;
-    rdfs:label     "Hardy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Hardy"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/characteristics_of_type>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプの特徴"@ja;
     rdfs:label     "characteristics of type"@en;
     rdf:type    kgc:OFobj;
@@ -7036,13 +7093,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "健康である"@ja;
     rdfs:label     "healthy"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_by_Typewriter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプライターの手紙"@ja;
-    rdfs:label     "letter by Typewriter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "letter by Typewriter"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/after_dance>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "舞踏会の後"@ja;
-    rdfs:label     "after dance"@en.
+    rdfs:label     "after dance"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/believe>
     rdf:type    kgc:Action;
     rdfs:label     "信じる"@ja;
@@ -7052,9 +7109,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "赤らめる"@ja;
     rdfs:label     "blush"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Under_hansom_carriage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "辻馬車の下"@ja;
-    rdfs:label     "Under hansom carriage"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Under hansom carriage"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Method>
     rdfs:label     "Method"@en;
     rdf:type    kgc:Object.
@@ -7071,9 +7128,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "笑う"@ja;
     rdfs:label     "laugh"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Two_letters>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "二通手紙"@ja;
-    rdfs:label     "Two letters"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Two letters"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/black_best>
     rdf:type    kgc:Property;
     rdfs:label     "黒のベストである"@ja;
@@ -7083,13 +7140,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "whisper"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dignity>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "気品"@ja;
-    rdfs:label     "dignity"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "dignity"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/treat>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ごまかし"@ja;
-    rdfs:label     "treat"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "treat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Complain>
     rdfs:label     "Complain"@en;
     rdf:type    kgc:Object.
@@ -7098,9 +7155,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "覗く"@ja;
     rdfs:label     "peep"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/woman>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "女"@ja;
-    rdfs:label     "woman"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "woman"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/leave>
     rdf:type    kgc:Action;
     rdfs:label     "去る"@ja;
@@ -7135,6 +7192,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "meaning"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/finger_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの指"@ja;
     rdfs:label     "finger of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7150,6 +7208,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/father>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/people_of_Dance_party>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "舞踏会の人"@ja;
     rdfs:label     "people of Dance party"@en;
     rdf:type    kgc:OFobj;
@@ -7170,25 +7229,26 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/repeat>
     rdf:type    kgc:Action;
-    rdfs:label     "重ねる"@ja;
+    rdfs:label     "繰り返す"@ja;
     rdfs:label     "repeat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/relive>
     rdf:type    kgc:Action;
     rdfs:label     "安心する"@ja;
     rdfs:label     "relive"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/4700_GBP>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "4700ポンド"@ja;
-    rdfs:label     "4700 GBP"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "4700 GBP"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dead>
     rdfs:label     "死んだよう"@ja;
     rdfs:label     "dead"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受け取る"@ja;
+    rdfs:label     "受ける"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/straw_hat_of_Blackboard_color>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "黒板色の鍔広麦わら帽子"@ja;
     rdfs:label     "straw hat of Blackboard color"@en;
     rdf:type    kgc:OFobj;
@@ -7214,10 +7274,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "裕福である"@ja;
     rdfs:label     "wealthy"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/yield>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "利回り"@ja;
-    rdfs:label     "yield"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "yield"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの生死"@ja;
     rdfs:label     "Life of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -7228,6 +7289,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "置く"@ja;
     rdfs:label     "put"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/story_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの話"@ja;
     rdfs:label     "story of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7238,26 +7300,27 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "十分である"@ja;
     rdfs:label     "enough"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/One_Typewriter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "１つのタイプライター"@ja;
-    rdfs:label     "One Typewriter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "One Typewriter"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/deposit>
     rdf:type    kgc:Action;
     rdfs:label     "預けている"@ja;
     rdfs:label     "deposit"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Armchair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "肘掛け椅子"@ja;
     rdfs:label     "Armchair"@en;
-    rdfs:label     "肘掛椅子"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "肘掛椅子"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appeal>
     rdfs:label     "Appeal"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Love>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "情"@ja;
-    rdfs:label     "Love"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Love"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/love_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの愛"@ja;
     rdfs:label     "love of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7275,22 +7338,23 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/mark>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/type>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/door>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "扉"@ja;
-    rdfs:label     "door"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "door"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/rebel>
     rdf:type    kgc:Action;
     rdfs:label     "反抗する"@ja;
     rdfs:label     "rebel"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "母"@ja;
-    rdfs:label     "mother"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "mother"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Morning>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "朝"@ja;
     rdfs:label     "Morning"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sleeve_of_Woman>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "女の袖"@ja;
     rdfs:label     "sleeve of Woman"@en;
     rdf:type    kgc:OFobj;
@@ -7309,12 +7373,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "逃げられない"@ja;
     rdfs:label     "cannotEscape"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/friend_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの兄弟親友"@ja;
     rdfs:label     "friend of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/friend>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Between_seams_of_window>
+    rdf:type    kgc:Place;
     rdfs:label     "窓掛けの合わせ目の間"@ja;
     rdfs:label     "Between seams of window"@en;
     rdf:type    kgc:OFobj;
@@ -7347,9 +7413,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ぶら下げている"@ja;
     rdfs:label     "hanging"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "衣服"@ja;
-    rdfs:label     "clothes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "clothes"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Father>
     rdfs:label     "Father"@en;
     rdf:type    kgc:Object.
@@ -7375,26 +7441,27 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "relation"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Handwritten_letter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手書きの手紙"@ja;
-    rdfs:label     "Handwritten letter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Handwritten letter"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Violet_ink>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "すみれ色のインク"@ja;
-    rdfs:label     "Violet ink"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Violet ink"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/older>
     rdf:type    kgc:Property;
     rdfs:label     "年上である"@ja;
     rdfs:label     "older"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>
+    rdf:type    kgc:Person;
     rdfs:label     "ウィンディバンク"@ja;
     rdfs:label     "Windybank"@en;
-    rdfs:label     "ウィンディバンクの物腰"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの物腰"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/100_GBP>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "100ポンド"@ja;
-    rdfs:label     "100 GBP"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "100 GBP"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Cheat>
     rdfs:label     "Cheat"@en;
     rdf:type    kgc:Object.
@@ -7404,37 +7471,36 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "enter"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Horizontal_shelf>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "横棚"@ja;
-    rdfs:label     "Horizontal shelf"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Horizontal shelf"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Company>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "会社"@ja;
-    rdfs:label     "Company"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Company"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/one_year>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "一年"@ja;
     rdfs:label     "one year"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "声"@ja;
-    rdfs:label     "voice"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "voice"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/small>
     rdf:type    kgc:Property;
     rdfs:label     "小さい"@ja;
     rdfs:label     "small"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/14_features>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "14の特徴"@ja;
-    rdfs:label     "14 features"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "14 features"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosma>
     rdfs:label     "Hosma"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Morning_of_wedding_day>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "結婚式当日の朝"@ja;
     rdfs:label     "Morning of wedding day"@en;
     rdf:type    kgc:OFobj;
@@ -7456,9 +7522,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Dramatically"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/60_GBP>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "60ポンド"@ja;
-    rdfs:label     "60 GBP"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "60 GBP"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life>
     rdfs:label     "Life"@en;
     rdf:type    kgc:Object.
@@ -7467,17 +7533,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "報告する"@ja;
     rdfs:label     "report"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "お金"@ja;
-    rdfs:label     "money"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "money"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/safe>
     rdf:type    kgc:Property;
     rdfs:label     "安全である"@ja;
     rdfs:label     "safe"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Note>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "メモ"@ja;
-    rdfs:label     "Note"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Note"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Meet>
     rdfs:label     "Meet"@en;
     rdf:type    kgc:Object.
@@ -7486,6 +7552,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "おっとりしている"@ja;
     rdfs:label     "relaxed"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/shop_of_father_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "店"@ja;
     rdfs:label     "shop of father of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7502,11 +7569,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "現れない"@ja;
     rdfs:label     "notAppear"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mustache>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "口髯"@ja;
     rdfs:label     "mustache"@en;
-    rdfs:label     "口髭"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "口髭"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの身なり"@ja;
     rdfs:label     "appearance of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7522,7 +7590,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "要求する"@ja;
+    rdfs:label     "依頼する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance_of_Gas_Industry>
     rdfs:label     "dance of Gas Industry"@en;
@@ -7547,10 +7615,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "騙せない"@ja;
     rdfs:label     "cannotCheat"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sleeve>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "袖"@ja;
-    rdfs:label     "sleeve"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "sleeve"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/right_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "権利"@ja;
     rdfs:label     "right of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7564,6 +7633,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "gold"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Hosma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの手紙"@ja;
     rdfs:label     "letter of Hosma"@en;
     rdf:type    kgc:OFobj;
@@ -7576,9 +7646,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "dividend"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Totenham_Court_street>
+    rdf:type    kgc:Place;
     rdfs:label     "トテナム・コート通り"@ja;
-    rdfs:label     "Totenham Court street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Totenham Court street"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/beWritten>
     rdf:type    kgc:Action;
     rdfs:label     "書かれている"@ja;
@@ -7594,18 +7664,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "会えない"@ja;
     rdfs:label     "cannotMeet"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Color_glasses>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "色眼鏡"@ja;
-    rdfs:label     "Color glasses"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Color glasses"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Left_and_right_separate_shoes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "左右別の靴"@ja;
-    rdfs:label     "Left and right separate shoes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Left and right separate shoes"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/beTypeed>
     rdf:type    kgc:Action;
     rdfs:label     "タイプである"@ja;
     rdfs:label     "beTypeed"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの身だしなみ"@ja;
     rdfs:label     "appearance of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -7633,6 +7704,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "勧める"@ja;
     rdfs:label     "recommend"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death_of_husband_of_Etheridge>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "エサリッジの夫の死亡"@ja;
     rdfs:label     "death of husband of Etheridge"@en;
     rdf:type    kgc:OFobj;
@@ -7655,10 +7727,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Surprised"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Around>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "回り"@ja;
-    rdfs:label     "Around"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Around"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの顔色"@ja;
     rdfs:label     "color of face of hozma"@en;
     rdf:type    kgc:OFobj;
@@ -7667,6 +7740,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの手紙"@ja;
     rdfs:label     "letter of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7674,7 +7748,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪れる"@ja;
+    rdfs:label     "訪ねる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/albert_chain_of_gold>
     rdf:type    kgc:Property;
@@ -7688,6 +7762,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ウィンディバンクである"@ja;
     rdfs:label     "is"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの居場所"@ja;
     rdfs:label     "location of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -7732,9 +7807,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "解決できる"@ja;
     rdfs:label     "canSolve"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Boy>
+    rdf:type    kgc:Person;
     rdfs:label     "給仕服の少年"@ja;
-    rdfs:label     "Boy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Boy"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/continue>
     rdf:type    kgc:Action;
     rdfs:label     "続けている"@ja;
@@ -7747,6 +7822,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hozma"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/signature_of_letter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙の署名"@ja;
     rdfs:label     "signature of letter"@en;
     rdf:type    kgc:OFobj;
@@ -7757,9 +7833,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "奪う"@ja;
     rdfs:label     "rob"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/2_pence>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "2ペンス"@ja;
-    rdfs:label     "2 pence"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "2 pence"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/large_money>
     rdfs:label     "大金"@ja;
     rdfs:label     "large money"@en;
@@ -7769,25 +7845,27 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "消える"@ja;
     rdfs:label     "disappear"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの住所"@ja;
     rdfs:label     "Address of Hozma"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Face_value_of_heritage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "遺産の額面"@ja;
     rdfs:label     "Face value of heritage"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Face_value>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heritage>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Family_calamity>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家庭の災難"@ja;
-    rdfs:label     "Family calamity"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Family calamity"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "以前"@ja;
-    rdfs:label     "Before"@en.
+    rdfs:label     "Before"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/solve>
     rdf:type    kgc:Action;
     rdfs:label     "解決する"@ja;
@@ -7809,30 +7887,32 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "not持つ"@ja;
+    rdfs:label     "持たない"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Continue>
     rdfs:label     "Continue"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Character_position>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "文字の位置"@ja;
-    rdfs:label     "Character position"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Character position"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/shoes_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの靴"@ja;
     rdfs:label     "shoes of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/shoes>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Compassion>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "思いやり"@ja;
-    rdfs:label     "Compassion"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Compassion"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/leaveBehind>
     rdf:type    kgc:Action;
     rdfs:label     "置いていく"@ja;
     rdfs:label     "leaveBehind"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Industries_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの業種"@ja;
     rdfs:label     "Industries of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -7840,7 +7920,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "しようとする"@ja;
+    rdfs:label     "試みる"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/string>
     rdfs:label     "string"@en;
@@ -7867,6 +7947,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "気を配る"@ja;
     rdfs:label     "payAttention"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家"@ja;
     rdfs:label     "House of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -7881,9 +7962,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Service Boy"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/one_sheet>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "1枚で"@ja;
-    rdfs:label     "one sheet"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "one sheet"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotSleep>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -7891,19 +7972,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "眠れない"@ja;
     rdfs:label     "cannotSleep"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Corridor>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "廊下"@ja;
-    rdfs:label     "Corridor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Corridor"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの身長"@ja;
     rdfs:label     "height of Hozma"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Just_before_the_letter_arrives>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "手紙が着く直前"@ja;
-    rdfs:label     "Just before the letter arrives"@en.
+    rdfs:label     "Just before the letter arrives"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/gain>
     rdf:type    kgc:Action;
     rdfs:label     "獲得する"@ja;
@@ -7917,10 +7999,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "レドンホール街である"@ja;
     rdfs:label     "Redon Hall street"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hunting_whistle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "狩猟鞭"@ja;
-    rdfs:label     "Hunting whistle"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Hunting whistle"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/thought_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの思い"@ja;
     rdfs:label     "thought of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -7944,6 +8027,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/teller>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/Redon_Hall_Street_office>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの人相書き"@ja;
     rdfs:label     "personalities of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -7958,6 +8042,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sender>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak_of_hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの話し方"@ja;
     rdfs:label     "speak of hozma"@en;
     rdf:type    kgc:OFobj;
@@ -7967,19 +8052,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Blackboard color"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/right_shoes_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの左右の靴"@ja;
     rdfs:label     "right shoes of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/right_shoes>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Mystery>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "謎"@ja;
-    rdfs:label     "Mystery"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Mystery"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/machine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "機械"@ja;
-    rdfs:label     "machine"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "machine"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Forget>
     rdfs:label     "Forget"@en;
     rdf:type    kgc:Object.
@@ -7999,10 +8085,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Oversight"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Woman>
+    rdf:type    kgc:Person;
     rdfs:label     "女性"@ja;
     rdfs:label     "Woman"@en;
-    rdfs:label     "女"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "女"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/Come>
     rdfs:label     "Come"@en;
     rdf:type    kgc:Object.
@@ -8022,6 +8109,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "裕福ではない"@ja;
     rdfs:label     "notRich"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/button_of_Glove>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手袋の釦"@ja;
     rdfs:label     "button of Glove"@en;
     rdf:type    kgc:OFobj;
@@ -8032,6 +8120,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "腹を立てている"@ja;
     rdfs:label     "angree"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/help_of_mother_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの母の助け"@ja;
     rdfs:label     "help of mother of Sutherland"@en;
     rdf:type    kgc:OFobj;
@@ -8052,6 +8141,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "起こる"@ja;
     rdfs:label     "happen"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/character_of_typewriter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプライターの文字"@ja;
     rdfs:label     "character of typewriter"@en;
     rdf:type    kgc:OFobj;
@@ -8066,25 +8156,25 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Room>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/parents>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "親"@ja;
-    rdfs:label     "parents"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "parents"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/advice>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "助言"@ja;
-    rdfs:label     "advice"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "advice"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙"@ja;
-    rdfs:label     "letter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "letter"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/ｍedium_height>
     rdf:type    kgc:Property;
     rdfs:label     "中背である"@ja;
     rdfs:label     "ｍedium height"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Black_beads>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "黒のビーズ"@ja;
-    rdfs:label     "Black beads"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Black beads"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/BeInTime>
     rdfs:label     "BeInTime"@en;
     rdf:type    kgc:Object.
@@ -8093,19 +8183,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "On the sleeve"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Quotation_from_Balzac>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "バルザックからの引用"@ja;
-    rdfs:label     "Quotation from Balzac"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Quotation from Balzac"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Solution>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "解決"@ja;
-    rdfs:label     "Solution"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Solution"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>
+    rdf:type    kgc:Person;
     rdfs:label     "サザランド"@ja;
     rdfs:label     "Sutherland"@en;
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドと"@ja;
-    rdfs:label     "ホームズ"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ホームズ"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/shadow>
     rdf:type    kgc:Action;
     rdfs:label     "跡をつける"@ja;
@@ -8120,14 +8211,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "はない"@ja;
     rdfs:label     "notImportant"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/e>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "e"@ja;
-    rdfs:label     "e"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "e"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/prohibit>
     rdf:type    kgc:Action;
     rdfs:label     "禁じる"@ja;
     rdfs:label     "prohibit"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windybank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウィンディバンクの手紙"@ja;
     rdfs:label     "letter of Windybank"@en;
     rdf:type    kgc:OFobj;
@@ -8141,6 +8233,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "bible"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/France_office_of_company_of_Bordeaux>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ボルドーの会社のフランス事務所"@ja;
     rdfs:label     "France office of company of Bordeaux"@en;
     rdf:type    kgc:OFobj;
@@ -8149,19 +8242,20 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Bordeaux>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/The_Horseman>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "辻馬車の御者"@ja;
     rdfs:label     "The Horseman"@en;
-    rdfs:label     "御者"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "御者"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Inscription>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "座右の銘"@ja;
-    rdfs:label     "Inscription"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Inscription"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/France>
+    rdf:type    kgc:Place;
     rdfs:label     "フランス"@ja;
-    rdfs:label     "France"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "France"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/address_of_sender_of_letter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙の差出人の住所"@ja;
     rdfs:label     "address of sender of letter"@en;
     rdf:type    kgc:OFobj;
@@ -8177,6 +8271,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ホズマ"@ja;
     rdfs:label     "Hozma"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマ失踪"@ja;
     rdfs:label     "missing of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -8184,17 +8279,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appearance>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "姿"@ja;
-    rdfs:label     "Appearance"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Appearance"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/busy>
     rdf:type    kgc:Action;
     rdfs:label     "忙しい"@ja;
     rdfs:label     "busy"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Money>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "金"@ja;
-    rdfs:label     "Money"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Money"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1_year>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "1年"@ja;
@@ -8207,16 +8302,16 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "したくない"@ja;
+    rdfs:label     "望まない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dark_blue>
     rdfs:label     "鼠色だ"@ja;
     rdfs:label     "dark blue"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson>
+    rdf:type    kgc:Person;
     rdfs:label     "ワトソン"@ja;
-    rdfs:label     "Watson"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watson"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Camberwell>
     rdf:type    kgc:Property;
     rdfs:label     "キャンバウェルである"@ja;
@@ -8226,9 +8321,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "到着する"@ja;
     rdfs:label     "arrive"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/wedding>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "結婚式"@ja;
-    rdfs:label     "wedding"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "wedding"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Exist>
     rdfs:label     "Exist"@en;
     rdf:type    kgc:Object.
@@ -8239,6 +8334,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Find"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "自分の財産"@ja;
     rdfs:label     "property of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -8248,21 +8344,22 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Plush weave"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/r>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "r"@ja;
-    rdfs:label     "r"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "r"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heart>
     rdfs:label     "heart"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/pavement>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "舗道"@ja;
-    rdfs:label     "pavement"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "pavement"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/newspaper>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "新聞"@ja;
-    rdfs:label     "newspaper"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "newspaper"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death_of_Hozma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの生死"@ja;
     rdfs:label     "death of Hozma"@en;
     rdf:type    kgc:OFobj;
@@ -8285,9 +8382,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "驚く"@ja;
     rdfs:label     "beSurprised"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/One_hundred_dollars>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "百ドル"@ja;
-    rdfs:label     "One hundred dollars"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "One hundred dollars"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotCatch>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -8295,6 +8392,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "捉えられない"@ja;
     rdfs:label     "cannotCatch"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Office_of_Redon_Hall_Street>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レドンホール街の事務所"@ja;
     rdfs:label     "Office of Redon Hall Street"@en;
     rdf:type    kgc:OFobj;
@@ -8325,13 +8423,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Industries"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Someone>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "人"@ja;
-    rdfs:label     "Someone"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Someone"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sin>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "罪"@ja;
-    rdfs:label     "sin"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "sin"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/last_year>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "昨年"@ja;
@@ -8340,47 +8438,48 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "trouble"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/England>
+    rdf:type    kgc:Place;
     rdfs:label     "イングランド"@ja;
-    rdfs:label     "England"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "England"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "色"@ja;
-    rdfs:label     "color"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "color"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/punish>
     rdf:type    kgc:Action;
     rdfs:label     "懲らしめる"@ja;
     rdfs:label     "punish"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company_in_Central_City>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "中心区シティの会社"@ja;
-    rdfs:label     "company in Central City"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "company in Central City"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/uncle>
     rdfs:label     "uncle"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/truth>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事実"@ja;
     rdfs:label     "truth"@en;
-    rdfs:label     "真相"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "真相"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hansom_carriage>
     rdfs:label     "ハンソム馬車"@ja;
     rdfs:label     "hansom carriage"@en;
-    rdfs:label     "辻馬車"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdf:type    kgc:Person;
+    rdfs:label     "辻馬車"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland&#39_s_remark>
     rdfs:label     "mother of Sutherland&#39;s remark"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland&#39;s_remark>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Trace>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "跡"@ja;
-    rdfs:label     "Trace"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Trace"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Dance_party>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "舞踏会"@ja;
-    rdfs:label     "Dance party"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dance party"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notUnderstand>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -8388,16 +8487,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "わからない"@ja;
     rdfs:label     "notUnderstand"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/nobody>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "誰も"@ja;
-    rdfs:label     "nobody"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "nobody"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/black>
     rdf:type    kgc:Property;
     rdfs:label     "黒い"@ja;
     rdfs:label     "black"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "立ち会う"@ja;
+    rdfs:label     "参加する"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notHesitate>
     rdf:type    kgc:Action;
@@ -8406,6 +8505,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ためらわない"@ja;
     rdfs:label     "notHesitate"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/trouble_of_Women>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "女性の悩み"@ja;
     rdfs:label     "trouble of Women"@en;
     rdf:type    kgc:OFobj;
@@ -8416,9 +8516,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "鋭い"@ja;
     rdfs:label     "sharp"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Opposite_door>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "反対の戸"@ja;
-    rdfs:label     "Opposite door"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Opposite door"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/someone_of_Company>
     rdfs:label     "someone of Company"@en;
     rdf:type    kgc:OFobj;
@@ -8451,7 +8551,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/insist>
     rdf:type    kgc:Action;
-    rdfs:label     "言い張る"@ja;
+    rdfs:label     "主張する"@ja;
     rdfs:label     "insist"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/edge_of_hem>
     rdfs:label     "裾のふさ縁に"@ja;
@@ -8461,20 +8561,21 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hem>.
 <http://kgc.knowledge-graph.jp/data/predicate/whisper>
     rdf:type    kgc:Action;
-    rdfs:label     "囁く"@ja;
+    rdfs:label     "ささやく"@ja;
     rdfs:label     "whisper"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>
+    rdf:type    kgc:Person;
     rdfs:label     "ホズマ"@ja;
     rdfs:label     "Hozma"@en;
-    rdfs:label     "サザランド"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "サザランド"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Man>
+    rdf:type    kgc:Person;
     rdfs:label     "男"@ja;
-    rdfs:label     "Man"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Man"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/grab>
     rdf:type    kgc:Action;
-    rdfs:label     "つかむ"@ja;
+    rdfs:label     "掴む"@ja;
     rdfs:label     "grab"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/interesting>
     rdf:type    kgc:Property;
@@ -8504,6 +8605,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "straw hat"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/string_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "呼び鈴の紐"@ja;
     rdfs:label     "string of bell"@en;
     rdf:type    kgc:OFobj;
@@ -8513,21 +8615,23 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Sutherland&#39;s remark"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/knee_of_Man>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "男のズボンの膝"@ja;
     rdfs:label     "knee of Man"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/knee>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Man>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/character_of_Sutherland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの性格"@ja;
     rdfs:label     "character of Sutherland"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/character>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/day_after_dance>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "舞踏会の翌日"@ja;
-    rdfs:label     "day after dance"@en.
+    rdfs:label     "day after dance"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/cross>
     rdf:type    kgc:Action;
     rdfs:label     "渡る"@ja;
@@ -8537,18 +8641,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Quickly"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "舞踏会"@ja;
-    rdfs:label     "dance"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "dance"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sneer>
     rdf:type    kgc:Action;
     rdfs:label     "冷笑する"@ja;
     rdfs:label     "sneer"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Place>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホズマの居場所"@ja;
-    rdfs:label     "Place"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Place"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/invitation_of_dance_of_Gas_Industry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ガス工組合の舞踏会の招待状"@ja;
     rdfs:label     "invitation of dance of Gas Industry"@en;
     rdf:type    kgc:OFobj;
@@ -8557,9 +8662,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Gas_Industry>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/With_voice>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "声"@ja;
-    rdfs:label     "With voice"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "With voice"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Reach>
     rdfs:label     "Reach"@en;
     rdf:type    kgc:Object.
@@ -8569,12 +8674,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "sufferFrom"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Deep_motive>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "深い動機"@ja;
-    rdfs:label     "Deep motive"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Deep motive"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1_day>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "１日"@ja;

--- a/ACaseOfIdentity.ttl
+++ b/ACaseOfIdentity.ttl
@@ -2750,7 +2750,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/290a>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/call> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/291>
     rdf:type    kgc:Situation ;
@@ -8195,8 +8195,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "サザランド"@ja;
     rdfs:label     "Sutherland"@en;
     rdf:type    kgc:PhysicalObject;
-    rdfs:label     "サザランドと"@ja;
-    rdfs:label     "ホームズ"@ja.
+    rdfs:label     "サザランドと"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/shadow>
     rdf:type    kgc:Action;
     rdfs:label     "跡をつける"@ja;

--- a/AbbeyGrange.ttl
+++ b/AbbeyGrange.ttl
@@ -6997,8 +6997,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件"@ja;
-    rdfs:label     "case"@en;
-    rdf:type    kgc:Person.
+    rdfs:label     "case"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Recovery>
     rdfs:label     "Recovery"@en;
     rdf:type    kgc:Object.

--- a/AbbeyGrange.ttl
+++ b/AbbeyGrange.ttl
@@ -6180,11 +6180,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "killing of Lady Brackenstall"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mouth_of_Lady_Brackenstall>
-    rdf:type    kgc:Person;
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの口"@ja;
     rdfs:label     "Mouth of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
-    rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mouth>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brutal_character>
@@ -7092,7 +7091,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "残さない"@ja;
     rdfs:label     "notLeave"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sound>
-    rdf:type    kgc:Person;
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "音"@ja;
     rdfs:label     "sound"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins>
@@ -7391,7 +7390,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Person;
     rdfs:label     "レディー・ブラックンストール"@ja;
     rdfs:label     "Lady Brackenstall"@en;
-    rdf:type    kgc:Place;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディーブラックンストール"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/barefoot>

--- a/AbbeyGrange.ttl
+++ b/AbbeyGrange.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -202,10 +202,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wakeUp> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wakeUp> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/001>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Winter_of_1897> ;
     kgc:time  "1897-02-01T08:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T08> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T08> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/001>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/early_morning> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/002> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/002>
@@ -213,25 +217,39 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "ホームズは電車の中で手紙を取り出した"@ja ;
     kgc:source  "Holmes took a letter on the train"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/takeOut> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/letter> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/train> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/takeOut> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/002>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/letter> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/002>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/train> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/002>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-02-01T010"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T010> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T010> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/002>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/003> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/003>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは手紙を音読した"@ja ;
     kgc:source  "Holmes was reading a letter aloud"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/readAloud> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/letter> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/readAloud> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/003>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/letter> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/003>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/004> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/005> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/006> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/007> ;
     kgc:time  "1897-02-01T010"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T010> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T010> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/003>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/008> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/004>
     rdf:type    kgc:Statement ;
@@ -239,17 +257,27 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "There is a remarkable incident at the Abbey Grange"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/beSurprising> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/beSurprising> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/004>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/004>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/005> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/005>
-    rdf:type    kgc:Statement ;
+    rdf:type    kgc:Situation ;
     kgc:source  "スタンリィ・ホプキンスがホームズに助力を頼む"@ja ;
-    kgc:source  "Stanley Hopkins asks for help to Holmes"@en ;
+    kgc:source  "Stanley Hopkins asks for help to Holmes"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/005>
+    rdf:type    kgc:Statement ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/request> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/help> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/request> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/005>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/help> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/005>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/006> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/006>
@@ -258,8 +286,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Dining room is kept as found"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/beKept> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/as_found> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/beKept> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/006>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/as_found> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/006>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/007> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/007>
     rdf:type    kgc:Statement ;
@@ -267,16 +299,24 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Blackenstall cannot be kept in the dining room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotbeKept> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotbeKept> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/007>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/007>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/008>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは以下を言った"@ja ;
     kgc:source  "Holmes said the following"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/009> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/008>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/009> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/008>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-02-01T010"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T010> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/009>
@@ -293,7 +333,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:time  "1897-02-01T010"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T010> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T010> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/009a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/009b> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/009b>
     rdf:type    kgc:Situation ;
@@ -311,20 +353,28 @@ kgc:Thought rdf:type owl:Class ;
     kgc:whoｍ   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/011>
-    rdf:type    kgc:Thought ;
+    rdf:type    kgc:Situation ;
     kgc:source  "ユースタスが自殺である"@ja ;
-    kgc:source  "Sir Eustace Brackenstall committed suicide"@en ;
+    kgc:source  "Sir Eustace Brackenstall committed suicide"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/011>
+    rdf:type    kgc:Thought ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/suicide> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/012>
-    rdf:type    kgc:Thought ;
+    rdf:type    kgc:Situation ;
     kgc:source  "スタンリィ・ホプキンスがホームズに使いを出すことはない"@ja ;
-    kgc:source  "There is no possibility that Stanley Hopkins issues a use in Holmes"@en ;
+    kgc:source  "There is no possibility that Stanley Hopkins issues a use in Holmes"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/012>
+    rdf:type    kgc:Thought ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notContact> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notContact> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/012>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/012>
+    rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/011> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/013>
     rdf:type    kgc:Thought ;
@@ -333,11 +383,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beConfined> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beConfined> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/013>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/013>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/12_00_yesterday> ;
     kgc:time  "1897-01-31T23:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/013>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/014> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/014>
     rdf:type    kgc:Thought ;
@@ -345,8 +401,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Stanley Hopkins calls the local police"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/call> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_local_police> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/call> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/014>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_local_police> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/011> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/014>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/015> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/015>
     rdf:type    kgc:Thought ;
@@ -354,8 +417,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Stanley Hopkins contacts the Scotland Yard"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/contact> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Scotland_Yard> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/contact> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/015>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Scotland_Yard> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/015>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/016> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/016>
     rdf:type    kgc:Thought ;
@@ -363,8 +430,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Stanley Hopkins should go to Abbey Grange"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/016>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/016>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/017> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/017>
     rdf:type    kgc:Thought ;
@@ -372,7 +443,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Stanley Hopkins issues a use in Holmes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/putOut> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/putOut> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/017>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/use> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/018>
     rdf:type    kgc:Thought ;
@@ -380,10 +453,21 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Stanley Hopkins do all of the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/014> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/015> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/016> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/018>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/014> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/018>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/015> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/018>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/016> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解し，その文IDをここに入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/017> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/018>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/017> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/018x>
     rdf:type    kgc:Thought ;
@@ -399,7 +483,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "スタンリィ・ホプキンスは以下を説明した"@ja ;
     kgc:source  "Stanley Hopkins explained the following"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/018a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/019> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/020> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/021> ;
@@ -414,8 +500,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall was clearly talking about the particulars of things"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/details_of_case> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/019>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/details_of_case> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/019>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/027> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/020>
@@ -424,18 +514,33 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Burglary team of Lewisham was seen two weeks before Sydenham"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/appear> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/appear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/015> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/020>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/2_weeks_ago> ;
     kgc:time  "1897-01-15T00:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-15T00> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-15T00> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/016> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/020>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/017> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/021>
     rdf:type    kgc:Statement ;
     kgc:source  "ルイシャムの夜盗団は人相書きが出ている"@ja ;
     kgc:source  "Burglary team of Lewisham has come up with a personal description"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beKnown> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beKnown> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/021>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/face> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/020> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/022>
@@ -444,7 +549,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Burglary team of Lewisham excecuted the case"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/execute> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/execute> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/022>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/021> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/023>
@@ -454,7 +561,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/023>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/poker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/024>
     rdf:type    kgc:Statement ;
@@ -462,38 +571,56 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall is dead"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/024>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/023> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解し，その文IDをここに入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/020> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/025>
     rdf:type    kgc:Statement ;
     kgc:source  "サー・ユースタス・ブラックンストールはケントでも指折りの資産家"@ja ;
     kgc:source  "Sir Eustace Brackenstall is one of the wealthiest men in Kent"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wealthy> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wealthy> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/025>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Kent> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/021> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/026>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは半死半生の状態でダイニングルームにいる"@ja ;
     kgc:source  "Lady Brackenstall is in the dining room in a state of being half alive"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/half_alive_state> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/half_alive_state> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/026>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/027>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールの片方の目の上がはれ上がっていた"@ja ;
     kgc:source  "There was swelling on top of one eye of Lady Brackenstall"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/one_eye_of_Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/swell> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/swell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/027>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/028> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/028>
     rdf:type    kgc:Situation ;
     kgc:source  "テリーサがレディー・ブラックンストールのはれ上がった片方の目を一生懸命冷やしていた"@ja ;
     kgc:source  "Theresa had cold hard the one eye that rose sunny Lady Brackenstall"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/chill> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/one_eye_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/chill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/028>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/one_eye_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/028>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/027> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/028a>
     rdf:type    kgc:Situation ;
@@ -506,31 +633,45 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "レディー・ブラックンストールは警戒の表情を浮かべた"@ja ;
     kgc:source  "Lady Brackenstall showed an expression of vigilance"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/warn> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/warn> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/029>
+    rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/030> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/030>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールのそばに黒のスパンコールのディナードレスが置かれていた"@ja ;
     kgc:source  "Lady Brackenstall’s dinner dress was a black sequined dress"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dinner_dress_of_black_sequins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/030>
+    rdf:type    kgc:Situation ;
+    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/030>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/031> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/031>
     rdf:type    kgc:Situation ;
     kgc:source  "ゆるいガウンがレディー・ブラックンストールの腕から滑り落ちた"@ja ;
     kgc:source  "A loose gown slipped from the forearm of Lady Brackenstall"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drop> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Loose_gown> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drop> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/031>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Loose_gown> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/031>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/032> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/032>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールは傷を急いで隠した"@ja ;
     kgc:source  "Lady Bracknstall hastily hid her scratch"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/scratch> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/032>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/scratch> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/032>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Quickly> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/033> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/033>
@@ -539,6 +680,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall's scratches are two red dots on upper limbs"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/scratch_of_Lady_Brackenstall> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Two_red_dots> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/030> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/>
     rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Upper_limbs> .
@@ -560,10 +704,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/035>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1_year_ago> ;
     kgc:time  "1896-02-01T12:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-02-01T12> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-02-01T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/035>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/038> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/036>
     rdf:type    kgc:Statement ;
@@ -571,8 +719,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall did not meet the etiquette of the United Kingdom"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notFit> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Etiquette_of_UK> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notFit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/036>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Etiquette_of_UK> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/036>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/035> ;
     kgc:time  "1896-02-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-02-01T12> .
@@ -582,7 +734,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall was an alcoholic"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/alcoholism> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/alcoholism> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/034> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/037>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/035> ;
     kgc:time  "1896-02-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-02-01T12> .
@@ -593,9 +750,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notHappy> ;
-    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/036> ;
-    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/037> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notHappy> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/038>
+    rdf:type    kgc:Situation ;
+    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/036> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/038>
+    rdf:type    kgc:Situation ;
+    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/037> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/038>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/035> ;
     kgc:time  "1896-02-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-02-01T12> .
@@ -605,7 +768,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Maids rest in an annex of Abbey Grange"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/All_of_maids> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/039>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Annex_of_Abbey_Grange> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/040>
     rdf:type    kgc:Statement ;
@@ -613,7 +778,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The center of the Abbey Grange is made from the room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/center_of_Abbey_Grange> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/040>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Many_rooms> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/041>
     rdf:type    kgc:Statement ;
@@ -621,7 +788,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The kitchen is in the back of the center of the Abbey Grange"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Kitchen> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/041>
+    rdf:type    kgc:Situation ;
     kgc:nextTo   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/center_of_Abbey_Grange> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/042>
     rdf:type    kgc:Statement ;
@@ -629,16 +798,31 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa rests above the room of Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/036> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/042>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Lady_Blackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/037> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/035> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/043>
     rdf:type    kgc:Thought ;
     kgc:source  "別棟にいる召使いには物音が聞こえない"@ja ;
     kgc:source  "The maid in the annex can't hear a thing."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHear> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sound> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/043>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sound> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/043>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/annex> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/044>
     rdf:type    kgc:Thought ;
@@ -646,7 +830,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminals knew the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/044>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/039> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/040> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/041> ;
@@ -658,7 +844,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall slept at around 22:30"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sleep> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sleep> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/045>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/10_30> ;
     kgc:time  "1897-01-31T22:30:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:30> .
@@ -668,9 +856,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Teresa was awake"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/awake> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/awake> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/046>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-01-31T22:30:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:30> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:30> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/046>
+    rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/047>
     rdf:type    kgc:Statement ;
@@ -678,10 +870,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa was waiting for Lady Bracknstall's business"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Requirements_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/047>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Requirements_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/047>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-01-31T22:30:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:30> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:30> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/047>
+    rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/048>
     rdf:type    kgc:Statement ;
@@ -689,13 +887,30 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa was left on the top floor room of the Theresa of the Abbey Grange"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stay> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Theresa> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_top_floor_of_the_Abbey_Grange> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stay> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/039> ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/040> ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/041> ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/042> ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/043> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/048>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Theresa> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/048>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_top_floor_of_the_Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/048>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> ;
     kgc:time  "1897-01-31T22:30:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:30> ;
-    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/047> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:30> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/048>
+    rdf:type    kgc:Situation ;
+    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/047> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/048>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/049> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/049>
     rdf:type    kgc:Statement ;
@@ -703,11 +918,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall was sitting in the living room until 11 o'clock"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sit> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/049>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/11_00> ;
     kgc:time  "1897-01-31T23:05:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:05> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Living_room> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:05> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/049>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Living_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/049>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050>
     rdf:type    kgc:Statement ;
@@ -715,9 +936,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall was carried out patrol"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/patrol> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/patrol> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/050>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-01-31T23:10:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:10> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:10> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/050>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/052> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/051>
     rdf:type    kgc:Statement ;
@@ -725,22 +950,42 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Dining room window was open"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_Dining_room> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/open> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/open> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/051>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> ;
     kgc:time  "1897-01-31T23:10:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:10> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/052>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは以下に気づいた"@ja ;
     kgc:source  "Lady Brackenstall noticed the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notice> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/051> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notice> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/052>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/051> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/052>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> ;
     kgc:time  "1897-01-31T23:10:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:10> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:10> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/052>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/053> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/047> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/053>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールはダイニングルームで犯人と会った"@ja ;
@@ -748,11 +993,20 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/053>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/053>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> ;
     kgc:time  "1897-01-31T23:10:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:10> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:10> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/053>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/054> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/054>
     rdf:type    kgc:Statement ;
@@ -760,18 +1014,34 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "There were two other perpetrators besides the older man"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/include> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Two_people> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/include> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/054>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/054>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Two_people> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/054>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/055> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/052> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/055>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは以下を見た"@ja ;
     kgc:source  "Lady Bracknstall saw the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/054> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/055>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/054> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解してください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/055>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/056> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/056>
     rdf:type    kgc:Statement ;
@@ -779,28 +1049,53 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The elderly man grabbed the wrist and throat of Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/grab> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wrist_of_Lady_Brackenstall> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Throat_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/grab> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/056>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wrist_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/056>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Throat_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/051> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/056>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/057> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/057>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは年配の男のこぶしで目の上を殴られた"@ja ;
     kgc:source  "Lady Brackenstall was beaten over the eye by the fist of the elderly man"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fist> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/One_eye_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/057>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/057>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/One_eye_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/057>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/058> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/058>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは床に打ち倒された"@ja ;
     kgc:source  "Lady Brackenstall was thrown on the floor"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collapse> ;
-    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/floor> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collapse> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/058>
+    rdf:type    kgc:Situation ;
+    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/floor> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/058>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/059> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/059>
     rdf:type    kgc:Statement ;
@@ -808,37 +1103,63 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall had lost consciousness for a few minutes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unconscious> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/A_few_minutes> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unconscious> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/059>
+    rdf:type    kgc:Situation ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/A_few_minutes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/059>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/060> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/054> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/060>
     rdf:type    kgc:Statement ;
     kgc:source  "犯人はベルの紐を引きちぎった"@ja ;
     kgc:source  "The criminals were torn off a code of bell"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cut> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cut> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/060>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/060>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/062> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/057> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/061>
     rdf:type    kgc:Statement ;
     kgc:source  "オークの椅子はダイニングテーブルにあった"@ja ;
     kgc:source  "An oak chair was on the dining table"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Oak_chair> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/061>
+    rdf:type    kgc:Situation ;
     kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_table> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/061>
     rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/060> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/058> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/062>
     rdf:type    kgc:Statement ;
     kgc:source  "犯人はレディー・ブラックンストールをオークの椅子に縛り付けた"@ja ;
     kgc:source  "The criminals tied Lady Brackenstall to the oak chair"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/tie> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/tie> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/062>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/059> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/062>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Oak_chair> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/063> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/063>
@@ -847,15 +1168,22 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall could not move"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/63a> ;
+    kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/63a> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/063>
+    rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotMove> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/060> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/63a>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは声を立てることができなかった"@ja ;
     kgc:source  "Lady Brackenstall could not make a voice"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSpeak> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSpeak> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/63a>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/064> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/064>
     rdf:type    kgc:Statement ;
@@ -863,8 +1191,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall came into the dinining room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enter> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enter> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/062> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/064>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/064>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/065> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/065>
     rdf:type    kgc:Statement ;
@@ -872,8 +1207,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The elderly man took the poker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/take> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Poker> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/take> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/065>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Poker> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/060> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/065>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/066> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/066>
     rdf:type    kgc:Statement ;
@@ -881,9 +1223,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The elderly man added a blow from the side to Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/side> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/066>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/066>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/side> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/063> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/066>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/067> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/067>
     rdf:type    kgc:Statement ;
@@ -891,17 +1242,31 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall lost consciousness again"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/faint> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/faint> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/067>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/068> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/064> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/068>
     rdf:type    kgc:Statement ;
     kgc:source  "犯人はサイドボードから銀製品を集めた"@ja ;
     kgc:source  "The criminals collected the silver products from the sideboard"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collect> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collect> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/068>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/065> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/068>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/068>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/069> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/069>
     rdf:type    kgc:Statement ;
@@ -909,9 +1274,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal took out a wine from the sideboard"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/take> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/take> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/066> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/069>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/069>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/069>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/072> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/070>
     rdf:type    kgc:Statement ;
@@ -919,7 +1293,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The elderly man had a beard"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/067> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/070>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/beard> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/071>
     rdf:type    kgc:Statement ;
@@ -927,7 +1306,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Two people are both young and unshaven"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Two_people> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/071>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Beard> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/072>
     rdf:type    kgc:Statement ;
@@ -935,8 +1316,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The perpetrator identified the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/confirm> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/062> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/confirm> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/069> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/072>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/062> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/072>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/073> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/073>
     rdf:type    kgc:Statement ;
@@ -944,9 +1332,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal closed the window behind him"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/close> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_dining_room> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/back> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/close> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/073>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/072> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/073>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/back> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/073>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/074> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/074>
     rdf:type    kgc:Statement ;
@@ -954,10 +1351,19 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminals left"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/074>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/074>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-01-31T23:30:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:30> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:30> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/074>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/075> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/075>
     rdf:type    kgc:Statement ;
@@ -965,11 +1371,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall's mouth became free 15-minute afterward"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mouth_of_Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/075>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/free> ;
     kgc:after   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/15_minutes> ;
     kgc:time  "1897-01-31T23:45:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:45> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:45> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/075>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/076> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/076>
     rdf:type    kgc:Statement ;
@@ -977,7 +1390,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall screamed"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/073> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/076>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/084> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/077>
     rdf:type    kgc:Statement ;
@@ -985,16 +1403,23 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa came to the rescue of Lady Bracknstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/help> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/help> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/077>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/076> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/074> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/078>
     rdf:type    kgc:Statement ;
     kgc:source  "犯人がアビ屋敷に入った"@ja ;
     kgc:source  "The criminals entered the Abbey Grange"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enter> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enter> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/078>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/079>
     rdf:type    kgc:Statement ;
@@ -1002,22 +1427,47 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa saw the criminals"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/078> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/079>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/079>
+    rdf:type    kgc:Situation ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/078> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/079>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-01-31T22:35:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:35> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T22:35> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/079>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/080> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/076> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/080>
     rdf:type    kgc:Statement ;
     kgc:source  "サー・ユースタス・ブラックンストールはダイニングルーム中に血と脳みそをまき散らしていた"@ja ;
     kgc:source  "Sir Eustace Brackenstall had sprinkled blood and brains in the dining room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sprinkle> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blood_of_Sir_Eustace_Brackenstall> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brains_of_Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sprinkle> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/080>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/080>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blood_of_Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/084> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/080>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brains_of_Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/080>
+    rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/081> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/081>
     rdf:type    kgc:Statement ;
@@ -1025,8 +1475,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall was down in the dining room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collapse> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collapse> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/081>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/081>
+    rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/082> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/082>
     rdf:type    kgc:Statement ;
@@ -1034,8 +1488,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa found Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/082>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/082>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/083> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/083>
     rdf:type    kgc:Statement ;
@@ -1043,9 +1501,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The dress was stained with Sir Eustace Brackenstall's blood and brains"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dress> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beStain> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blood_of_Sir_Eustace_Brackenstall> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brains_of_Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beStain> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/083>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blood_of_Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/083>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brains_of_Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/078> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/083>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/084> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/084>
     rdf:type    kgc:Situation ;
@@ -1053,15 +1520,21 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Blacknstall and Teresa take a break in Lady Blacknstall's room"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/084>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/084>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/087> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/085>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールが赤ん坊だった"@ja ;
     kgc:source  "Lady Brackenstall was a baby"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/baby> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/baby> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/085>
+    rdf:type    kgc:Situation ;
     kgc:time  "1872-01-01T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1872-01-01> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/086>
@@ -1070,7 +1543,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa has served"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/serve> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/serve> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/086>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/085> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/087>
     rdf:type    kgc:Situation ;
@@ -1078,39 +1553,61 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The charm of the incident has left a mystery"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Charm_of_the_case> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mystery_of_the_case> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/087>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/088> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/084> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/088>
     rdf:type    kgc:Thought ;
     kgc:source  "ホームズは強い関心をなくした"@ja ;
     kgc:source  "Holmes lost a strong interest"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/lose> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Interest_of_case> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/087> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/lose> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/088>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Interest_of_case> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/088>
+    rdf:type    kgc:Situation ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/087> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/088>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/089> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/087> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/089>
     rdf:type    kgc:Thought ;
     kgc:source  "ホームズの目が腹立たしさを表している"@ja ;
     kgc:source  "Holmes' eyes show his annoyance"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/angry> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/angry> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/089>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/090> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/090>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはダイニングルームを見た"@ja ;
     kgc:source  "Holmes saw the dining room of Abbey Grange"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/090>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/090>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/091> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/090a>
     rdf:type    kgc:Situation ;
     kgc:source  "アビ屋敷にはダイニングルームがある"@ja ;
     kgc:source  "The Abbey Grange has a dining room"@en ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/090a>
+    rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/091>
@@ -1118,8 +1615,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "ホームズは興味を呼び戻した"@ja ;
     kgc:source  "Holmes recalled interest"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/callBack> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Interest_of_case> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/callBack> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/091>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Interest_of_case> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/091>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/100> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/092>
     rdf:type    kgc:Statement ;
@@ -1127,18 +1628,32 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "There was a high French window on the opposite side of the end of the dining room's door"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/High_French_windows> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/092>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/092>
+    rdf:type    kgc:Situation ;
     kgc:opposite   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/door> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/087> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/093>
     rdf:type    kgc:Statement ;
     kgc:source  "ドアの右側には小さい3つの窓があった"@ja ;
     kgc:source  "There were three small windows on the right side of the door"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Small_three_windows> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:right   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/door> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/093>
+    rdf:type    kgc:Situation ;
+    kgc:right   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/door> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/093>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/090> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/094>
     rdf:type    kgc:Statement ;
     kgc:source  "ドアの左側には暖炉、マントルピースがあった"@ja ;
@@ -1146,9 +1661,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fireplace> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mantelpiece> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:left   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/door> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/094>
+    rdf:type    kgc:Situation ;
+    kgc:left   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/door> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/094>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/091> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/095>
     rdf:type    kgc:Statement ;
     kgc:source  "暖炉のそばに肘掛とオークの椅子がある"@ja ;
@@ -1156,8 +1678,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Oak_chair> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Armrest> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fireplace> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/095>
+    rdf:type    kgc:Situation ;
+    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fireplace> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/095>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/096>
     rdf:type    kgc:Statement ;
@@ -1165,8 +1691,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "A bell code is woven into the gap of wood products"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:middleOf   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wooden_products> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/096>
+    rdf:type    kgc:Situation ;
+    kgc:middleOf   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wooden_products> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/096>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/097>
     rdf:type    kgc:Statement ;
@@ -1174,8 +1704,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Both ends of the cord had been fixed to the oak chair"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Both_ends_of_cord_of_bell> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beFixed> ;
-    kgc:under   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Oak_chair> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beFixed> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/097>
+    rdf:type    kgc:Situation ;
+    kgc:under   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Oak_chair> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/097>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/098> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/098>
@@ -1184,9 +1718,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "A knot had fixed the bell code"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/knot> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fix> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fix> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/098>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/098>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/098>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/099> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/099>
     rdf:type    kgc:Statement ;
@@ -1194,7 +1734,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The knot was left"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/knot> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/remain> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/remain> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/099>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/100>
     rdf:type    kgc:Statement ;
@@ -1203,9 +1745,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
-    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fireplace> ;
-    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Rugs> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/100>
+    rdf:type    kgc:Situation ;
+    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fireplace> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/100>
+    rdf:type    kgc:Situation ;
+    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Rugs> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/100>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/101>
     rdf:type    kgc:Statement ;
@@ -1234,7 +1782,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The corpse was lying on his back"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/104>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/back> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/105>
     rdf:type    kgc:Statement ;
@@ -1242,8 +1792,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The corpse had been facing up"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/direct> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/face> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/direct> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/105>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/face> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/105>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Up> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/106>
     rdf:type    kgc:Statement ;
@@ -1251,7 +1805,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The corpse had bare white teeth"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/expose> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/expose> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/106>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/White_teeth> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/107>
     rdf:type    kgc:Statement ;
@@ -1259,7 +1815,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The corpse had been raised on top of the head and both hands"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/raise> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/raise> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/107>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/both_hands> ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/head_of_cadaver> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/108>
@@ -1268,7 +1826,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The corpse had a stick of heavy blackthorn"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/108>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Heavy_blackthorn_stick> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/109>
     rdf:type    kgc:Statement ;
@@ -1276,7 +1836,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The corpse's facial features were distorted"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/distort> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/distort> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/109>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/face> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/110>
     rdf:type    kgc:Statement ;
@@ -1297,8 +1859,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall was sleeping"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/asleep> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/111> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/asleep> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/112>
+    rdf:type    kgc:Situation ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/111> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/112>
+    rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/113> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/113>
     rdf:type    kgc:Thought ;
@@ -1306,9 +1872,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall was wearing sleeping clothes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wear> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/113>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pajama> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/111> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/111> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/113>
+    rdf:type    kgc:Situation ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/114> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/114>
     rdf:type    kgc:Thought ;
@@ -1316,7 +1886,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall was barefoot"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/barefoot> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/barefoot> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/114>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/111> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/115>
     rdf:type    kgc:Statement ;
@@ -1324,8 +1896,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall had a terrible injury on the head"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Severe_injury> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/115>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Severe_injury> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/115>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Head> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/116>
     rdf:type    kgc:Thought ;
@@ -1333,7 +1909,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The entire room testified to the brutal character of criminal"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_entire_room> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/testify> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/testify> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/116>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brutal_character_of_criminal> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/117>
     rdf:type    kgc:Statement ;
@@ -1341,7 +1919,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "A heavy curved poker was lying near Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Heavy_curved_poker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/117>
+    rdf:type    kgc:Situation ;
     kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/118>
     rdf:type    kgc:Statement ;
@@ -1349,7 +1929,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Burglary team of Lewisham has powerful men"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/114> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/118>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/powerful_men> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/119>
     rdf:type    kgc:Statement ;
@@ -1357,7 +1942,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall did not say the physiognomy"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/111> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/119>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/looks_of_criminal> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/120>
     rdf:type    kgc:Statement ;
@@ -1365,7 +1955,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal was silenced Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/120>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/121>
     rdf:type    kgc:Statement ;
@@ -1373,7 +1965,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal did not silence Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKill> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/121>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/122>
     rdf:type    kgc:Statement ;
@@ -1381,7 +1975,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal did not notice that the Lady Brackenstall had recovered"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notNotice> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notNotice> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/122>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Recovery_of_Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/123>
     rdf:type    kgc:Situation ;
@@ -1395,8 +1991,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The men did not take Lady Bracknstall's life"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKill> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/124>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/124>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/123> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/125>
     rdf:type    kgc:Statement ;
@@ -1404,7 +2004,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall is friendly when sober"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/friendly> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/friendly> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/125>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sober> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/126>
     rdf:type    kgc:Statement ;
@@ -1419,7 +2021,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall was like a demon"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/demon> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/demon> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/127>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/126> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/128>
     rdf:type    kgc:Statement ;
@@ -1428,8 +2032,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Police> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrest> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/several_times> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrest> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/128>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/several_times> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/128>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/127> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/129>
     rdf:type    kgc:Statement ;
@@ -1437,9 +2045,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall multiplied by the oil to the Lady Brackenstall dog"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pour> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/oil> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dog_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pour> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/129>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/oil> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/129>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dog_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/129>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/130> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/130>
     rdf:type    kgc:Statement ;
@@ -1447,7 +2061,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall lit the fire over the oil to the Lady Brackenstall dog"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fire> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fire> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/130>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dog_of_Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/131>
     rdf:type    kgc:Statement ;
@@ -1455,8 +2071,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall threw a decanter to Theresa"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/throw> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/decanter> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/throw> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/131>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/decanter> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/131>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/132>
     rdf:type    kgc:Situation ;
@@ -1464,25 +2084,46 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall had been tied with a bell code"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/tie> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/tie> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/132>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/132>
+    rdf:type    kgc:Situation ;
     kgc:time  "1897-01-31T23:15:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T23:15> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/045> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/133>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは紐の結び目を調べた"@ja ;
     kgc:source  "Holmes was examined the knot of bell code"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knot_of_cord_of_bell> ;
-    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/132> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/127> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/133>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knot_of_cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/133>
+    rdf:type    kgc:Situation ;
+    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/132> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/133>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/134> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/134>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはベルの紐の端を検査した"@ja ;
     kgc:source  "Holmes inspected the end of the bell code"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/130> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/134>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/end_of_cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/135>
     rdf:type    kgc:Thought ;
@@ -1490,7 +2131,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal pulled down the bell code"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pullDown> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pullDown> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/135>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/136>
     rdf:type    kgc:Thought ;
@@ -1498,7 +2141,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The bell rang"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Bell> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ring> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ring> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/136>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/135> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/137>
     rdf:type    kgc:Statement ;
@@ -1506,7 +2151,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The sound of the bell did not hear"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sound_of_bell> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHear> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/137>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/041> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/138>
     rdf:type    kgc:Thought ;
@@ -1514,15 +2161,21 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal knew the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/139> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/138>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/139> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/138>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/140> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/139>
     rdf:type    kgc:Situation ;
     kgc:source  "召使は早い時間に休む"@ja ;
     kgc:source  "Maids rest at an early time"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Maid> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rest> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/139>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/early_time> ;
     kgc:time  "1897-01-31T20:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-31T20> .
@@ -1531,7 +2184,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "召使いには調理場のベルが聞こえない"@ja ;
     kgc:source  "The maids can't hear the bell in the kitchen"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Maid> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHear> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/140>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell_of_kitchen> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/141>
     rdf:type    kgc:Thought ;
@@ -1540,8 +2195,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Maid> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/gangUp> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/gangUp> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/141>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/138> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/135> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/142>
     rdf:type    kgc:Thought ;
     kgc:source  "八人の召使は疑わしくない"@ja ;
@@ -1549,22 +2209,34 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/eight_maids> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notDoubtful> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/041> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/143>
     rdf:type    kgc:Thought ;
     kgc:source  "テリーサが疑わしい"@ja ;
     kgc:source  "Theresa is doubtful"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/doubtful> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/doubtful> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/143>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/131> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/139> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/144>
     rdf:type    kgc:Statement ;
     kgc:source  "事件時マントルピースのろうそくがついていた"@ja ;
     kgc:source  "The candle was on the mantelpiece during the incident"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/candle> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/lighted> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/11_00> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/lighted> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/144>
+    rdf:type    kgc:Situation ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/11_00> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/144>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mantelpiece> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/145>
     rdf:type    kgc:Statement ;
@@ -1572,20 +2244,31 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall had a candle in the bedroom"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/candle> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/145>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/candle> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/145>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/146>
-    rdf:type    kgc:Thought ;
+    rdf:type    kgc:Situation ;
     kgc:source  "犯人はダイニングルームを見た"@ja ;
-    kgc:source  "The criminal saw the dining room"@en ;
+    kgc:source  "The criminal saw the dining room"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/146>
+    rdf:type    kgc:Thought ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/146>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/140>
     rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/144> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/138> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/146>
     rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/145> .
@@ -1595,8 +2278,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal took six dishes from the sideboard"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/steal> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_products> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/steal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/147>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_products> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/147>
+    rdf:type    kgc:Situation ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/148>
     rdf:type    kgc:Thought ;
@@ -1604,7 +2291,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminals were upset about the death of Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/upset> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/upset> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/148>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Death_of_Sir_Eustace_brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/149>
     rdf:type    kgc:Thought ;
@@ -1612,7 +2301,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminals were not from turning too much clams"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExamine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExamine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/149>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/148> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/150>
@@ -1621,54 +2312,87 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal had some drinking wine to soothe his nerves"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drink> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drink> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/050> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/150>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/150>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/148> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/151>
     rdf:type    kgc:Situation ;
     kgc:source  "三つのグラスすべてにワインの色がついていた"@ja ;
     kgc:source  "All three glasses had the color of wine on them"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Three_of_glass> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/151>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/color_of_wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/144> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/145> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/152>
     rdf:type    kgc:Situation ;
     kgc:source  "ひとつのグラスにはオリのカスがいくらか入っていた"@ja ;
     kgc:source  "Some dregs went to one of the glasses"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/one_of_glass> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/152>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dregs_of_wine> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/153>
     rdf:type    kgc:Situation ;
     kgc:source  "三つのグラスの近くに三分の二ほど入った瓶が立っている"@ja ;
     kgc:source  "A bottle is standing filled in two-thirds in the vicinity of the three glasses"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_of_wine> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/two-thirds_of_the_wine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/153>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/two-thirds_of_the_wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/153>
+    rdf:type    kgc:Situation ;
     kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Three_of_glass> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/154>
     rdf:type    kgc:Situation ;
     kgc:source  "瓶のそばにコルクがあった"@ja ;
     kgc:source  "Long near the bottle, there was a dyed dark cork"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cork_of_bottle> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/154>
+    rdf:type    kgc:Situation ;
     kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_of_wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/148> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/155>
     rdf:type    kgc:Thought ;
     kgc:source  "ワインは外観と瓶の上のほこりから並みのヴィンテージではない"@ja ;
     kgc:source  "Wine is not a vintage moderate from the dust on the appearance and bottle"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Vintage_wine> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Vintage_wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/155>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Appearance> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dust> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/148> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/156>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールはワインが開けられたとき意識を失っていた"@ja ;
     kgc:source  "Lady Brackenstall had lost consciousness"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unconscious> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unconscious> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/156>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/150> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/157>
     rdf:type    kgc:Thought ;
@@ -1676,8 +2400,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Bottle opener was driven three times in order to extract the cork"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_opener> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/157>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_opener> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/157>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/157a> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Three_times> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/157a>
@@ -1686,7 +2414,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal pulls the cork out"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/remove> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/remove> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/157a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cork_of_bottle> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/158>
     rdf:type    kgc:Thought ;
@@ -1694,7 +2424,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The bottle was opened with a portable bottle opener rather than a big corkscrew"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_opener> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/mobile_Bottle_opener> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/mobile_Bottle_opener> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/158>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/157> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/159>
     rdf:type    kgc:Thought ;
@@ -1702,8 +2434,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal has a utility knife"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/All-purpose_knife> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/159>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/All-purpose_knife> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/159>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/158> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/160>
     rdf:type    kgc:Statement ;
@@ -1711,7 +2447,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall saw the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/160>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/150> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/161>
     rdf:type    kgc:Statement ;
@@ -1719,8 +2457,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes requested the following from Stanley Hopkins"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/request> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/request> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/161>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/161a> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/150> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/161a>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンリィ・ホプキンスはホームズに知らせる"@ja ;
@@ -1728,8 +2471,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/161a>
+    rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/162> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/150> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/162>
     rdf:type    kgc:Statement ;
     kgc:source  "ルイシャムの夜盗団が逮捕された"@ja ;
@@ -1744,7 +2492,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Way back per, Holmes was suffering badly"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/worry> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/worry> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/163>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/On_the_way_home> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/164>
     rdf:type    kgc:Thought ;
@@ -1752,25 +2502,43 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes thought he returned to the dining room of Abbey Grange"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mind_of_Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dining_room_of_Abbey_Grange> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/164>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dining_room_of_Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/164>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/165> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/165>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは列車からホームに飛び降りた"@ja ;
     kgc:source  "Holmes jumped from the train home"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/getOff> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/getOff> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/157> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/165>
+    rdf:type    kgc:Situation ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/train> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/home> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/home> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/165>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/166> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/166>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはワトソンを引っ張り出した"@ja ;
     kgc:source  "Holmes pulled Watson"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pullOut> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pullOut> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/158> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/166>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/166>
+    rdf:type    kgc:Situation ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/train> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/196> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/167>
@@ -1779,7 +2547,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The testimony of Lady Brackenstall was perfection"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/perfect> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/perfect> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/167>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/169> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/168>
     rdf:type    kgc:Thought ;
@@ -1787,7 +2557,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The testimony of Theresa is enough"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Theresa> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/sufficient> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/sufficient> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/168>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/169> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/169>
     rdf:type    kgc:Thought ;
@@ -1811,19 +2583,29 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes denies the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/deny> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/deny> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/171>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/170> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/172>
     rdf:type    kgc:Situation ;
     kgc:source  "ルイシャムの夜盗団は2週間前シドナムで相当の獲物を獲た"@ja ;
     kgc:source  "The burglary team of Lewisham caught the prey in the previous two weeks in Sydenham"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/get> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/substantial_property> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/get> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/172>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/substantial_property> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/172>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/2_weeks_ago> ;
     kgc:time  "1897-01-15T00:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-15T00> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-01-15T00> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/172>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/172>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/173> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/173>
     rdf:type    kgc:Situation ;
@@ -1831,7 +2613,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The burglary team of Lewisham appeared in the newspaper"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/newspaper> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/article_of_Burglary_team_of_Lewisham> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/post> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/post> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/173>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/174> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/174>
     rdf:type    kgc:Thought ;
@@ -1839,7 +2623,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal plays the burglary team of Lewisham"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/174>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/175>
     rdf:type    kgc:Thought ;
@@ -1847,7 +2633,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall made up the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hoax> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hoax> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/175>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/174> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/176>
     rdf:type    kgc:Thought ;
@@ -1855,7 +2643,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Burglary team enjoys a successful job"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enjoy> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enjoy> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/176>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Success_of_work> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/177>
     rdf:type    kgc:Thought ;
@@ -1863,7 +2653,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The following are anomalies"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/178> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/abnormal> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/abnormal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/177>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/176> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/178>
     rdf:type    kgc:Situation ;
@@ -1878,7 +2670,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The following is abnormal"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/057> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/abnormal> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/abnormal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/170> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/179>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/180> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/180>
     rdf:type    kgc:Thought ;
@@ -1886,7 +2683,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall exclaims"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/180>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/180a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/180a>
     rdf:type    kgc:Thought ;
@@ -1894,7 +2693,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal strikes Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/180a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/181>
     rdf:type    kgc:Thought ;
@@ -1902,7 +2703,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The burglary team of Lewisham consists of three people"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/181>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/three_people> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/182>
     rdf:type    kgc:Thought ;
@@ -1910,9 +2713,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Do not kill people but just stifle one person"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notKill> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notKill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/182>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_brackenstall> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Restraint> ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Restraint> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/182>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/181> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/183>
     rdf:type    kgc:Thought ;
@@ -1921,6 +2728,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/149> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/abnormal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解し，ここにその文IDを入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/174> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/184>
     rdf:type    kgc:Thought ;
     kgc:source  "以下は異常である"@ja ;
@@ -1941,7 +2751,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall notifies the police"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/report> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/report> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/186>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/187>
     rdf:type    kgc:Thought ;
@@ -1949,8 +2761,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "It was necessary to immobilize or kill Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/need> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Restraint_of_Lady_Brackenstall_OR_killing_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/need> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/180> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/187>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Restraint_of_Lady_Brackenstall_OR_killing_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/187>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/186> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/188>
     rdf:type    kgc:Situation ;
@@ -1963,8 +2782,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "三つ目のワイングラスにオリがいっぱい入っていた"@ja ;
     kgc:source  "Dregs in the third of the wine glasses were wholly entered"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/third_glass> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dregs_of_wine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/189>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dregs_of_wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/189>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/full> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/190>
     rdf:type    kgc:Thought ;
@@ -1972,8 +2795,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal filled the second glass"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fill> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/second_glass> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/190>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/second_glass> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/190>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/191> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/191>
     rdf:type    kgc:Thought ;
@@ -1981,28 +2808,47 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal shook the bottle violently"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shake> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shake> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/191>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_of_wine> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/violently> ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/violently> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/191>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/192> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/149> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/192>
     rdf:type    kgc:Thought ;
     kgc:source  "二つのグラスの澱が三つ目のグラスに注がれた"@ja ;
     kgc:source  "The dregs of two glasses poured into a third glass"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pour> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pour> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/192>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dreg_of_two_of_glass> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Third_glass> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Third_glass> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/192>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/193> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解し，ここにその文IDを入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/153> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/193>
     rdf:type    kgc:Thought ;
     kgc:source  "犯人は三人の人物を印象づける"@ja ;
     kgc:source  "The criminal impresses three people"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/impress> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/impress> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/193>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/three_people> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/062> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/194>
     rdf:type    kgc:Thought ;
     kgc:source  "レディー・ブラックンストールとテリーサは故意にホームズとワトソンに嘘をついた"@ja ;
@@ -2010,10 +2856,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/lie> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/lie> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/194>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Deliberately> ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Deliberately> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/194>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/195> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/195>
     rdf:type    kgc:Thought ;
@@ -2023,14 +2873,21 @@ kgc:Thought rdf:type owl:Class ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Theresa> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Incredible> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/186> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/196>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズとワトソンはアビ屋敷に戻ってきた"@ja ;
     kgc:source  "Holmes and Watson came back to Abbey Grange"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/196>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/196>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/198> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/197>
     rdf:type    kgc:Situation ;
@@ -2049,7 +2906,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "ホームズはダイニングルームで二時間調査した"@ja ;
     kgc:source  "Holmes was committed to the occupation and investigation of the dining room for two hours"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/198>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/196>
     rdf:type    kgc:Situation ;
@@ -2064,33 +2923,51 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "ホームズはマントルピースの上に上った"@ja ;
     kgc:source  "Holmes went up on top of the massive mantel"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goUp> ;
-    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mantelpiece> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goUp> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/199>
+    rdf:type    kgc:Situation ;
+    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mantelpiece> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/199>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/199>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/200> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/200>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはベルの紐に近寄る"@ja ;
     kgc:source  "Holmes wants to approach the bell code"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/approach> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/approach> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/200>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/201>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはブラケットにひざを乗せた"@ja ;
     kgc:source  "Holmes put his knee on the bracket"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/put> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knee> ;
-    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wooden_blanket> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/200> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/put> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/201>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knee> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/201>
+    rdf:type    kgc:Situation ;
+    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wooden_blanket> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/201>
+    rdf:type    kgc:Situation ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/200> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/201>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/202> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/202>
     rdf:type    kgc:Situation ;
     kgc:source  "ブラケットはホームズの注意を引いた"@ja ;
     kgc:source  "Bracket drew the attention of the Holmes"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/focus> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/focus> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/202>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bracket> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/203>
     rdf:type    kgc:Thought ;
@@ -2106,15 +2983,38 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/formidable> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解し，ここにその文IDを入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/198> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/記載内容が誰かの「発言」や「考え」の場合，「誰の発言/考えか」を記載する> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/205>
     rdf:type    kgc:Thought ;
     kgc:source  "犯人は身長六フィート三インチである"@ja ;
     kgc:source  "The criminal is six feet three inches tall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/equalTo> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/6_feet_3_inch> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/205>
+    rdf:type    kgc:Situation ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/205>
+    rdf:type    kgc:Situation ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/equalTo> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:要確認．「犯人の身長は」？   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［複数行可］他のシーンとのつながりを，「シーンのID」＋「つながりの種類（下記から選択）」で記入> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/205>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/6_feet_3_inch> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解し，ここにその文IDを入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/196> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/205>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/209> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［必須・１行のみ］下記のフォームに入力した内容を「簡単な文」で表現する．> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/206>
     rdf:type    kgc:Situation ;
     kgc:source  "犯人はリスのように機敏である"@ja ;
@@ -2138,34 +3038,89 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/209>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはブラケットから切断面まで3インチ届かなかった"@ja ;
-    kgc:source  "Holmes did not reach three inches to the cutting surface from the bracket"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notReach> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/End_of_cord_of_bell> ;
+    kgc:source  "Holmes did not reach three inches to the cutting surface from the bracket"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/209>
+    rdf:type    kgc:Situation ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/209>
+    rdf:type    kgc:Situation ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notReach> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［複数行可］下記から種類を選択の上「目的語」を記入> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/209>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/End_of_cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［複数行可］他のシーンとのつながりを，「シーンのID」＋「つながりの種類（下記から選択）」で記入> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/209>
+    rdf:type    kgc:Situation ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/blanket> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［必須・１行のみ］下記のフォームに入力した内容を「簡単な文」で表現する．> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/記載内容が誰かの「発言」や「考え」の場合，「誰の発言/考えか」を記載する> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/210>
     rdf:type    kgc:Thought ;
     kgc:source  "犯人はこの独創的な話全体をでっち上げた"@ja ;
     kgc:source  "The criminal concocted this whole ingenious story"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hoax> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/210>
+    rdf:type    kgc:Situation ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/210>
+    rdf:type    kgc:Situation ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hoax> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［複数行可］他のシーンとのつながりを，「シーンのID」＋「つながりの種類（下記から選択）」で記入> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/210>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/original_fiction> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［必須・１行のみ］下記のフォームに入力した内容を「簡単な文」で表現する．> ;
+    kgc:time  "対象文が文全体を表していません．加筆してください．T00:00:00"^^xsd:dateTime ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/対象文が文全体を表していません．加筆してください．> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/記載内容が誰かの「発言」や「考え」の場合，「誰の発言/考えか」を記載する> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［必須・複数行可］「主語」を記入> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/211>
+    rdf:type    kgc:Situation ;
+    kgc:source  "犯人はベルの紐に手がかりを残した"@ja ;
+    kgc:source  "The criminal left a clue on the bell code"@en .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/211>
     rdf:type    kgc:Thought ;
-    kgc:source  "犯人はベルの紐に手がかりを残した"@ja ;
-    kgc:source  "The criminal left a clue on the bell code"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leaveBehind> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/clue> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/211>
+    rdf:type    kgc:Situation ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/211>
+    rdf:type    kgc:Situation ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leaveBehind> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/202> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/211>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/clue> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/211>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/212>
     rdf:type    kgc:Situation ;
     kgc:source  "箇所Aは針金にくっついている"@ja ;
     kgc:source  "Point A is stuck to the wire"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Point_A> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stuck> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stuck> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/212>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wire> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/213>
     rdf:type    kgc:Thought ;
@@ -2173,7 +3128,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Break of the cord of bell was not a place A"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Break_of_cord_of_bell> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notEqualTo> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notEqualTo> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/213>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Point_A> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/214>
     rdf:type    kgc:Thought ;
@@ -2182,8 +3139,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Break_of_cord_of_bell> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cut> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/3_inch> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cut> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/214>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/3_inch> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/214>
+    rdf:type    kgc:Situation ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/ベルの紐の先端> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/215>
     rdf:type    kgc:Thought ;
@@ -2191,7 +3152,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal needed a bell code"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/need> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/need> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/215>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/216>
     rdf:type    kgc:Situation ;
@@ -2199,15 +3162,24 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The opposite end of the bell code is frayed"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/opposite_end_of_cord_of_bell> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/fray> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/210> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/217>
     rdf:type    kgc:Thought ;
     kgc:source  "犯人は実に狡猾な男でナイフでそうした"@ja ;
     kgc:source  "The criminal did so with a knife as a truly cunning man"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/knife> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Cleverly> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/217>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/knife> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/217>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Cleverly> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/217>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/216> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/218>
     rdf:type    kgc:Thought ;
@@ -2215,8 +3187,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal did not tear off the bell code"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notCut> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notCut> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/218>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/218>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/219> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/219>
     rdf:type    kgc:Thought ;
@@ -2224,7 +3200,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The ringing of the bell alerts the maids to the urgency of the situation"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sound_of_bell> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/219>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/maid> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/220>
@@ -2233,7 +3211,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Criminal hopped on top of the mantelpiece"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hop> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hop> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/220>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/mantelpiece> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/221>
     rdf:type    kgc:Thought ;
@@ -2241,7 +3221,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal couldn't reach the bell code"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notReach> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notReach> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/221>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/222>
     rdf:type    kgc:Thought ;
@@ -2249,10 +3231,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal was devoted to putting a knee on the bracket"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/put> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knee> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/put> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/222>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knee> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/222>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bracket> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/221> ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/221> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/222>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/223> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/223>
     rdf:type    kgc:Thought ;
@@ -2268,7 +3256,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "ほこりの中に痕跡が見える"@ja ;
     kgc:source  "Visible traces are in the dust"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/224>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/trace> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dust> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/225>
@@ -2276,23 +3266,37 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "オークの椅子の座部の上に血の痕がある"@ja ;
     kgc:source  "There are traces of blood on the seat of the oak chair"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/blood> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/225>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/seat_of_oak_chair> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/216> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/226>
     rdf:type    kgc:Thought ;
     kgc:source  "椅子の座部に血の跡はつかない"@ja ;
     kgc:source  "No blood marks are there on the seat of the chair"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/blood> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExist> ;
-    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/seat_of_oak_chair> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/226>
+    rdf:type    kgc:Situation ;
+    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/seat_of_oak_chair> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/226>
+    rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/062> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:別の文としてSVO分解し，ここにその文IDを入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/219> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/227>
     rdf:type    kgc:Situation ;
     kgc:source  "サー・ユースタス・ブラックンストールが死んだ"@ja ;
     kgc:source  "Sir Eustace Blackenstall is dead"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/227>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/228> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/228>
     rdf:type    kgc:Thought ;
@@ -2300,7 +3304,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall was sitting in a chair"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sit> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/228>
+    rdf:type    kgc:Situation ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/oak_chair> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/225> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/229>
@@ -2332,17 +3338,27 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "テリーサは時間が必要である"@ja ;
     kgc:source  "Theresa took a while"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/need> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/while> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/time> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/need> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/233>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/while> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/233>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/time> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/233>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/232> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/234>
     rdf:type    kgc:Situation ;
     kgc:source  "テリーサはサー・ユースタス・ブラックンストールに対する憎悪を隠さなかった"@ja ;
     kgc:source  "Theresa did not hide his hatred for Sir Eustace Brackenstall"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHide> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Hatred> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHide> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/234>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Hatred> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/234>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/235>
     rdf:type    kgc:Statement ;
@@ -2350,8 +3366,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall said abuse to Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/abuse> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/235>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/abuse> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/235>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/236>
     rdf:type    kgc:Statement ;
@@ -2359,7 +3379,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa heard the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/236>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/235> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/237>
     rdf:type    kgc:Statement ;
@@ -2367,8 +3389,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall cannot be considered ill when there is a brother of Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSay> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/abuse_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSay> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/237>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/abuse_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/237>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/siblings_of_Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/238>
     rdf:type    kgc:Statement ;
@@ -2376,7 +3402,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa said the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/238>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/237> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/239>
     rdf:type    kgc:Statement ;
@@ -2384,8 +3412,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa was threw a decanter to Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/throw> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Decanter> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/throw> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/239>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Decanter> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/239>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/240>
     rdf:type    kgc:Statement ;
@@ -2393,7 +3425,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall did not complain"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/240>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/complaint> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/241>
     rdf:type    kgc:Thought ;
@@ -2402,7 +3436,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stabble> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stabble> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/241>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Pin_of_hat> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/242>
     rdf:type    kgc:Statement ;
@@ -2410,8 +3446,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa called Sir Eustace Brackenstall a wicked devil"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/call> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/crafty> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/call> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/242>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/crafty> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/242>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/243>
     rdf:type    kgc:Statement ;
@@ -2421,7 +3461,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/243>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/first_time> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/244>
     rdf:type    kgc:Statement ;
@@ -2429,18 +3471,31 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall was a nice guy"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/nice> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/nice> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/244>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/243> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/235> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/245>
     rdf:type    kgc:Statement ;
     kgc:source  "サー・ユースタス・ブラックンストールは肩書と財産と偽りのロンドン式のやり方でレディー・ブラックンストールを射止めた"@ja ;
     kgc:source  "Sir Eustace Blackenstall shot Lady Blackenstall with his title, fortune, and false London-style ways"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shot> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Title> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/property> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wrong_London_way> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shot> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/245>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Title> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/245>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/property> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/245>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wrong_London_way> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/245>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/246>
     rdf:type    kgc:Statement ;
@@ -2448,7 +3503,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Blackenstall and Lady Blackenstall met in July"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/237> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/246>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/July> ;
     kgc:time  "1895-07-01T12:00:00"^^xsd:dateTime ;
@@ -2459,8 +3519,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall went to London in June"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrive> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/London> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrive> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/247>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/London> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/247>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/June> ;
     kgc:time  "1896-06-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-06-01T12> .
@@ -2471,7 +3535,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/248>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/January,_last_year> ;
     kgc:time  "1896-01-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-01-01T12> .
@@ -2481,23 +3547,33 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes interrogates Lady Blackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/question> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/question> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/249>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/250>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールは以下を言った"@ja ;
     kgc:source  "Lady Bracknstall said the following"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/249> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/250>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/249> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/250>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/251> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/251>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは優しく以下を否定した"@ja ;
     kgc:source  "Holmes gently denied the following"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/deny> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/249> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/deny> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/251>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/249> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/251>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Gently> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/252>
     rdf:type    kgc:Statement ;
@@ -2505,8 +3581,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes wants the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/252>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/252a> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/243> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/252a>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールが楽になる"@ja ;
@@ -2514,13 +3595,20 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ease> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/243> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/253>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは以下をレディー・ブラックンストールに言った"@ja ;
     kgc:source  "Holmes told Lady Bracknstall the following"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/252> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/253>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/252> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/253>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/254>
     rdf:type    kgc:Statement ;
@@ -2528,7 +3616,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes wants the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/254>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/254a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/254a>
     rdf:type    kgc:Statement ;
@@ -2536,7 +3626,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall speaks the truth"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/254a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/255>
     rdf:type    kgc:Situation ;
@@ -2550,7 +3642,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes said the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/256>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/254> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/255> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/257>
@@ -2565,14 +3659,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "レディー・ブラックンストールの顔にためらいが見えた"@ja ;
     kgc:source  "Hesitation was visible on the face of the Lady Brackenstall"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/258>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Hesitation_of_Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/259>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールの顔が仮面のように固くなった"@ja ;
     kgc:source  "The face of Lady Brackenstall has become firm as a mask"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Face_of_Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/firmly> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/firmly> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/259>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/like_mask> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/260>
     rdf:type    kgc:Statement ;
@@ -2580,23 +3678,33 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall told us everything she knew"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/260>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/261>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはアビ屋敷を後にした"@ja ;
     kgc:source  "Holmes was after the Abbey Grange"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/261>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/261>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/262> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/262>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは庭園の池に向かった"@ja ;
     kgc:source  "Holmes went to the pond of the garden"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond_of_garden_of_Abbey_Grange> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/262>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond_of_garden_of_Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/262>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/265> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/263>
     rdf:type    kgc:Situation ;
@@ -2609,23 +3717,33 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "池には白鳥のための穴が一つだけ残されていた"@ja ;
     kgc:source  "The pond had been left only one hole for the swan"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hole> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/remain> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond_of_garden_of_Abbey_Grange> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/remain> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/264>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond_of_garden_of_Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/264>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/swan> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/265>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは穴をじっと見つめた"@ja ;
     kgc:source  "Holmes stared a hole"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/gaze> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hole> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/gaze> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/265>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hole> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/265>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/266> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/266>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは番小屋のある門へ向かった"@ja ;
     kgc:source  "Holmes went to the gate with a guard house"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/266>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Gate_of_garden> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/267>
     rdf:type    kgc:Statement ;
@@ -2633,26 +3751,38 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes is not going to reveal the secret to Stanley Hopkins"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/267>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/267>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/268>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはアデレイドに向かう"@ja ;
     kgc:source  "Holmes headed to Adelaide"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/268>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Adelaide> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/269>
     rdf:type    kgc:Situation ;
     kgc:source  "1895年にロック・オブ・ジブラルタルはサザンプトン航路で母港に着いた"@ja ;
     kgc:source  "In 1895 the Rock of Gibraltar arrived at her home port on the Southampton route"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Rock-of-Gibraltar> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrive> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrive> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/269>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895> ;
     kgc:time  "1895-02-01T12:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895-02-01T12> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/home_port> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895-02-01T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/269>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/home_port> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/269>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Southampton_route> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/270>
     rdf:type    kgc:Situation ;
@@ -2660,45 +3790,69 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall and Teresa sailed on the Rock of Gibraltar"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sail> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sail> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/270>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895> ;
     kgc:time  "1895-02-01T12:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895-02-01T12> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895-02-01T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/270>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Rock-of-Gibraltar> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/271>
     rdf:type    kgc:Situation ;
     kgc:source  "1897年、ロック・オブ・ジブラルタル号はスエズ運河の辺りだった"@ja ;
     kgc:source  "The Rock-of-Gibraltar was around Suez Canal in 1897"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Rock-of-Gibraltar> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/271>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897> ;
     kgc:time  "1897-02-01T12:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T12> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/271>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Suez_Canal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/262> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/272>
     rdf:type    kgc:Situation ;
     kgc:source  "乗務員は1985年と一緒だった"@ja ;
     kgc:source  "The crew was with 1895"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Train_crew> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/272>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895> ;
     kgc:time  "1895-02-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895-02-01T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/265> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/273>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは一等航海士だった"@ja ;
-    kgc:source  "Jack Crocker was the Chief officer"@en ;
+    kgc:source  "Jack Crocker was the Chief officer"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/273>
+    rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Chief_officer> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Chief_officer> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/273>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895> ;
     kgc:time  "1895-02-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895-02-01T12> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/274>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは船長になっている"@ja ;
-    kgc:source  "Jack Crocker has become the captain"@en ;
+    kgc:source  "Jack Crocker has become the captain"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/274>
+    rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Captain> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Captain> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/274>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897> ;
     kgc:time  "1897-02-01T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T12> .
@@ -2707,53 +3861,74 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "2日後、サザンプトンからベイス・ロック号が出港する"@ja ;
     kgc:source  "Two days later, the Base Rock sails from Southampton"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_Bays_Rock> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/Depart> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/Depart> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/275>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Two_days_later> ;
     kgc:time  "1897-02-03T12:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-03T12> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-03T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/275>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Southampton> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/276>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーはベイス・ロック号の指揮を執る"@ja ;
     kgc:source  "Jack Crocker takes command of the Base Rock"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/command> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/command> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/276>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_Bays_Rock> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/277>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーはシドナムに住んでいる"@ja ;
     kgc:source  "Jack Crocker lives in Sydenham"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/277>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/278>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーの経歴はすばらしかった"@ja ;
     kgc:source  "The career of Jack Crocker was wonderful"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career_of_Jack_Crocker> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wonderful> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wonderful> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/278>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/279> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/279>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーに匹敵する航海士はどの船にもいなかった"@ja ;
     kgc:source  "The officer comparable to Jack Crocker was not on any ship"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notExist> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Comparable_Officer> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notExist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/279>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Comparable_Officer> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/279>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/any_ship> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/280>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは船を離れる"@ja ;
     kgc:source  "Jack Crocker leaves the ship"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/280>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/ship> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/281>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーの性格は無鉄砲である"@ja ;
     kgc:source  "The personality of Jack Crocker is wildly reckless"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality_of_Jack_Crocker> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Reckless> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Reckless> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/281>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/280> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/282>
     rdf:type    kgc:Situation ;
@@ -2761,6 +3936,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker easy excited in the short term"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/inpatient> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/283>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは忠実で正直で優しい"@ja ;
@@ -2774,16 +3952,24 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "会社事務所はアデレイド、サザンプトンにある"@ja ;
     kgc:source  "The company's office is in Adelaide, Southampton"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Company_office> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Adelaide> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/284>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Adelaide> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/284>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Southampton> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/285>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは会社の事務所で情報を得た"@ja ;
     kgc:source  "Holmes gets the information in the company's office"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/get> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Company_office> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/get> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/285>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Company_office> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/285>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/information> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/286>
     rdf:type    kgc:Situation ;
@@ -2798,7 +3984,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes can't save the criminal"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSave> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/287>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/286> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/288>
     rdf:type    kgc:Statement ;
@@ -2806,7 +3994,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes does not want the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/288>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/288a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/288a>
     rdf:type    kgc:Statement ;
@@ -2814,7 +4004,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes cheats his conscience"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cheat> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cheat> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/288a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/conscience> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/289>
     rdf:type    kgc:Statement ;
@@ -2822,7 +4014,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes want the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/289>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/289a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/289a>
     rdf:type    kgc:Statement ;
@@ -2830,7 +4024,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes cheats on England's laws"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cheat> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cheat> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/289a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/law_of_England> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/290>
     rdf:type    kgc:Statement ;
@@ -2838,7 +4034,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The stolen silver product was at the bottom of the pond"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/silver_products> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/290>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottom_of_pond_of_garden> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/291>
     rdf:type    kgc:Statement ;
@@ -2846,7 +4044,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes did not know the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/291>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/290> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/292>
     rdf:type    kgc:Statement ;
@@ -2854,7 +4054,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes had the following done"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/let> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/let> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:調べさせた   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/280> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/292>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/292a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/292a>
     rdf:type    kgc:Statement ;
@@ -2862,7 +4067,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Stanley Hopkins examines the bottom of the pond"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:調べさせた   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/280> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/292a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottom_of_pond_of_garden> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/293>
     rdf:type    kgc:Thought ;
@@ -2870,7 +4080,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal didn't want silverware"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/293>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_products> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/294>
     rdf:type    kgc:Thought ;
@@ -2878,7 +4090,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal was taken to blinding"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/steal> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/steal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/294>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fiction> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/295>
     rdf:type    kgc:Thought ;
@@ -2886,7 +4100,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "There is a pond by the French windows"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond_of_garden> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/295>
+    rdf:type    kgc:Situation ;
     kgc:nextTo   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/French_windows> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/296>
     rdf:type    kgc:Thought ;
@@ -2894,7 +4110,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holes in the pond will be in cache"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holes_of_pond> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/296>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cache> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/297>
     rdf:type    kgc:Thought ;
@@ -2902,7 +4120,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal has a silver products"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/297>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/298>
     rdf:type    kgc:Thought ;
@@ -2910,19 +4130,30 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The criminal was terrified the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fear> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/298>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/297> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:別文にして文IDを入れてください．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/286> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/299>
     rdf:type    kgc:Thought ;
     kgc:source  "犯人は後日、銀製品を取りにアビ屋敷に戻るつもりだった"@ja ;
     kgc:source  "The criminal was going to return to Abbey Grange to take the silver products later"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/willReturn> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/willReturn> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/299>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/later_date> ;
     kgc:time  "1897-03-01T12:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-03-01T12> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-03-01T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/299>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/299>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/300>
     rdf:type    kgc:Statement ;
@@ -2930,17 +4161,23 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Stanley Hopkins has made a stunning hypothesis"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/estimate> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/estimate> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/300>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/297> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/298> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/299> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/299> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/300>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brilliantly> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/301>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンリィ・ホプキンズは頓挫した"@ja ;
     kgc:source  "Stanley Hopkins was derailed"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/derail> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/derail> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/301>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/302> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/302>
     rdf:type    kgc:Statement ;
@@ -2949,10 +4186,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Police> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrest> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrest> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/302>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/this_morning> ;
     kgc:time  "1897-02-01T08:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T08> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897-02-01T08> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/302>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/New_York> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/303>
     rdf:type    kgc:Statement ;
@@ -2961,6 +4202,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blinding> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Hint> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/290> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/304>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズの知ることは非公式である"@ja ;
@@ -2981,7 +4225,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "There is no private judgment of the rights to Stanley Hopkins"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/306>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Private_decision> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/307>
     rdf:type    kgc:Statement ;
@@ -2989,7 +4235,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Watson attend the final curtain of the small drama"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/attend> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/attend> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/307>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/end_of_case> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/308>
     rdf:type    kgc:Situation ;
@@ -3002,14 +4250,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "ジャック・クロッカーがホームズの部屋に入ってきた"@ja ;
     kgc:source  "Jack Crocker walked into Holmes' room"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/309>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Holmes> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/310>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは軽快な足取りをしていた"@ja ;
     kgc:source  "Jack Crocker had a nimble gait"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/nimble-footed> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/nimble-footed> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/310>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/309> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/311>
     rdf:type    kgc:Statement ;
@@ -3017,33 +4269,55 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker received a telegram from Holmes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Telegram> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/311>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Telegram> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/311>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/311>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/309> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/297> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/312>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは以下のことをさせた"@ja ;
     kgc:source  "Holmes had the following done"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/let> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/let> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/312>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/312a> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/313> ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/313> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/312>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/309> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/312a>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは葉巻を吸う"@ja ;
     kgc:source  "Jack Crocker smoked a cigar"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/smoke> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/smoke> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/312a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cigar> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/313>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは以下を思っていない"@ja ;
     kgc:source  "Holmes does not think the following"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notThink> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notThink> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/313>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/314> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/297> ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/298> ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/299> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/314>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは普通の犯罪者である"@ja ;
@@ -3056,15 +4330,23 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker believe Holmes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/315>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/315>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは以下を誓った"@ja ;
-    kgc:source  "Jack Crocker vowed the following"@en ;
+    kgc:source  "Jack Crocker vowed the following"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/316>
+    rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/swear> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/swear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/316>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316a>
     rdf:type    kgc:Statement ;
@@ -3072,7 +4354,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker speaks the truth."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/316a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/317>
     rdf:type    kgc:Statement ;
@@ -3082,14 +4366,22 @@ kgc:Thought rdf:type owl:Class ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/revive> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
-    rdf:type    kgc:Statement ;
+    rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは同じことをする"@ja ;
-    kgc:source  "Jack Crocker does the same thing to Sir Eustace Brackenstall"@en ;
+    kgc:source  "Jack Crocker does the same thing to Sir Eustace Brackenstall"@en .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
+    rdf:type    kgc:Statement ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/repeat> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/same> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/repeat> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/same> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
+    rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/317> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/319>
     rdf:type    kgc:Statement ;
@@ -3097,7 +4389,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker does not want the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/319>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/319a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/320>
     rdf:type    kgc:Situation ;
@@ -3107,8 +4401,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/involve> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/involve> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/319a>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/319a>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/danger_position> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/320>
     rdf:type    kgc:Statement ;
@@ -3116,8 +4414,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker gives his life"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/dedicate> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/life> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/dedicate> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/320>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/life> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/320>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/319> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/321>
     rdf:type    kgc:Statement ;
@@ -3126,7 +4428,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/321>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_Rock-Of-Gibraltar> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/322>
     rdf:type    kgc:Statement ;
@@ -3134,8 +4438,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall just became one of the women for Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Only_one_woman> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/322>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Only_one_woman> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/322>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/322> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/323>
     rdf:type    kgc:Statement ;
@@ -3143,15 +4451,24 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Love was the only person of Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/love> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/323>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/love> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/323>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/309> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/324>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーが次の航海から帰った"@ja ;
     kgc:source  "Jack Crocker was back from the next voyage"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/324>
+    rdf:type    kgc:Situation ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/next_voyage> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/325>
     rdf:type    kgc:Statement ;
@@ -3159,8 +4476,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker was aware of the marriage of Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Marriage_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/325>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Marriage_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/325>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/324> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/326>
     rdf:type    kgc:Thought ;
@@ -3168,7 +4489,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall is not married to a favorite man"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notMarry> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notMarry> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/326>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/favorite_man> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/327>
     rdf:type    kgc:Thought ;
@@ -3183,7 +4506,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Bracknstall is not unhappy for Jack Crocker."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notUnhappy> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notUnhappy> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/328>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/329>
     rdf:type    kgc:Statement ;
@@ -3191,7 +4516,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker was pleased with the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bePleased> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bePleased> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/329>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/328> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/330>
     rdf:type    kgc:Statement ;
@@ -3199,11 +4526,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker had been waiting in Sydenham for the new ship for several months"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/330>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/330>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/A_few_months> ;
     kgc:time  "1896-12-01T12:00:00"^^xsd:dateTime ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-12-01T12> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1896-12-01T12> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/330>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/new_ship> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/331>
     rdf:type    kgc:Statement ;
@@ -3212,8 +4545,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/330> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/331>
+    rdf:type    kgc:Situation ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/330> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/331>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/332> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/332>
     rdf:type    kgc:Statement ;
@@ -3221,8 +4558,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker heard the story of Sir Eustace Brackenstall from Theresa"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Story_of_Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/332>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Story_of_Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/332>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/333> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/333>
     rdf:type    kgc:Statement ;
@@ -3231,8 +4572,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/again> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/333>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/again> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/333>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/334> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/334>
     rdf:type    kgc:Statement ;
@@ -3248,7 +4593,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker go on a voyage"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/335>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/voyage> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/336>
     rdf:type    kgc:Statement ;
@@ -3256,9 +4603,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker met Teresa once more"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/335> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/336>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/336>
+    rdf:type    kgc:Situation ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/335> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/336>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/again> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/337>
     rdf:type    kgc:Statement ;
@@ -3266,8 +4619,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa was always an ally of Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/ally> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/338> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/ally> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/337>
+    rdf:type    kgc:Situation ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/338> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/337>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/339> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/338>
     rdf:type    kgc:Situation ;
@@ -3275,8 +4632,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa is hated Sir Eustace Brackenstall in the same way as Jack Crocker"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hate> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/similarly> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hate> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/338>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/similarly> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/338>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/339>
     rdf:type    kgc:Situation ;
@@ -3284,8 +4645,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa loves Lady Brackenstall in the same way as Jack Crocker"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/similarly> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/339>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/similarly> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/339>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/340>
     rdf:type    kgc:Statement ;
@@ -3293,9 +4658,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker heard the following from Theresa"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/341> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/340>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/341> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:from_テリーサ，を入れて下さい   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/324> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/340>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/340>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/342> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/341>
     rdf:type    kgc:Statement ;
@@ -3303,8 +4677,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall is always reading a book in a small room downstairs"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/read> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Book> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/read> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/341>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Book> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/341>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/342>
     rdf:type    kgc:Statement ;
@@ -3312,8 +4690,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker scratched the window of the room of Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/scratch> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_room_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/scratch> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/342>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_room_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/342>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/344> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/343>
     rdf:type    kgc:Statement ;
@@ -3321,7 +4703,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall love Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/343>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
     rdf:type    kgc:Statement ;
@@ -3329,10 +4713,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker was invited to the dining room by Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inviteIn> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/343> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inviteIn> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
+    rdf:type    kgc:Situation ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/343> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/345> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/345>
     rdf:type    kgc:Statement ;
@@ -3340,9 +4732,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker heard what happened from Lady Bracknstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Situation> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/345>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Situation> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/345>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/345>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/347> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/346>
     rdf:type    kgc:Statement ;
@@ -3351,8 +4749,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stand> ;
-    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stand> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/346>
+    rdf:type    kgc:Situation ;
+    kgc:near   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/346>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/345> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/347>
     rdf:type    kgc:Statement ;
@@ -3360,8 +4762,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall has rushed to the dining room like crazy"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rush> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rush> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/347>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/347>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/348> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/348>
     rdf:type    kgc:Statement ;
@@ -3369,9 +4775,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall hit the face of the Lady Brackenstall from the side with a stick"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Face_of_Lady_Brackenstall> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/stick> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/348>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Face_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/348>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/stick> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/348>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/349> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/349>
     rdf:type    kgc:Statement ;
@@ -3379,8 +4791,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker jumped at the poker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Poker> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/349>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Poker> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/349>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/350> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/350>
     rdf:type    kgc:Statement ;
@@ -3389,8 +4805,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fight> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fairly> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fight> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/350>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fairly> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/350>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/351> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/351>
     rdf:type    kgc:Statement ;
@@ -3398,8 +4818,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Sir Eustace Brackenstall added a blow to the arm of Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Arm_of_Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/351>
+    rdf:type    kgc:Situation ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Arm_of_Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/351>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/352> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/352>
     rdf:type    kgc:Statement ;
@@ -3407,8 +4831,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker beat Sir Eustace Blackenstall like a rotten pumpkin"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/339> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/352>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/352>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/rotten_pumpkin> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/353>
     rdf:type    kgc:Statement ;
@@ -3416,14 +4847,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker does not regret the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notRegret> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notRegret> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/353>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/352> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/354>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーがサー・ユースタス・ブラックンストールを殺さない"@ja ;
     kgc:source  "Jack Crocker does not kill Sir Eustace Brackenstall"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKill> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/354>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/355>
     rdf:type    kgc:Statement ;
@@ -3431,7 +4866,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker was dangerous"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/dangerous> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/dangerous> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/355>
+    rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/354> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/356>
     rdf:type    kgc:Thought ;
@@ -3439,7 +4876,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall was dangerous"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/dangerous> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/dangerous> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/356>
+    rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/354> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/357>
     rdf:type    kgc:Statement ;
@@ -3447,8 +4886,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker could not leave Lady Blackenstall for Sir Eustace Blackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notLeave> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notLeave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/357>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/357>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/358>
     rdf:type    kgc:Statement ;
@@ -3456,8 +4899,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker killed Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/358>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/344> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/358>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/357> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/359>
     rdf:type    kgc:Statement ;
@@ -3465,7 +4915,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall was beaten by Sir Eustace Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/359>
+    rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/360>
     rdf:type    kgc:Statement ;
@@ -3473,17 +4925,28 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall screamed"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/359> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/360>
+    rdf:type    kgc:Situation ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/359> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/360>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/361> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/345> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/361>
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサはレディー・ブラックンストールの叫び声を聞いた"@ja ;
     kgc:source  "Theresa heard the screams of Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Screams_of_Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/361>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Screams_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/361>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/362> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/362>
     rdf:type    kgc:Statement ;
@@ -3491,7 +4954,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa came down from the top of the room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goDown> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goDown> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/362>
+    rdf:type    kgc:Situation ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Theresa> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/363>
     rdf:type    kgc:Statement ;
@@ -3499,8 +4964,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "On the sideboard, there was a wine bottle"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Bottle_of_wine> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/363>
+    rdf:type    kgc:Situation ;
+    kgc:on   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/363>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/364> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/364>
     rdf:type    kgc:Statement ;
@@ -3508,7 +4977,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker opened the bottle of wine"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/open> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/open> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/364>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Bottle_of_wine> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/365>
     rdf:type    kgc:Statement ;
@@ -3516,7 +4987,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall is as dead in shock"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unconscious> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unconscious> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/365>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/shock> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/366>
     rdf:type    kgc:Statement ;
@@ -3524,10 +4997,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker poured a little wine into the mouth of Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pour> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mouth_of_Lady_Brackenstall> ;
-    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/365> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pour> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/366>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/366>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mouth_of_Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/366>
+    rdf:type    kgc:Situation ;
+    kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/365> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/366>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/367> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/367>
     rdf:type    kgc:Statement ;
@@ -3535,8 +5016,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker also had a glass of wine"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drink> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/a_cup_of_wine> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drink> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/367>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/a_cup_of_wine> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/367>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/368> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/368>
     rdf:type    kgc:Statement ;
@@ -3545,8 +5030,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/consider> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fiction> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/consider> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/368>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fiction> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/368>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/369> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/369>
     rdf:type    kgc:Statement ;
@@ -3555,9 +5044,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/camouflage> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Death_of_Sir_Eustace_Brackenstall> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/camouflage> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/369>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Death_of_Sir_Eustace_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:ユースタスの死   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/352> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/369>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/369>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/370> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/370>
     rdf:type    kgc:Statement ;
@@ -3565,10 +5063,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Theresa let Lady Brackenstall repeat the apocryphal"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fiction> ;
-    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/repeatedly> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/370>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fiction> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/370>
+    rdf:type    kgc:Situation ;
+    kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/repeatedly> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/370>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/370>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/371> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/371>
     rdf:type    kgc:Statement ;
@@ -3576,8 +5082,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker cut the bell code"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cut> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cut> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/371>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/371>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/372> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/372>
     rdf:type    kgc:Statement ;
@@ -3585,8 +5095,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker was tied to chair the Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/tie> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/tie> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/372>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/372>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/373> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/373>
     rdf:type    kgc:Statement ;
@@ -3594,23 +5108,31 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker frayed the ends of the code"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fray> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/End_of_cord_of_bell> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fray> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/373>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/End_of_cord_of_bell> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/373>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/374> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/374>
     rdf:type    kgc:Situation ;
     kgc:source  "警察がどうやって紐を切ったのかと怪しむ"@ja ;
     kgc:source  "Police wonder how the code was cut off"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/Wonder> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/Wonder> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/374>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/End_of_cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/375>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは泥棒というアイディアを貫徹したい"@ja ;
-    kgc:source  "Jack Crocker want to penetration of the idea of ​​thief"@en ;
+    kgc:source  "Jack Crocker want to penetration of the idea of __thief"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/keep> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/keep> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/375>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fiction> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/376>
     rdf:type    kgc:Statement ;
@@ -3618,8 +5140,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker has gathered some of the silver plates and pots"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collect> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collect> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/376>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/376>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/375> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/377>
     rdf:type    kgc:Statement ;
@@ -3628,8 +5154,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/377>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/377>
+    rdf:type    kgc:Situation ;
     kgc:after   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/15_minutes> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/378>
     rdf:type    kgc:Statement ;
@@ -3637,17 +5167,28 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker instructed"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/instruct> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/377> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/instruct> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/378>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/377> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/378>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/379> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/364> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/379>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは池の底に銀製品を落とした"@ja ;
     kgc:source  "Jack Crocker dropped the silver product to the bottom of the pond"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drop> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drop> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/379>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/379>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottom_of_pond> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/380>
     rdf:type    kgc:Statement ;
@@ -3655,7 +5196,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker did a really good thing"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/380>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/good_thing> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/381>
     rdf:type    kgc:Statement ;
@@ -3663,8 +5206,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker thought the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/380> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/381>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/380> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/381>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/382> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/382>
     rdf:type    kgc:Statement ;
@@ -3672,22 +5219,30 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker went to Sydenham"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/382>
+    rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/383>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは真実を話した"@ja ;
     kgc:source  "Jack Crocker told the truth"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/383>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/383>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/384> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/384>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはジャック・クロッカーの手を握った"@ja ;
     kgc:source  "Holmes was holding the hand of Jack Crocker"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hold> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hold> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/384>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand_of_Jack_Crocker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/385>
     rdf:type    kgc:Statement ;
@@ -3695,24 +5250,43 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes finds Jack Crocker's story to be true"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Jack_Crocker> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/385>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Jack_Crocker> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/370> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/385>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/386> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/386>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーはホームズの知らないことを言わなかった"@ja ;
     kgc:source  "Jack Crocker never told Holmes what he didn't know"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/386>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Unknown_things> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/371> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/387>
     rdf:type    kgc:Situation ;
     kgc:source  "軽業師と船乗りはブラケットからベルの紐に届く"@ja ;
     kgc:source  "Acrobat and the sailor reach the cord of the bell from the bracket"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/acrobat> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sailor> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/reach> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bracket> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/reach> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/387>
+    rdf:type    kgc:Situation ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bracket> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/372> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/387>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/388>
     rdf:type    kgc:Thought ;
@@ -3720,14 +5294,24 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes thought the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/373> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/388>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/387> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/389>
     rdf:type    kgc:Situation ;
     kgc:source  "船乗りは結び目を作れる"@ja ;
     kgc:source  "Sailors can make the knot"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sailor> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/canMake> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/canMake> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/374> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/389>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/knot> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/390>
     rdf:type    kgc:Thought ;
@@ -3735,7 +5319,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes thought the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/390>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/389> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/391>
     rdf:type    kgc:Thought ;
@@ -3744,21 +5330,33 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sailor> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/391>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Voyage_of_Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/392>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールは以下を試みた"@ja ;
     kgc:source  "Lady Brackenstall was trying the following"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/try> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/try> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/375> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/392>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/392a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/392a>
     rdf:type    kgc:Situation ;
     kgc:source  "レディー・ブラックンストールは犯人を守る"@ja ;
     kgc:source  "Lady Bracknstall protect the criminal"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/protect> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/protect> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/375> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/392a>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/criminal> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/393>
     rdf:type    kgc:Thought ;
@@ -3766,9 +5364,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "On the voyage, the sailors were of the same class as Lady Bracknstall."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sailor> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/The_same_class> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/392> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/The_same_class> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/393>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/393>
+    rdf:type    kgc:Situation ;
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/392> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/393>
+    rdf:type    kgc:Situation ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Voyage_of_Lady_Brackenstall> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/394>
     rdf:type    kgc:Statement ;
@@ -3776,8 +5380,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The police have not managed to see through the criminal"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/377> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/394>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/379> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/395>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーの行動は極めて重大な問題である"@ja ;
@@ -3798,15 +5410,25 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes is unsure about the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notUnderstand> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notUnderstand> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/397>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/396> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:別文にして文IDを入れて下さい．   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/380> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・otherwise（さもないと）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/382> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/398>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはジャック・クロッカーにおおいに同情している"@ja ;
     kgc:source  "Holmes has shown much sympathy for Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sympathy> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sympathy> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/398>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399>
     rdf:type    kgc:Statement ;
@@ -3814,7 +5436,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "No one prevents Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/everyone> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notInterfere> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notInterfere> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/399>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399>
     rdf:type    kgc:Situation ;
@@ -3825,8 +5449,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker hide the appearance within twenty-four hours"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/appearance> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/399a>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/appearance> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/399a>
+    rdf:type    kgc:Situation ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/within_24_hours> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/400>
     rdf:type    kgc:Statement ;
@@ -3834,7 +5462,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes promised the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/promise> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/promise> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/400>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/401>
     rdf:type    kgc:Statement ;
@@ -3842,8 +5472,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker is hidden"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/appearance> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/401>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/appearance> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
+    rdf:type    kgc:Situation ;
+    kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/386> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/401>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/402> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/402>
     rdf:type    kgc:Statement ;
@@ -3859,7 +5496,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/concider> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/concider> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/403>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/accomplice> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/404>
     rdf:type    kgc:Situation ;
@@ -3867,7 +5506,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Lady Brackenstall is restrained as an accomplice"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/constrain> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/constrain> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/404>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/403> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/405>
     rdf:type    kgc:Statement ;
@@ -3875,7 +5516,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker will not run away at Lady Brackenstall"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notEscape> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notEscape> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/405>
+    rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/404> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/406>
     rdf:type    kgc:Statement ;
@@ -3883,8 +5526,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes only had to try Jack Crocker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/try> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity_of_Jack_Crocker> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/try> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/406>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity_of_Jack_Crocker> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/406>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/407> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/407>
     rdf:type    kgc:Statement ;
@@ -3892,8 +5539,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Holmes won't tell Stanley Hopkins the truth"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/407>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/407>
+    rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/408> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/408>
@@ -3901,9 +5552,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "ホームズはジャック・クロッカーの罪をワトソンに聞いた"@ja ;
     kgc:source  "Holmes asked Watson about Jack Crocker's crimes"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ask> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin_of_Jack_Crocker> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ask> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/408>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin_of_Jack_Crocker> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/408>
+    rdf:type    kgc:Situation ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/408>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/410> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/409>
     rdf:type    kgc:Statement ;
@@ -3918,7 +5575,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Watson said the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/410>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/409> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/411>
     rdf:type    kgc:Statement ;
@@ -3926,8 +5585,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker was acquitted"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sin> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/411>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sin> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/411>
+    rdf:type    kgc:Situation ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/412> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/412>
     rdf:type    kgc:Situation ;
@@ -3941,15 +5604,21 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Jack Crocker believes Holmes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/413>
+    rdf:type    kgc:Situation ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/413>
+    rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/414> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/414>
     rdf:type    kgc:Situation ;
     kgc:source  "法が他の犠牲者を見出さない"@ja ;
     kgc:source  "The law does not find the other victims"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotFind> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotFind> .
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/414>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/False_charge_person> .
 #Objectとして参照されているリソースの定義
 <http://kgc.knowledge-graph.jp/data/predicate/inform>
@@ -3961,9 +5630,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "酔う"@ja;
     rdfs:label     "drunk"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/January,_last_year>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "昨年1月"@ja;
-    rdfs:label     "January, last year"@en.
+    rdfs:label     "January, last year"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/notThink>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -3979,12 +5648,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "公式"@ja;
     rdfs:label     "official"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/looks_of_criminal>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "犯人の人相"@ja;
     rdfs:label     "looks of criminal"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/looks>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/criminal>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Two_of_glass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "二つのワイングラス"@ja;
     rdfs:label     "Two of glass"@en;
     rdf:type    kgc:OFobj;
@@ -4011,9 +5682,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Regret"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
     rdfs:label     "Holmes"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/predicate/scary_demon>
     rdf:type    kgc:Property;
     rdfs:label     "恐ろしい鬼"@ja;
@@ -4028,17 +5700,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Think"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Bottle_of_wine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ワインボトル"@ja;
     rdfs:label     "Bottle of wine"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Bottle>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/oak_chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "オークの椅子"@ja;
-    rdfs:label     "oak chair"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "oak chair"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Voyage_of_Lady_Brackenstall>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "レディー・ブラックンストールの船旅"@ja;
     rdfs:label     "Voyage of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -4049,9 +5721,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "住む"@ja;
     rdfs:label     "live"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Beard>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ひげ"@ja;
-    rdfs:label     "Beard"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Beard"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Fit>
     rdfs:label     "Fit"@en;
     rdf:type    kgc:Object.
@@ -4068,6 +5740,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Throat"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Restraint_of_Lady_Brackenstall_OR_killing_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの殺害 OR レディー・ブラックンストールの拘束"@ja;
     rdfs:label     "Restraint of Lady Brackenstall OR killing of Lady Brackenstall"@en;
     rdf:type    kgc:ORobj;
@@ -4089,9 +5762,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "remain"@en;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sin>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "罪"@ja;
-    rdfs:label     "sin"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "sin"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotMove>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -4100,9 +5773,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cannotMove"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pour>
     rdf:type    kgc:Action;
-    rdfs:label     "浴びせる"@ja;
+    rdfs:label     "注ぐ"@ja;
     rdfs:label     "pour"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_of_wine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ワインボトル"@ja;
     rdfs:label     "bottle of wine"@en;
     rdf:type    kgc:OFobj;
@@ -4115,9 +5789,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "end"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Police>
+    rdf:type    kgc:Person;
     rdfs:label     "警察"@ja;
-    rdfs:label     "Police"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Police"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotSay>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -4125,6 +5799,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "言えない"@ja;
     rdfs:label     "cannotSay"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Charm_of_the_case>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件の魅力"@ja;
     rdfs:label     "Charm of the case"@en;
     rdf:type    kgc:OFobj;
@@ -4139,6 +5814,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "軽快な足取りである"@ja;
     rdfs:label     "nimble-footed"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/face_of_corpse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "死体の顔"@ja;
     rdfs:label     "face of corpse"@en;
     rdf:type    kgc:OFobj;
@@ -4148,9 +5824,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Sir Eustace brackenstall"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/door>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ドア"@ja;
-    rdfs:label     "door"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "door"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notFit>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4158,9 +5834,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "合わない"@ja;
     rdfs:label     "notFit"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/eight_maids>
+    rdf:type    kgc:Person;
     rdfs:label     "八人の召使"@ja;
-    rdfs:label     "eight maids"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "eight maids"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/baby>
     rdf:type    kgc:Property;
     rdfs:label     "赤ん坊"@ja;
@@ -4173,9 +5849,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "非公式"@ja;
     rdfs:label     "unofficial"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Armrest>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "肘掛"@ja;
-    rdfs:label     "Armrest"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Armrest"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Findings>
     rdfs:label     "Findings"@en;
     rdf:type    kgc:Object.
@@ -4187,15 +5863,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notKill"@en;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Recovery_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの回復"@ja;
     rdfs:label     "Recovery of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Recovery>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ワイン"@ja;
-    rdfs:label     "wine"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "wine"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/camouflage>
     rdf:type    kgc:Action;
     rdfs:label     "偽装する"@ja;
@@ -4204,29 +5881,30 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "looks"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/accomplice>
+    rdf:type    kgc:Person;
     rdfs:label     "共犯者"@ja;
-    rdfs:label     "accomplice"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "accomplice"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/details>
     rdfs:label     "details"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/third_glass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "三つ目のワイングラス"@ja;
-    rdfs:label     "third glass"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "third glass"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hold>
     rdf:type    kgc:Action;
     rdfs:label     "握る"@ja;
     rdfs:label     "hold"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Severe_injury>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ひどい怪我"@ja;
-    rdfs:label     "Severe injury"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Severe injury"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/appear>
     rdf:type    kgc:Action;
     rdfs:label     "現れる"@ja;
     rdfs:label     "appear"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/center_of_Abbey_Grange>
+    rdf:type    kgc:Place;
     rdfs:label     "中央の建物"@ja;
     rdfs:label     "center of Abbey Grange"@en;
     rdf:type    kgc:OFobj;
@@ -4236,13 +5914,21 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "関係ない"@ja;
     rdfs:label     "unrelated"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/記載内容が誰かの「発言」や「考え」の場合，「誰の発言/考えか」を記載する>
+    rdfs:label     "Loading..."@ja;
+    rdfs:label     "記載内容が誰かの「発言」や「考え」の場合，「誰の発言/考えか」を記載する"@en;
+    rdfs:label     "come close"@ja;
+    rdfs:label     "Holmes"@ja;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/As_of_squirrel>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "リスのように"@ja;
     rdfs:label     "As of squirrel"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/As>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/squirrel>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/End_of_cord_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの紐の切断面"@ja;
     rdfs:label     "End of cord of bell"@en;
     rdf:type    kgc:OFobj;
@@ -4266,21 +5952,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "40歳"@ja;
     rdfs:label     "40 years old"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/letter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙"@ja;
-    rdfs:label     "letter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "letter"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/tall>
     rdf:type    kgc:Property;
     rdfs:label     "背が高い"@ja;
     rdfs:label     "tall"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/London>
+    rdf:type    kgc:Place;
     rdfs:label     "ロンドン"@ja;
-    rdfs:label     "London"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "London"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/new_ship>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "新しい船"@ja;
-    rdfs:label     "new ship"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "new ship"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/close>
     rdf:type    kgc:Action;
     rdfs:label     "閉める"@ja;
@@ -4311,9 +5997,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "pond"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wooden_blanket>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブランケット"@ja;
-    rdfs:label     "Wooden blanket"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Wooden blanket"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotbeKept>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -4335,16 +6021,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Lewisham"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/mantelpiece>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "マントルピース"@ja;
-    rdfs:label     "mantelpiece"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "mantelpiece"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/amiable>
     rdf:type    kgc:Property;
     rdfs:label     "愛想がよい"@ja;
     rdfs:label     "amiable"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "殴る"@ja;
+    rdfs:label     "打つ"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notMarry>
     rdf:type    kgc:Action;
@@ -4354,22 +6040,24 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notMarry"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins>
     rdfs:label     "Stanley Hopkins"@en;
+    rdf:type    kgc:Person;
     rdfs:label     "スタンリィ・ホプキンス"@ja;
-    rdfs:label     "スタンリィ・ホプキンズ"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place;
+    rdfs:label     "スタンリィ・ホプキンズ"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/White_teeth>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "白い歯"@ja;
-    rdfs:label     "White teeth"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "White teeth"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/July>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "7月"@ja;
-    rdfs:label     "July"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Heavy_curved_poker>
-    rdfs:label     "曲がった重い火かき棒"@ja;
-    rdfs:label     "Heavy curved poker"@en;
+    rdfs:label     "July"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Heavy_curved_poker>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "曲がった重い火かき棒"@ja;
+    rdfs:label     "Heavy curved poker"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Findings_of_Holmes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホームズの知ること"@ja;
     rdfs:label     "Findings of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -4395,16 +6083,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "believe"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fill>
     rdf:type    kgc:Action;
-    rdfs:label     "埋めつくす"@ja;
+    rdfs:label     "満たす"@ja;
     rdfs:label     "fill"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/15_minutes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "15分"@ja;
-    rdfs:label     "15 minutes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "15 minutes"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Restraint>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "拘束"@ja;
-    rdfs:label     "Restraint"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Restraint"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notKnow>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4424,9 +6112,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "two-thirds"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Quickly>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "急いで"@ja;
-    rdfs:label     "Quickly"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Quickly"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Holmes>
     rdfs:label     "Thought of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -4444,10 +6132,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Wrist"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Appearance>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "外観"@ja;
-    rdfs:label     "Appearance"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Appearance"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottom_of_pond_of_garden>
+    rdf:type    kgc:Place;
     rdfs:label     "池の底"@ja;
     rdfs:label     "bottom of pond of garden"@en;
     rdf:type    kgc:OFobj;
@@ -4456,18 +6145,21 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/garden>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bracket>
+    rdf:type    kgc:Person;
     rdfs:label     "ブラケット"@ja;
     rdfs:label     "bracket"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa>
+    rdf:type    kgc:Person;
     rdfs:label     "テリーサ"@ja;
     rdfs:label     "Theresa"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1_year_ago>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "1年前"@ja;
-    rdfs:label     "1 year ago"@en.
+    rdfs:label     "1 year ago"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Face_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの顔"@ja;
     rdfs:label     "Face of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -4488,9 +6180,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "killing of Lady Brackenstall"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mouth_of_Lady_Brackenstall>
+    rdf:type    kgc:Person;
     rdfs:label     "レディー・ブラックンストールの口"@ja;
     rdfs:label     "Mouth of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mouth>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brutal_character>
@@ -4511,26 +6205,27 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "dregs"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mantelpiece>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "マントルピース"@ja;
-    rdfs:label     "Mantelpiece"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Mantelpiece"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "葉巻"@ja;
-    rdfs:label     "cigar"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cigar"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wakeUp>
     rdf:type    kgc:Action;
-    rdfs:label     "起きる"@ja;
+    rdfs:label     "起こす"@ja;
     rdfs:label     "wakeUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hide>
     rdf:type    kgc:Action;
     rdfs:label     "隠す"@ja;
     rdfs:label     "hide"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/home_port>
+    rdf:type    kgc:Place;
     rdfs:label     "母港"@ja;
-    rdfs:label     "home port"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "home port"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_top_floor_of_the_Abbey_Grange>
+    rdf:type    kgc:Place;
     rdfs:label     "建物の最上階"@ja;
     rdfs:label     "The top floor of the Abbey Grange"@en;
     rdf:type    kgc:OFobj;
@@ -4538,7 +6233,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/the_Abbey_Grange>.
 <http://kgc.knowledge-graph.jp/data/predicate/repeat>
     rdf:type    kgc:Action;
-    rdfs:label     "重ねる"@ja;
+    rdfs:label     "繰り返す"@ja;
     rdfs:label     "repeat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hate>
     rdf:type    kgc:Action;
@@ -4553,27 +6248,35 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "怒る"@ja;
     rdfs:label     "angry"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Point_A>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "箇所A"@ja;
-    rdfs:label     "Point A"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Point A"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wire>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "針金"@ja;
-    rdfs:label     "wire"@en;
+    rdfs:label     "wire"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/［複数行可］他のシーンとのつながりを，「シーンのID」＋「つながりの種類（下記から選択）」で記入>
+    rdfs:label     "very"@ja;
+    rdfs:label     "［複数行可］他のシーンとのつながりを，「シーンのID」＋「つながりの種類（下記から選択）」で記入"@en;
+    rdfs:label     "#VALUE!"@ja;
+    rdfs:label     "Holmes put a knee on the bracket"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/train>
+    rdf:type    kgc:place;
     rdfs:label     "電車"@ja;
     rdfs:label     "train"@en;
-    rdfs:label     "列車"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "列車"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/fear>
     rdf:type    kgc:Action;
     rdfs:label     "恐れる"@ja;
     rdfs:label     "fear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受け取る"@ja;
+    rdfs:label     "受ける"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_room_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの部屋の窓"@ja;
     rdfs:label     "window of room of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -4586,9 +6289,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "真実である"@ja;
     rdfs:label     "truth"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Scotland_Yard>
+    rdf:type    kgc:Place;
     rdfs:label     "スコットランドヤード"@ja;
-    rdfs:label     "Scotland Yard"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Scotland Yard"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room>
     rdfs:label     "dining room"@en;
     rdf:type    kgc:Object.
@@ -4597,9 +6300,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "気絶する"@ja;
     rdfs:label     "faint"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/crafty>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "悪賢い"@ja;
-    rdfs:label     "crafty"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "crafty"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notReach>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4607,9 +6310,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "届かない"@ja;
     rdfs:label     "notReach"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/June>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "6月"@ja;
-    rdfs:label     "June"@en.
+    rdfs:label     "June"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/takeOut>
     rdf:type    kgc:Action;
     rdfs:label     "取り出す"@ja;
@@ -4626,16 +6329,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "疑わしくない"@ja;
     rdfs:label     "notDoubtful"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Poker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "火かき棒"@ja;
-    rdfs:label     "Poker"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Poker"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cadaver>
     rdfs:label     "cadaver"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/put>
     rdf:type    kgc:Action;
     rdfs:label     "置く"@ja;
-    rdfs:label     "put"@en.
+    rdfs:label     "put"@en;
+    rdfs:label     "乗せる"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand>
     rdfs:label     "hand"@en;
     rdf:type    kgc:Object.
@@ -4643,10 +6347,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Mind"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/same>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "同じこと"@ja;
-    rdfs:label     "same"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "same"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottom_of_pond>
+    rdf:type    kgc:Place;
     rdfs:label     "池の底"@ja;
     rdfs:label     "bottom of pond"@en;
     rdf:type    kgc:OFobj;
@@ -4657,9 +6362,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "time"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/A_few_months>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "数ヵ月"@ja;
-    rdfs:label     "A few months"@en.
+    rdfs:label     "A few months"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/faithful>
     rdf:type    kgc:Property;
     rdfs:label     "正直"@ja;
@@ -4669,6 +6374,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "間違いである"@ja;
     rdfs:label     "wrong"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/end_of_cord_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの紐の端"@ja;
     rdfs:label     "end of cord of bell"@en;
     rdf:type    kgc:OFobj;
@@ -4691,23 +6397,23 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Move"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/All-purpose_knife>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "万能ナイフ"@ja;
-    rdfs:label     "All-purpose knife"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "All-purpose knife"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Speak>
     rdfs:label     "Speak"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Small_three_windows>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "小さい3つの窓"@ja;
-    rdfs:label     "Small three windows"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Small three windows"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/command>
     rdf:type    kgc:Action;
-    rdfs:label     "指揮を執る"@ja;
+    rdfs:label     "命令する"@ja;
     rdfs:label     "command"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考える"@ja;
+    rdfs:label     "考慮する"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/revive>
     rdf:type    kgc:Action;
@@ -4718,9 +6424,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "航海する"@ja;
     rdfs:label     "sail"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/scratch>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "傷"@ja;
-    rdfs:label     "scratch"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "scratch"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/ease>
     rdf:type    kgc:Action;
     rdfs:label     "楽になる"@ja;
@@ -4737,6 +6443,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "印象づける"@ja;
     rdfs:label     "impress"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Story_of_Sir_Eustace_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サー・ユースタス・ブラックンストールの話"@ja;
     rdfs:label     "Story of Sir Eustace Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -4747,20 +6454,22 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "駆け込む"@ja;
     rdfs:label     "rush"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sober>
-    rdf:type    kgc:AbstractTime;
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "しらふ"@ja;
     rdfs:label     "sober"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior_of_Jack_Crocker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの行動は"@ja;
     rdfs:label     "Behavior of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:Person;
     rdfs:label     "ジャック・クロッカーの行動"@ja;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Upper_limbs>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "上肢"@ja;
-    rdfs:label     "Upper limbs"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Upper limbs"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/rest>
     rdf:type    kgc:Action;
     rdfs:label     "休む"@ja;
@@ -4774,6 +6483,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "行く"@ja;
     rdfs:label     "go"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの紐"@ja;
     rdfs:label     "cord of bell"@en;
     rdf:type    kgc:OFobj;
@@ -4792,10 +6502,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "maids"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Many_rooms>
+    rdf:type    kgc:Place;
     rdfs:label     "多くの部屋"@ja;
-    rdfs:label     "Many rooms"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Many rooms"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/article_of_Burglary_team_of_Lewisham>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ルイシャムの夜盗団の記事"@ja;
     rdfs:label     "article of Burglary team of Lewisham"@en;
     rdf:type    kgc:OFobj;
@@ -4804,31 +6515,32 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lewisham>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Company_office>
+    rdf:type    kgc:Place;
     rdfs:label     "会社事務所"@ja;
-    rdfs:label     "Company office"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Company office"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knot>
     rdfs:label     "Knot"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell_of_kitchen>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "調理場のベル"@ja;
     rdfs:label     "bell of kitchen"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/kitchen>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/this_morning>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "今朝"@ja;
-    rdfs:label     "this morning"@en.
+    rdfs:label     "this morning"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dust>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ほこり"@ja;
     rdfs:label     "dust"@en;
-    rdfs:label     "ほこりの中"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ほこりの中"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/abuse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "悪口"@ja;
-    rdfs:label     "abuse"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "abuse"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Marriage>
     rdfs:label     "Marriage"@en;
     rdf:type    kgc:Object.
@@ -4837,10 +6549,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "手ごわい"@ja;
     rdfs:label     "formidable"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/oil>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "石油"@ja;
-    rdfs:label     "oil"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "oil"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blood_of_Sir_Eustace_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サー・ユースタス・ブラックンストールの血"@ja;
     rdfs:label     "Blood of Sir Eustace Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -4859,9 +6572,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "楽しむ"@ja;
     rdfs:label     "enjoy"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Deliberately>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "故意に"@ja;
-    rdfs:label     "Deliberately"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Deliberately"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/siblings>
     rdfs:label     "siblings"@en;
     rdf:type    kgc:Object.
@@ -4871,32 +6584,33 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lewisham>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mary>
+    rdf:type    kgc:Person;
     rdfs:label     "メアリー"@ja;
-    rdfs:label     "Mary"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Mary"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/exist>
     rdf:type    kgc:Action;
     rdfs:label     "存在する"@ja;
     rdfs:label     "exist"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wrong_London_way>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "偽りのロンドン方式"@ja;
-    rdfs:label     "Wrong London way"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Wrong London way"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Hesitation>
     rdfs:label     "Hesitation"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/French_windows>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "フランス窓"@ja;
-    rdfs:label     "French windows"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "French windows"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/All>
     rdfs:label     "All"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/use>
+    rdf:type    kgc:Person;
     rdfs:label     "使い"@ja;
-    rdfs:label     "use"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "use"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity_of_Jack_Crocker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの誠実さ"@ja;
     rdfs:label     "Sincerity of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
@@ -4907,12 +6621,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "鬼のようである"@ja;
     rdfs:label     "demon"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Marriage_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの結婚"@ja;
     rdfs:label     "Marriage of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Marriage>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Jack_Crocker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの証言"@ja;
     rdfs:label     "Testimony of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
@@ -4932,18 +6648,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Pin"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Two_people>
+    rdf:type    kgc:Person;
     rdfs:label     "二人"@ja;
     rdfs:label     "Two people"@en;
-    rdfs:label     "二人は"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "二人は"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dress>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ドレス"@ja;
-    rdfs:label     "dress"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "dress"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/life>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "命"@ja;
-    rdfs:label     "life"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "life"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Examine>
     rdfs:label     "Examine"@en;
     rdf:type    kgc:Object.
@@ -4952,9 +6668,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "二つの赤い点"@ja;
     rdfs:label     "Two red dots"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/stick>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ステッキ"@ja;
-    rdfs:label     "stick"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "stick"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/readAloud>
     rdf:type    kgc:Action;
     rdfs:label     "音読する"@ja;
@@ -4978,20 +6694,22 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "law"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sound_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの音"@ja;
     rdfs:label     "sound of bell"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sound>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall>
+    rdf:type    kgc:Person;
     rdfs:label     "サー・ユースタス・ブラックンストール"@ja;
-    rdfs:label     "Sir Eustace Brackenstall"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Sir Eustace Brackenstall"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/enter>
     rdf:type    kgc:Action;
     rdfs:label     "入る"@ja;
     rdfs:label     "enter"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Lady_Brackenstall>
+    rdf:type    kgc:Place;
     rdfs:label     "レディー・ブラックンストールの部屋"@ja;
     rdfs:label     "room of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -4999,45 +6717,48 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holes_of_pond>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "池の穴"@ja;
     rdfs:label     "Holes of pond"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holes>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dregs_of_wine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ワインの澱"@ja;
     rdfs:label     "dregs of wine"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dregs>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Book>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "本"@ja;
-    rdfs:label     "Book"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Book"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/keep>
     rdf:type    kgc:Action;
-    rdfs:label     "飼っている"@ja;
+    rdfs:label     "維持する"@ja;
     rdfs:label     "keep"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/report>
     rdf:type    kgc:Action;
     rdfs:label     "報告する"@ja;
     rdfs:label     "report"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/warrant>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "令状"@ja;
-    rdfs:label     "warrant"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "warrant"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/alcoholism>
     rdf:type    kgc:Property;
     rdfs:label     "アルコール中毒"@ja;
     rdfs:label     "alcoholism"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fireplace>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "暖炉"@ja;
-    rdfs:label     "fireplace"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "fireplace"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Screams_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの叫び声"@ja;
     rdfs:label     "Screams of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -5051,14 +6772,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Voyage"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sydenham>
+    rdf:type    kgc:Place;
     rdfs:label     "シドナム"@ja;
-    rdfs:label     "Sydenham"@en;
+    rdfs:label     "Sydenham"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/［必須・１行のみ］下記のフォームに入力した内容を「簡単な文」で表現する．>
+    rdfs:label     "#VALUE!"@ja;
+    rdfs:label     "［必須・１行のみ］下記のフォームに入力した内容を「簡単な文」で表現する．"@en;
+    rdfs:label     "Holmes"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/Beefy_man>
     rdf:type    kgc:Property;
     rdfs:label     "がっしりした男"@ja;
     rdfs:label     "Beefy man"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/seat_of_oak_chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "オークの椅子の座部"@ja;
     rdfs:label     "seat of oak chair"@en;
     rdf:type    kgc:OFobj;
@@ -5071,33 +6798,34 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Behavior"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/annex>
+    rdf:type    kgc:Place;
     rdfs:label     "別棟"@ja;
-    rdfs:label     "annex"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "annex"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/innocent>
     rdf:type    kgc:Property;
     rdfs:label     "無罪である"@ja;
     rdfs:label     "innocent"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sideboard>
+    rdf:type    kgc:Place;
     rdfs:label     "サイドボード"@ja;
     rdfs:label     "Sideboard"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/three_people>
+    rdf:type    kgc:Person;
     rdfs:label     "3人"@ja;
-    rdfs:label     "three people"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "three people"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/help>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "助力"@ja;
-    rdfs:label     "help"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "help"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_opener>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "栓抜き"@ja;
-    rdfs:label     "bottle opener"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bottle opener"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/alarm>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "警報"@ja;
-    rdfs:label     "alarm"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "alarm"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/constrain>
     rdf:type    kgc:Action;
     rdfs:label     "拘束する"@ja;
@@ -5106,6 +6834,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the Abbey Grange"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/head_of_cadaver>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "頭の上"@ja;
     rdfs:label     "head of cadaver"@en;
     rdf:type    kgc:OFobj;
@@ -5118,9 +6847,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Charm"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/any_ship>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "どの船"@ja;
-    rdfs:label     "any ship"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "any ship"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/kitchen>
     rdfs:label     "kitchen"@en;
     rdf:type    kgc:Object.
@@ -5134,9 +6863,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Arm"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Rock-of-Gibraltar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロック・オブ・ジブラルタル"@ja;
-    rdfs:label     "Rock-of-Gibraltar"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Rock-of-Gibraltar"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/the_wine>
     rdfs:label     "the wine"@en;
     rdf:type    kgc:Object.
@@ -5145,6 +6874,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ヴィンテージワイン"@ja;
     rdfs:label     "Vintage wine"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Success_of_work>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "仕事の成功"@ja;
     rdfs:label     "Success of work"@en;
     rdf:type    kgc:OFobj;
@@ -5155,17 +6885,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "推定する"@ja;
     rdfs:label     "estimate"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/complaint>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "不平"@ja;
-    rdfs:label     "complaint"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "complaint"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "要求する"@ja;
+    rdfs:label     "依頼する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window>
+    rdf:type    kgc:Place;
     rdfs:label     "窓"@ja;
-    rdfs:label     "window"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "window"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/ask>
     rdf:type    kgc:Action;
     rdfs:label     "尋ねる"@ja;
@@ -5185,9 +6915,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "article"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/like_mask>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "仮面のように"@ja;
-    rdfs:label     "like mask"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "like mask"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought>
     rdfs:label     "Thought"@en;
     rdf:type    kgc:Object.
@@ -5196,24 +6926,25 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "半死半生の状態である"@ja;
     rdfs:label     "half alive state"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/trace>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "痕跡"@ja;
-    rdfs:label     "trace"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "trace"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Contact>
     rdfs:label     "Contact"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Unknown_things>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "未知のこと"@ja;
-    rdfs:label     "Unknown things"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Unknown things"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/one>
     rdfs:label     "one"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/criminal>
+    rdf:type    kgc:Person;
     rdfs:label     "犯人"@ja;
-    rdfs:label     "criminal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "criminal"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dog_of_Lady_Brackenstall>
+    rdf:type    kgc:Animal;
     rdfs:label     "レディー・ブラックンストールの犬"@ja;
     rdfs:label     "dog of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -5223,9 +6954,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Escape"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Criminal>
+    rdf:type    kgc:Person;
     rdfs:label     "犯人"@ja;
     rdfs:label     "Criminal"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/predicate/cut>
     rdf:type    kgc:Action;
     rdfs:label     "切る"@ja;
@@ -5236,46 +6968,49 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brilliantly>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "見事に"@ja;
-    rdfs:label     "Brilliantly"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Brilliantly"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの証言"@ja;
     rdfs:label     "Testimony of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/first_time>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "初めて"@ja;
-    rdfs:label     "first time"@en.
+    rdfs:label     "first time"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/court>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "裁判所"@ja;
-    rdfs:label     "court"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "court"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/both_hands>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "両手"@ja;
-    rdfs:label     "both hands"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "both hands"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Hatred>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "憎悪"@ja;
-    rdfs:label     "Hatred"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Hatred"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件"@ja;
     rdfs:label     "case"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Recovery>
     rdfs:label     "Recovery"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Oak_chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "オークの椅子"@ja;
-    rdfs:label     "Oak chair"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Oak chair"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
     rdfs:label     "会う"@ja;
-    rdfs:label     "meet"@en.
+    rdfs:label     "meet"@en;
+    rdfs:label     "出会う"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/smart>
     rdf:type    kgc:Property;
     rdfs:label     "利口である"@ja;
@@ -5285,60 +7020,64 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "普通の犯罪者"@ja;
     rdfs:label     "Ordinary criminal"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/11_00>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "11時過ぎ"@ja;
-    rdfs:label     "11:00"@en.
+    rdfs:label     "11:00"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/two>
     rdfs:label     "two"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mystery_of_the_case>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件の謎"@ja;
     rdfs:label     "Mystery of the case"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mystery>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/the_case>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/10_30>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "10時30分頃"@ja;
-    rdfs:label     "10:30"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/next_voyage>
-    rdfs:label     "次の航海"@ja;
-    rdfs:label     "next voyage"@en;
+    rdfs:label     "10:30"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/next_voyage>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "次の航海"@ja;
+    rdfs:label     "next voyage"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Three_of_glass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "三つのグラス"@ja;
     rdfs:label     "Three of glass"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Three>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/glass>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Telegram>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "電報"@ja;
-    rdfs:label     "Telegram"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Telegram"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/a_cup_of_wine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ワインを一杯"@ja;
     rdfs:label     "a cup of wine"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/a_cup>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin_of_Jack_Crocker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの罪"@ja;
     rdfs:label     "Sin of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/High_French_windows>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "フランス窓"@ja;
-    rdfs:label     "High French windows"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "High French windows"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/examine>
     rdf:type    kgc:Action;
     rdfs:label     "調べる"@ja;
     rdfs:label     "examine"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/substantial_property>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "相当な獲物"@ja;
-    rdfs:label     "substantial property"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "substantial property"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/testify>
     rdf:type    kgc:Action;
     rdfs:label     "証言する"@ja;
@@ -5354,9 +7093,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "残さない"@ja;
     rdfs:label     "notLeave"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sound>
+    rdf:type    kgc:Person;
     rdfs:label     "音"@ja;
-    rdfs:label     "sound"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "sound"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins>
     rdfs:label     "Stanley Hopkins"@en;
     rdf:type    kgc:Object.
@@ -5365,6 +7104,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "監禁する"@ja;
     rdfs:label     "beConfined"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brains_of_Sir_Eustace_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サー・ユースタス・ブラックンストールの脳みそ"@ja;
     rdfs:label     "Brains of Sir Eustace Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -5374,17 +7114,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Cut"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/favorite_man>
+    rdf:type    kgc:Person;
     rdfs:label     "好きな男"@ja;
-    rdfs:label     "favorite man"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "favorite man"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/end_of_case>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "事件の終わり"@ja;
     rdfs:label     "end of case"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/end>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Holmes>
+    rdf:type    kgc:Place;
     rdfs:label     "ホームズたちの部屋"@ja;
     rdfs:label     "room of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -5392,7 +7132,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes>.
 <http://kgc.knowledge-graph.jp/data/predicate/include>
     rdf:type    kgc:Action;
-    rdfs:label     "含んでいる"@ja;
+    rdfs:label     "である"@ja;
     rdfs:label     "include"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/clean>
     rdf:type    kgc:Property;
@@ -5405,13 +7145,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "気づく"@ja;
     rdfs:label     "notice"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Southampton>
+    rdf:type    kgc:Place;
     rdfs:label     "サザンプトン"@ja;
-    rdfs:label     "Southampton"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Southampton"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_Rock-Of-Gibraltar>
+    rdf:type    kgc:Place;
     rdfs:label     "ロック・オブ・ジブラルタル号"@ja;
-    rdfs:label     "The Rock-Of-Gibraltar"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "The Rock-Of-Gibraltar"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/beClear>
     rdf:type    kgc:Property;
     rdfs:label     "明らかになる"@ja;
@@ -5428,38 +7168,39 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "喜ぶ"@ja;
     rdfs:label     "bePleased"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Living_room>
+    rdf:type    kgc:Place;
     rdfs:label     "居間"@ja;
-    rdfs:label     "Living room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Living room"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/2_hours>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "2時間"@ja;
-    rdfs:label     "2 hours"@en.
+    rdfs:label     "2 hours"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/black_sequins>
     rdfs:label     "black sequins"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/12_00_yesterday>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "昨日の午後12時前"@ja;
-    rdfs:label     "12:00 yesterday"@en.
+    rdfs:label     "12:00 yesterday"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/notHappy>
     rdf:type    kgc:Property;
     rdfs:label     "幸せではない"@ja;
     rdfs:label     "notHappy"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_entire_room>
+    rdf:type    kgc:Place;
     rdfs:label     "部屋全体"@ja;
-    rdfs:label     "The entire room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "The entire room"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sound_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの音"@ja;
     rdfs:label     "Sound of bell"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sound>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/love>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "恋心"@ja;
-    rdfs:label     "love"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "love"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5468,22 +7209,22 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notExist"@en;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Private_decision>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "私的な判断"@ja;
-    rdfs:label     "Private decision"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Private decision"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/willReturn>
     rdf:type    kgc:Action;
     rdfs:label     "帰るつもりである"@ja;
     rdfs:label     "willReturn"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/blood>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "血の痕"@ja;
-    rdfs:label     "blood"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "blood"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sailor>
+    rdf:type    kgc:Person;
     rdfs:label     "船員たち"@ja;
     rdfs:label     "Sailor"@en;
-    rdfs:label     "船員"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "船員"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/let>
     rdf:type    kgc:Action;
     rdfs:label     "させる"@ja;
@@ -5503,27 +7244,28 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Bottle"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1897>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "1897年"@ja;
-    rdfs:label     "1897"@en.
+    rdfs:label     "1897"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Death_of_Sir_Eustace_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サー・ユースタス・ブラックンストールの死"@ja;
     rdfs:label     "Death of Sir Eustace Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Death>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/1895>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "1895年"@ja;
-    rdfs:label     "1895"@en.
+    rdfs:label     "1895"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Situation>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事情"@ja;
-    rdfs:label     "Situation"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Situation"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/property>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "財産"@ja;
-    rdfs:label     "property"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "property"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/unconscious>
     rdf:type    kgc:Property;
     rdfs:label     "気絶している"@ja;
@@ -5540,13 +7282,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つからない"@ja;
+    rdfs:label     "見つけられない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExamine>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/examine>;
-    rdfs:label     "あさらない"@ja;
+    rdfs:label     "調べない"@ja;
     rdfs:label     "notExamine"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/putOut>
     rdf:type    kgc:Action;
@@ -5557,13 +7299,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "結婚する"@ja;
     rdfs:label     "marry"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/3_inch>
+    rdf:type    kgc:Place;
     rdfs:label     "上から3インチのところ"@ja;
-    rdfs:label     "3 inch"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "3 inch"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/early_time>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "早い時間帯"@ja;
-    rdfs:label     "early time"@en.
+    rdfs:label     "early time"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Crocker>
     rdfs:label     "Thought of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
@@ -5574,35 +7316,34 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "すばらしい"@ja;
     rdfs:label     "wonderful"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fiction>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "作り話"@ja;
-    rdfs:label     "Fiction"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Fiction"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/powerful_men>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "力の強い男"@ja;
-    rdfs:label     "powerful men"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "powerful men"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Maid>
+    rdf:type    kgc:Person;
     rdfs:label     "召使"@ja;
-    rdfs:label     "Maid"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Maid"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Decanter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "デカンター"@ja;
-    rdfs:label     "Decanter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Decanter"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Heavy_blackthorn_stick>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "重いリンボクのステッキ"@ja;
-    rdfs:label     "Heavy blackthorn stick"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Heavy blackthorn stick"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/False_charge_person>
+    rdf:type    kgc:Person;
     rdfs:label     "冤罪者"@ja;
-    rdfs:label     "False charge person"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "False charge person"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pullDown>
     rdf:type    kgc:Action;
     rdfs:label     "引き下ろす"@ja;
     rdfs:label     "pullDown"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Winter_of_1897>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "1897年の冬"@ja;
     rdfs:label     "Winter of 1897"@en;
     rdf:type    kgc:OFobj;
@@ -5624,6 +7365,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "落とす"@ja;
     rdfs:label     "drop"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/scratch_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの傷"@ja;
     rdfs:label     "scratch of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -5634,6 +7376,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "味方である"@ja;
     rdfs:label     "ally"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Break_of_cord_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの紐の切れ目"@ja;
     rdfs:label     "Break of cord of bell"@en;
     rdf:type    kgc:OFobj;
@@ -5642,19 +7385,22 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Two_days_later>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "2日後"@ja;
-    rdfs:label     "Two days later"@en.
+    rdfs:label     "Two days later"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>
+    rdf:type    kgc:Person;
     rdfs:label     "レディー・ブラックンストール"@ja;
     rdfs:label     "Lady Brackenstall"@en;
-    rdfs:label     "レディーブラックンストール"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place;
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "レディーブラックンストール"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/barefoot>
     rdf:type    kgc:Property;
     rdfs:label     "裸足"@ja;
     rdfs:label     "barefoot"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/opposite_end_of_cord_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの紐の反対の端"@ja;
     rdfs:label     "opposite end of cord of bell"@en;
     rdf:type    kgc:OFobj;
@@ -5663,13 +7409,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/maid>
+    rdf:type    kgc:Person;
     rdfs:label     "召使"@ja;
-    rdfs:label     "maid"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "maid"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/blanket>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブランケット"@ja;
-    rdfs:label     "blanket"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "blanket"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notHide>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5677,9 +7423,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "隠さない"@ja;
     rdfs:label     "notHide"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/acrobat>
+    rdf:type    kgc:Person;
     rdfs:label     "軽業師"@ja;
-    rdfs:label     "acrobat"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "acrobat"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/garden_of_Abbey_Grange>
     rdfs:label     "garden of Abbey Grange"@en;
     rdf:type    kgc:OFobj;
@@ -5688,19 +7434,20 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson>
     rdfs:label     "Watson"@en;
     rdfs:label     "ワトソン"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dreg>
     rdfs:label     "dreg"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/original_fiction>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "独創的な話"@ja;
-    rdfs:label     "original fiction"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "original fiction"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Adelaide>
+    rdf:type    kgc:Place;
     rdfs:label     "アデレイド"@ja;
-    rdfs:label     "Adelaide"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Adelaide"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/All_of_maids>
+    rdf:type    kgc:Person;
     rdfs:label     "全ての召使"@ja;
     rdfs:label     "All of maids"@en;
     rdf:type    kgc:OFobj;
@@ -5723,6 +7470,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "知られる"@ja;
     rdfs:label     "beKnown"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_dining_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ダイニングルームの窓"@ja;
     rdfs:label     "window of dining room"@en;
     rdf:type    kgc:OFobj;
@@ -5742,21 +7490,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "救えない"@ja;
     rdfs:label     "cannotSave"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fairly>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "正々堂々"@ja;
-    rdfs:label     "fairly"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "fairly"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/contact>
     rdf:type    kgc:Action;
     rdfs:label     "連絡する"@ja;
     rdfs:label     "contact"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Head>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "頭"@ja;
-    rdfs:label     "Head"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Head"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/very_much>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "とても"@ja;
-    rdfs:label     "very much"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "very much"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mystery>
     rdfs:label     "Mystery"@en;
     rdf:type    kgc:Object.
@@ -5765,10 +7513,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "男らしい"@ja;
     rdfs:label     "manly"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/candle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ろうそく"@ja;
-    rdfs:label     "candle"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "candle"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_Dining_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ダイニングルームの窓"@ja;
     rdfs:label     "window of Dining room"@en;
     rdf:type    kgc:OFobj;
@@ -5782,7 +7531,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "not持つ"@ja;
+    rdfs:label     "持たない"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/callBack>
     rdf:type    kgc:Action;
@@ -5793,16 +7542,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "一等航海士"@ja;
     rdfs:label     "Chief officer"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_Bays_Rock>
+    rdf:type    kgc:Person;
     rdfs:label     "ベイス・ロック号"@ja;
     rdfs:label     "The Bays Rock"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/One_eye_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの片方の目"@ja;
     rdfs:label     "One eye of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/One_eye>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Lady_Blackenstall>
+    rdf:type    kgc:Place;
     rdfs:label     "レディー・ブラックンストールの部屋"@ja;
     rdfs:label     "room of Lady Blackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -5819,12 +7571,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ではない"@ja;
     rdfs:label     "notEqualTo"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/6_feet_3_inch>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "六フィート三インチ"@ja;
-    rdfs:label     "6 feet 3 inch"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "6 feet 3 inch"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "しようとする"@ja;
+    rdfs:label     "試みる"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/promise>
     rdf:type    kgc:Action;
@@ -5843,29 +7595,30 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "演ずる"@ja;
     rdfs:label     "perform"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>
+    rdf:type    kgc:Person;
     rdfs:label     "ジャック・クロッカー"@ja;
     rdfs:label     "Jack Crocker"@en;
     rdfs:label     "ジャック・クロッカ―"@ja;
-    rdfs:label     "レディー・ブラックンストール"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "レディー・ブラックンストール"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/goDown>
     rdf:type    kgc:Action;
-    rdfs:label     "降りる"@ja;
+    rdfs:label     "下りる"@ja;
     rdfs:label     "goDown"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/newspaper>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "新聞"@ja;
-    rdfs:label     "newspaper"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "newspaper"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Hesitation_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールのためらい"@ja;
     rdfs:label     "Hesitation of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Hesitation>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Title>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "肩書き"@ja;
-    rdfs:label     "Title"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Title"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/head>
     rdfs:label     "head"@en;
     rdf:type    kgc:Object.
@@ -5880,6 +7633,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "無鉄砲"@ja;
     rdfs:label     "Reckless"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Pin_of_hat>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "帽子のピン"@ja;
     rdfs:label     "Pin of hat"@en;
     rdf:type    kgc:OFobj;
@@ -5899,6 +7653,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "思う"@ja;
     rdfs:label     "think"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Burglary_team_of_Lewisham>
+    rdf:type    kgc:Person;
     rdfs:label     "ルイシャムの夜盗団"@ja;
     rdfs:label     "Burglary team of Lewisham"@en;
     rdf:type    kgc:OFobj;
@@ -5931,6 +7686,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "警戒する"@ja;
     rdfs:label     "warn"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Theresa>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "テリーサの証言"@ja;
     rdfs:label     "Testimony of Theresa"@en;
     rdf:type    kgc:OFobj;
@@ -5941,16 +7697,16 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着る"@ja;
+    rdfs:label     "着ている"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/conscience>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "良心"@ja;
-    rdfs:label     "conscience"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "conscience"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/as_found>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "発見したままに"@ja;
-    rdfs:label     "as found"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "as found"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fall>
     rdf:type    kgc:Action;
     rdfs:label     "倒れる"@ja;
@@ -5960,19 +7716,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "でっちあげる"@ja;
     rdfs:label     "hoax"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/danger_position>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "厄介な立場"@ja;
-    rdfs:label     "danger position"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "danger position"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/On_the_way_home>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "帰途"@ja;
-    rdfs:label     "On the way home"@en.
+    rdfs:label     "On the way home"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Lady_Brackenstall>
     rdfs:label     "room of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/scratch_of_Lady_Brackenstal>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの傷"@ja;
     rdfs:label     "scratch of Lady Brackenstal"@en;
     rdf:type    kgc:OFobj;
@@ -5982,20 +7739,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "garden"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/ship>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "船"@ja;
-    rdfs:label     "ship"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "ship"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Notice>
     rdfs:label     "Notice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/again>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "再び"@ja;
-    rdfs:label     "again"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "again"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dining_room>
+    rdf:type    kgc:Place;
     rdfs:label     "ダイニングルーム"@ja;
-    rdfs:label     "Dining room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dining room"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/love>
     rdf:type    kgc:Action;
     rdfs:label     "愛する"@ja;
@@ -6020,9 +7777,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "叫ぶ"@ja;
     rdfs:label     "shout"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/rotten_pumpkin>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "腐ったかぼちゃのように"@ja;
-    rdfs:label     "rotten pumpkin"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "rotten pumpkin"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/kill>
     rdf:type    kgc:Action;
     rdfs:label     "殺す"@ja;
@@ -6032,31 +7789,36 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "素敵である"@ja;
     rdfs:label     "nice"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/beard>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "あごひげ"@ja;
-    rdfs:label     "beard"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "beard"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/similarly>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "同様に"@ja;
-    rdfs:label     "similarly"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "similarly"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/getOff>
     rdf:type    kgc:Action;
-    rdfs:label     "飛び降りる"@ja;
+    rdfs:label     "下車する"@ja;
     rdfs:label     "getOff"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/［複数行可］下記から種類を選択の上「目的語」を記入>
+    rdfs:label     "Holmes approaches the bell string"@ja;
+    rdfs:label     "［複数行可］下記から種類を選択の上「目的語」を記入"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Arm_of_Sir_Eustace_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの腕"@ja;
     rdfs:label     "Arm of Sir Eustace Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Arm>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/knot>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "結び目"@ja;
-    rdfs:label     "knot"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "knot"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/knife>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ナイフ"@ja;
-    rdfs:label     "knife"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "knife"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottom>
     rdfs:label     "bottom"@en;
     rdf:type    kgc:Object.
@@ -6077,17 +7839,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Break"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Fist>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "こぶし"@ja;
-    rdfs:label     "Fist"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Fist"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/within_24_hours>
     rdfs:label     "24時間以内"@ja;
     rdfs:label     "within 24 hours"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/decanter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "デカンター"@ja;
-    rdfs:label     "decanter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "decanter"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/help>
     rdf:type    kgc:Action;
     rdfs:label     "助ける"@ja;
@@ -6101,17 +7863,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "information"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Rugs>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "敷物"@ja;
-    rdfs:label     "Rugs"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Rugs"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/worry>
     rdf:type    kgc:Action;
     rdfs:label     "悩む"@ja;
     rdfs:label     "worry"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/poker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "火かき棒"@ja;
-    rdfs:label     "poker"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "poker"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/distort>
     rdf:type    kgc:Action;
     rdfs:label     "歪ませる"@ja;
@@ -6124,26 +7886,26 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "船長"@ja;
     rdfs:label     "Captain"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/full>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "いっぱい"@ja;
-    rdfs:label     "full"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "full"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Cleverly>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "巧妙に"@ja;
-    rdfs:label     "Cleverly"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Cleverly"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Only_one_woman>
+    rdf:type    kgc:Person;
     rdfs:label     "ジャック・クロッカーのただ一人の女性"@ja;
-    rdfs:label     "Only one woman"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Only one woman"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_products>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "６枚の皿"@ja;
     rdfs:label     "Silver products"@en;
-    rdfs:label     "銀製品"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "銀製品"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/New_York>
+    rdf:type    kgc:Place;
     rdfs:label     "ニューヨーク"@ja;
-    rdfs:label     "New York"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "New York"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Watson>
     rdfs:label     "Thought of Watson"@en;
     rdf:type    kgc:OFobj;
@@ -6154,27 +7916,28 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "失う"@ja;
     rdfs:label     "lose"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Loose_gown>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ゆるいガウン"@ja;
-    rdfs:label     "Loose gown"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Loose gown"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/The_same_class>
     rdf:type    kgc:Property;
     rdfs:label     "同じ階級"@ja;
     rdfs:label     "The same class"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Silver_Products>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "銀製品"@ja;
-    rdfs:label     "Silver Products"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Silver Products"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Throat_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの喉"@ja;
     rdfs:label     "Throat of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Throat>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/face>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "顔"@ja;
-    rdfs:label     "face"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "face"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/derail>
     rdf:type    kgc:Action;
     rdfs:label     "頓挫する"@ja;
@@ -6184,24 +7947,24 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "来る"@ja;
     rdfs:label     "come"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blinding>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "目くらまし"@ja;
-    rdfs:label     "Blinding"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Blinding"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/voyage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "船旅"@ja;
-    rdfs:label     "voyage"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "voyage"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/work>
     rdf:type    kgc:Action;
-    rdfs:label     "働く"@ja;
+    rdfs:label     "仕事をする"@ja;
     rdfs:label     "work"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Kitchen>
+    rdf:type    kgc:Place;
     rdfs:label     "調理場"@ja;
-    rdfs:label     "Kitchen"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Kitchen"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pullOut>
     rdf:type    kgc:Action;
-    rdfs:label     "引きだす"@ja;
+    rdfs:label     "引き出す"@ja;
     rdfs:label     "pullOut"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/free>
     rdfs:label     "自由である"@ja;
@@ -6211,22 +7974,23 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Interest"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/short_term>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "短期間"@ja;
-    rdfs:label     "short term"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "short term"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/The_local_police>
+    rdf:type    kgc:Person;
     rdfs:label     "地元の警察"@ja;
-    rdfs:label     "The local police"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "The local police"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Old_man>
+    rdf:type    kgc:Person;
     rdfs:label     "年配の男"@ja;
     rdfs:label     "Old man"@en;
-    rdfs:label     "年輩の男"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "年輩の男"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality>
     rdfs:label     "Personality"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/siblings_of_Lady_Brackenstall>
+    rdf:type    kgc:Person;
     rdfs:label     "レディーブラックンストールの兄弟"@ja;
     rdfs:label     "siblings of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -6237,15 +8001,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "座る"@ja;
     rdfs:label     "sit"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand_of_Jack_Crocker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの手"@ja;
     rdfs:label     "hand of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Kent>
+    rdf:type    kgc:Place;
     rdfs:label     "ケント"@ja;
-    rdfs:label     "Kent"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Kent"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/self-defense>
     rdf:type    kgc:Property;
     rdfs:label     "正当防衛"@ja;
@@ -6257,10 +8022,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Dinner dress"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/clue>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手がかり"@ja;
-    rdfs:label     "clue"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "clue"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/abuse_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディーブラックンストールの悪口"@ja;
     rdfs:label     "abuse of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -6271,9 +8037,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "floor"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Train_crew>
+    rdf:type    kgc:Person;
     rdfs:label     "乗務員"@ja;
-    rdfs:label     "Train crew"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Train crew"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brains>
     rdfs:label     "Brains"@en;
     rdf:type    kgc:Object.
@@ -6282,6 +8048,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "眠っている"@ja;
     rdfs:label     "asleep"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dreg_of_two_of_glass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "２つのグラスの澱"@ja;
     rdfs:label     "dreg of two of glass"@en;
     rdf:type    kgc:OFobj;
@@ -6291,16 +8058,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/glass>.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "集中している"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
     rdfs:label     "聞く"@ja;
     rdfs:label     "hear"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hole>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "穴"@ja;
-    rdfs:label     "hole"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "hole"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Residents>
     rdfs:label     "Residents"@en;
     rdf:type    kgc:Object.
@@ -6314,9 +8081,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "したくない"@ja;
+    rdfs:label     "望まない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dining_room_of_Abbey_Grange>
+    rdf:type    kgc:Place;
     rdfs:label     "アビ屋敷のダイニングルーム"@ja;
     rdfs:label     "Dining room of Abbey Grange"@en;
     rdf:type    kgc:OFobj;
@@ -6337,6 +8105,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Sound"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mind_of_Holmes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ホームズの思い"@ja;
     rdfs:label     "Mind of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -6347,17 +8116,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "である"@ja;
     rdfs:label     "equalTo"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room>
+    rdf:type    kgc:Place;
     rdfs:label     "ダイニングルーム"@ja;
-    rdfs:label     "dining room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "dining room"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/become>
     rdf:type    kgc:Action;
     rdfs:label     "なる"@ja;
     rdfs:label     "become"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Comparable_Officer>
+    rdf:type    kgc:Person;
     rdfs:label     "匹敵する航海士"@ja;
-    rdfs:label     "Comparable Officer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Comparable Officer"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/drink>
     rdf:type    kgc:Action;
     rdfs:label     "飲む"@ja;
@@ -6378,6 +8147,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ごまかす"@ja;
     rdfs:label     "cheat"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Annex_of_Abbey_Grange>
+    rdf:type    kgc:Place;
     rdfs:label     "新館"@ja;
     rdfs:label     "Annex of Abbey Grange"@en;
     rdf:type    kgc:OFobj;
@@ -6396,6 +8166,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "刺す"@ja;
     rdfs:label     "stabble"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond_of_garden>
+    rdf:type    kgc:Place;
     rdfs:label     "池"@ja;
     rdfs:label     "pond of garden"@en;
     rdf:type    kgc:OFobj;
@@ -6405,17 +8176,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "bell"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_brackenstall>
+    rdf:type    kgc:Person;
     rdfs:label     "サー・ユースタス・ブラックンストール"@ja;
-    rdfs:label     "Sir Eustace brackenstall"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Sir Eustace brackenstall"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/gangUp>
     rdf:type    kgc:Action;
     rdfs:label     "結託する"@ja;
     rdfs:label     "gangUp"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/shock>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ショックで"@ja;
-    rdfs:label     "shock"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "shock"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/doubtful>
     rdf:type    kgc:Property;
     rdfs:label     "疑わしい"@ja;
@@ -6427,6 +8198,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "連絡しない"@ja;
     rdfs:label     "notContact"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality_of_Jack_Crocker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの性格"@ja;
     rdfs:label     "Personality of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
@@ -6437,9 +8209,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "朝早く"@ja;
     rdfs:label     "early morning"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wooden_products>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "木製品"@ja;
-    rdfs:label     "Wooden products"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Wooden products"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstal>
     rdfs:label     "Lady Brackenstal"@en;
     rdf:type    kgc:Object.
@@ -6455,10 +8227,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Annex"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/back>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "後ろ手で"@ja;
     rdfs:label     "back"@en;
-    rdfs:label     "仰向けに"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "仰向けに"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/collect>
     rdf:type    kgc:Action;
     rdfs:label     "集める"@ja;
@@ -6473,12 +8245,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "read"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Have>
     rdfs:label     "Have"@en;
-    rdfs:label     "持つ"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/repeatedly>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "繰り返し"@ja;
-    rdfs:label     "repeatedly"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "repeatedly"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Wonder>
     rdf:type    kgc:Action;
     rdfs:label     "怪しむ"@ja;
@@ -6496,9 +8267,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上る"@ja;
+    rdfs:label     "上がる"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Voice_of_the_people>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "民の声"@ja;
     rdfs:label     "Voice of the people"@en;
     rdf:type    kgc:OFobj;
@@ -6509,12 +8281,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "死ぬ"@ja;
     rdfs:label     "die"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Etiquette_of_UK>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "イギリスの礼儀作法"@ja;
     rdfs:label     "Etiquette of UK"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Etiquette>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/UK>.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/［必須・複数行可］「主語」を記入>
+    rdfs:label     "put"@ja;
+    rdfs:label     "［必須・複数行可］「主語」を記入"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Gate_of_garden>
+    rdf:type    kgc:Place;
     rdfs:label     "番小屋のある門"@ja;
     rdfs:label     "Gate of garden"@en;
     rdf:type    kgc:OFobj;
@@ -6542,17 +8320,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the people"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/sailor>
+    rdf:type    kgc:Person;
     rdfs:label     "船乗り"@ja;
-    rdfs:label     "sailor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "sailor"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/home>
+    rdf:type    kgc:Place;
     rdfs:label     "ホーム"@ja;
-    rdfs:label     "home"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "home"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/silver_products>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "盗まれた銀製品"@ja;
-    rdfs:label     "silver products"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "silver products"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room>
     rdfs:label     "room"@en;
     rdf:type    kgc:Object.
@@ -6565,10 +8343,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "崩れ落ちる"@ja;
     rdfs:label     "collapse"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/truth>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "真実"@ja;
     rdfs:label     "truth"@en;
-    rdfs:label     "事実"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "事実"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/notUnderstand>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -6591,9 +8369,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "The top floor"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/A_few_minutes>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "数分間"@ja;
-    rdfs:label     "A few minutes"@en.
+    rdfs:label     "A few minutes"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/approach>
     rdf:type    kgc:Action;
     rdfs:label     "近寄る"@ja;
@@ -6619,13 +8397,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "逃げない"@ja;
     rdfs:label     "notEscape"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Southampton_route>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザンプトン航路"@ja;
-    rdfs:label     "Southampton route"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Southampton route"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/side>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "横から"@ja;
-    rdfs:label     "side"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "side"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/God>
     rdfs:label     "God"@en;
     rdf:type    kgc:Object.
@@ -6634,6 +8412,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "不愛想"@ja;
     rdfs:label     "inhospitable"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Wrist_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの手首"@ja;
     rdfs:label     "Wrist of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -6641,23 +8420,25 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "立ち会う"@ja;
+    rdfs:label     "参加する"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pajama>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "寝巻き"@ja;
-    rdfs:label     "pajama"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "pajama"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/good_thing>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "本当に良いこと"@ja;
-    rdfs:label     "good thing"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "good thing"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Requirements_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの用件"@ja;
     rdfs:label     "Requirements of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Requirements>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/one_eye_of_Lady_Brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "レディー・ブラックンストールの片方の目"@ja;
     rdfs:label     "one eye of Lady Brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -6668,9 +8449,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "驚くべき"@ja;
     rdfs:label     "beSurprising"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベル"@ja;
-    rdfs:label     "Bell"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/canMake>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanAction;
@@ -6678,20 +8459,22 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "作れる"@ja;
     rdfs:label     "canMake"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Gently>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "優しく"@ja;
-    rdfs:label     "Gently"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Gently"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/raise>
     rdf:type    kgc:Action;
     rdfs:label     "上げる"@ja;
     rdfs:label     "raise"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/details_of_case>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件の詳細"@ja;
     rdfs:label     "details of case"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/details>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knot_of_cord_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの紐の結び目"@ja;
     rdfs:label     "Knot of cord of bell"@en;
     rdf:type    kgc:OFobj;
@@ -6700,12 +8483,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cache>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "隠し場所"@ja;
-    rdfs:label     "cache"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cache"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "滞在する"@ja;
+    rdfs:label     "留まる"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sprinkle>
     rdf:type    kgc:Action;
@@ -6723,13 +8506,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Lady Brackenstall"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/2_weeks_ago>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "2週間前"@ja;
-    rdfs:label     "2 weeks ago"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Three_times>
-    rdfs:label     "三回"@ja;
-    rdfs:label     "Three times"@en;
+    rdfs:label     "2 weeks ago"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Three_times>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "三回"@ja;
+    rdfs:label     "Three times"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/instruct>
     rdf:type    kgc:Action;
     rdfs:label     "指示する"@ja;
@@ -6739,12 +8522,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "呼ぶ"@ja;
     rdfs:label     "call"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Findings_of_Stanley_Hopkins>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "スタンリィ・ホプキンスの知ること"@ja;
     rdfs:label     "Findings of Stanley Hopkins"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Findings>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Stanley_Hopkins>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room_of_Theresa>
+    rdf:type    kgc:Place;
     rdfs:label     "テリーサの部屋"@ja;
     rdfs:label     "room of Theresa"@en;
     rdf:type    kgc:OFobj;
@@ -6756,21 +8541,24 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/two>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/glass>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange>
+    rdf:type    kgc:Place;
     rdfs:label     "アビ屋敷"@ja;
-    rdfs:label     "Abbey Grange"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Abbey Grange"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Property;
     rdfs:label     "開く"@ja;
     rdfs:label     "open"@en;
-    rdf:type    kgc:Action.
+    rdf:type    kgc:Action;
+    rdfs:label     "開ける"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brutal_character_of_criminal>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "犯人の残忍な性格"@ja;
     rdfs:label     "Brutal character of criminal"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brutal_character>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/criminal>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pond_of_garden_of_Abbey_Grange>
+    rdf:type    kgc:Place;
     rdfs:label     "庭園の池"@ja;
     rdfs:label     "pond of garden of Abbey Grange"@en;
     rdf:type    kgc:OFobj;
@@ -6780,13 +8568,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/garden>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/appearance>
+    rdf:type    kgc:Person;
     rdfs:label     "姿"@ja;
-    rdfs:label     "appearance"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "appearance"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police>
+    rdf:type    kgc:Person;
     rdfs:label     "警察"@ja;
     rdfs:label     "police"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place.
 <http://kgc.knowledge-graph.jp/data/predicate/abnormal>
     rdf:type    kgc:Property;
     rdfs:label     "異常である"@ja;
@@ -6800,17 +8589,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "swell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/grab>
     rdf:type    kgc:Action;
-    rdfs:label     "つかむ"@ja;
+    rdfs:label     "掴む"@ja;
     rdfs:label     "grab"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Suez_Canal>
+    rdf:type    kgc:Place;
     rdfs:label     "スエズ運河の辺り"@ja;
-    rdfs:label     "Suez Canal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Suez Canal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/see>
     rdf:type    kgc:Action;
     rdfs:label     "見る"@ja;
     rdfs:label     "see"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/color_of_wine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ワインの色"@ja;
     rdfs:label     "color of wine"@en;
     rdf:type    kgc:OFobj;
@@ -6828,9 +8618,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "燃やす"@ja;
     rdfs:label     "fire"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Third_glass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "三つ目のグラス"@ja;
-    rdfs:label     "Third glass"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Third glass"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Want>
     rdfs:label     "Want"@en;
     rdf:type    kgc:Object.
@@ -6838,6 +8628,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Blood"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/one_of_glass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ひとつのグラス"@ja;
     rdfs:label     "one of glass"@en;
     rdf:type    kgc:OFobj;
@@ -6847,6 +8638,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "center"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Both_ends_of_cord_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ベルの紐の両端"@ja;
     rdfs:label     "Both ends of cord of bell"@en;
     rdf:type    kgc:OFobj;
@@ -6855,28 +8647,32 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bell>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/swan>
+    rdf:type    kgc:Animal;
     rdfs:label     "白鳥"@ja;
-    rdfs:label     "swan"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "swan"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Residents_of_Abbey_Grange>
+    rdf:type    kgc:Person;
     rdfs:label     "アビ屋敷の住人"@ja;
     rdfs:label     "Residents of Abbey Grange"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Residents>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Abbey_Grange>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dinner_dress_of_black_sequins>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "黒のスパンコールのディナードレス"@ja;
     rdfs:label     "Dinner dress of black sequins"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dinner_dress>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/black_sequins>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/two-thirds_of_the_wine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "3分の2のワイン"@ja;
     rdfs:label     "two-thirds of the wine"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/two-thirds>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/the_wine>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Interest_of_case>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件の関心"@ja;
     rdfs:label     "Interest of case"@en;
     rdf:type    kgc:OFobj;
@@ -6884,9 +8680,10 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case>.
 <http://kgc.knowledge-graph.jp/data/predicate/fight>
     rdf:type    kgc:Action;
-    rdfs:label     "格闘する"@ja;
+    rdfs:label     "戦う"@ja;
     rdfs:label     "fight"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Death_of_Sir_Eustace_brackenstall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サー・ユースタス・ブラックンストールの死"@ja;
     rdfs:label     "Death of Sir Eustace brackenstall"@en;
     rdf:type    kgc:OFobj;
@@ -6907,9 +8704,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Success"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/corpse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "死体"@ja;
-    rdfs:label     "corpse"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "corpse"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/question>
     rdf:type    kgc:Action;
     rdfs:label     "質問する"@ja;
@@ -6919,17 +8716,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "むき出す"@ja;
     rdfs:label     "expose"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Up>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "上"@ja;
-    rdfs:label     "Up"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Up"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/second_glass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "二つ目のグラスを"@ja;
-    rdfs:label     "second glass"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "second glass"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/fiction>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "カモフラージュ"@ja;
-    rdfs:label     "fiction"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "fiction"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony>
     rdfs:label     "Testimony"@en;
     rdf:type    kgc:Object.
@@ -6937,24 +8734,26 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Hear"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Knee>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ひざ"@ja;
-    rdfs:label     "Knee"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Knee"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_table>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ダイニングテーブル"@ja;
-    rdfs:label     "dining table"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "dining table"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sufficient>
     rdf:type    kgc:Property;
     rdfs:label     "十分"@ja;
     rdfs:label     "sufficient"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career_of_Jack_Crocker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジャック・クロッカーの経歴"@ja;
     rdfs:label     "Career of Jack Crocker"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/law_of_England>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "イングランドの法"@ja;
     rdfs:label     "law of England"@en;
     rdf:type    kgc:OFobj;
@@ -6976,9 +8775,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "凍る"@ja;
     rdfs:label     "freeze"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/everyone>
+    rdf:type    kgc:Person;
     rdfs:label     "皆"@ja;
-    rdfs:label     "everyone"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "everyone"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Reach>
     rdfs:label     "Reach"@en;
     rdf:type    kgc:Object.
@@ -6986,18 +8785,19 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "ほつれている"@ja;
     rdfs:label     "fray"@en;
-    rdf:type    kgc:Action.
+    rdf:type    kgc:Action;
+    rdfs:label     "ほつれさせる"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/fix>
     rdf:type    kgc:Action;
     rdfs:label     "固定する"@ja;
     rdfs:label     "fix"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/later_date>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "後日"@ja;
-    rdfs:label     "later date"@en.
+    rdfs:label     "later date"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Voice>
     rdfs:label     "Voice"@en;
@@ -7013,10 +8813,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "否定する"@ja;
     rdfs:label     "deny"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/several_times>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "何回か"@ja;
-    rdfs:label     "several times"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "several times"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cork_of_bottle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "瓶のコルク"@ja;
     rdfs:label     "cork of bottle"@en;
     rdf:type    kgc:OFobj;

--- a/CrookedMan.ttl
+++ b/CrookedMan.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/CrookedMan/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -1676,7 +1676,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Morrison> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/_Nancy__> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy_> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/184>
     rdf:type    kgc:Statement ;
     kgc:source  "ナンシィは真っ青だった"@ja ;
@@ -2933,7 +2933,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sell> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/rebels> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/rebels> .
+<http://kgc.knowledge-graph.jp/data/CrookedMan/317>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1857-07-09> ;
     kgc:time  "1857-07-09T00:00:00"^^xsd:dateTime ;
@@ -3390,6 +3392,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "誓う"@ja;
     rdfs:label     "swear"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/face_of_Henry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘンリの顔"@ja;
     rdfs:label     "face of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -3400,10 +3403,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "しなやかである"@ja;
     rdfs:label     "supple"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/St._George_union>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "聖ジョージ組合の設立"@ja;
-    rdfs:label     "St. George union"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "St. George union"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/motive_of_killing_Berkeley>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "バークリ殺害の動機"@ja;
     rdfs:label     "motive of killing Berkeley"@en;
     rdf:type    kgc:OFobj;
@@ -3423,9 +3427,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "passionately"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/snake_killer>
+    rdf:type    kgc:Animal;
     rdfs:label     "ヘビトリ"@ja;
-    rdfs:label     "snake killer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "snake killer"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/old_friends>
     rdfs:label     "old friends"@en;
     rdf:type    kgc:Object.
@@ -3438,6 +3442,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "住む"@ja;
     rdfs:label     "live"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/witness_of_Henry>
+    rdf:type    kgc:Person;
     rdfs:label     "ヘンリの立会人"@ja;
     rdfs:label     "witness of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -3461,6 +3466,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "毎晩"@ja;
     rdfs:label     "every night"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/name_of_house_of_Berkeley>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "バークリの家の名前"@ja;
     rdfs:label     "name of house of Berkeley"@en;
     rdf:type    kgc:OFobj;
@@ -3469,16 +3475,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/house>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/lodge>
+    rdf:type    kgc:Place;
     rdfs:label     "下宿"@ja;
-    rdfs:label     "lodge"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "lodge"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Royal_Mallows>
     rdfs:label     "Royal Mallows"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/apoplexia>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "卒中"@ja;
-    rdfs:label     "apoplexia"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "apoplexia"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/canGetAhead>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanAction;
@@ -3493,19 +3499,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the St. George union"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/beast>
+    rdf:type    kgc:Animal;
     rdfs:label     "獣"@ja;
     rdfs:label     "beast"@en;
-    rdfs:label     "小動物"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "小動物"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "徘徊する"@ja;
+    rdfs:label     "歩き回る"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
-    rdfs:label     "Holmes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Holmes"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/barrack_of_India>
+    rdf:type    kgc:Place;
     rdfs:label     "インドの兵営"@ja;
     rdfs:label     "barrack of India"@en;
     rdf:type    kgc:OFobj;
@@ -3524,23 +3531,24 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "習慣ではない"@ja;
     rdfs:label     "unusual"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/first_battalion_of_Royal_MAllows>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロイヤル・マロウズ第一大隊"@ja;
     rdfs:label     "first battalion of Royal MAllows"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/first_battalion>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Royal_MAllows>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/outside>
+    rdf:type    kgc:Place;
     rdfs:label     "外と"@ja;
     rdfs:label     "outside"@en;
-    rdfs:label     "外へ"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "外へ"@ja.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/marten>
     rdfs:label     "marten"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Hudson_Street>
+    rdf:type    kgc:Place;
     rdfs:label     "ハドソン街"@ja;
-    rdfs:label     "Hudson Street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Hudson Street"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Marry>
     rdfs:label     "Marry"@en;
     rdf:type    kgc:Object.
@@ -3563,10 +3571,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/stick>
     rdfs:label     "棍棒で"@ja;
     rdfs:label     "stick"@en;
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "棍棒"@ja;
     rdfs:label     "木彫りの棍棒"@ja;
-    rdfs:label     "杖"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "杖"@ja.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/many_days>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "何日間"@ja;
@@ -3580,23 +3588,24 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "会話をする"@ja;
     rdfs:label     "talk"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/preface_of_Samuel>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サムエル前書"@ja;
     rdfs:label     "preface of Samuel"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/preface>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Samuel>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy>
+    rdf:type    kgc:Person;
     rdfs:label     "ナンシィ"@ja;
-    rdfs:label     "Nancy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Nancy"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/handsome_man>
     rdf:type    kgc:Property;
     rdfs:label     "美男である"@ja;
     rdfs:label     "handsome man"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/long_torso>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "長い胴体"@ja;
-    rdfs:label     "long torso"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "long torso"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/catchUp>
     rdf:type    kgc:Action;
     rdfs:label     "追いつく"@ja;
@@ -3617,9 +3626,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "character"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/curtain>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓掛け"@ja;
-    rdfs:label     "curtain"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "curtain"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notLove>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -3637,7 +3646,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "殴る"@ja;
+    rdfs:label     "打つ"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/scare>
     rdf:type    kgc:Action;
@@ -3654,6 +3663,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hair"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/key_of_living_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "居間の部屋の鍵"@ja;
     rdfs:label     "key of living room"@en;
     rdf:type    kgc:OFobj;
@@ -3661,9 +3671,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/key>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/David>
+    rdf:type    kgc:Person;
     rdfs:label     "デイヴィド"@ja;
-    rdfs:label     "David"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "David"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wait>
     rdf:type    kgc:Action;
     rdfs:label     "待つ"@ja;
@@ -3681,9 +3691,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "自殺する"@ja;
     rdfs:label     "suicide"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/coward>
+    rdf:type    kgc:Person;
     rdfs:label     "卑怯者"@ja;
-    rdfs:label     "coward"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "coward"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notKnow>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -3710,18 +3720,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "21:25"@ja;
     rdfs:label     "21:25"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/sin_of_Davide>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "デイヴィドの罪"@ja;
     rdfs:label     "sin of Davide"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/sin>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Davide>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/bedroom>
+    rdf:type    kgc:Place;
     rdfs:label     "寝室"@ja;
-    rdfs:label     "bedroom"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bedroom"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/turnOn>
     rdf:type    kgc:Action;
-    rdfs:label     "灯す"@ja;
+    rdfs:label     "点灯する"@ja;
     rdfs:label     "turnOn"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/boy_scout>
     rdf:type    kgc:Property;
@@ -3732,6 +3743,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "曲がっている"@ja;
     rdfs:label     "bent"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/eye_of_Henry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘンリの目"@ja;
     rdfs:label     "eye of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -3753,10 +3765,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "21:15"@ja;
     rdfs:label     "21:15"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/rebels>
+    rdf:type    kgc:Person;
     rdfs:label     "逆徒達"@ja;
     rdfs:label     "rebels"@en;
-    rdfs:label     "逆徒"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "逆徒"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/blame>
     rdf:type    kgc:Action;
     rdfs:label     "非難する"@ja;
@@ -3774,14 +3786,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "凶暴ではない"@ja;
     rdfs:label     "notViolent"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/money>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "お金"@ja;
-    rdfs:label     "money"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "money"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/superstition>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "迷信"@ja;
-    rdfs:label     "superstition"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "superstition"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/dwellers_of_mountain>
+    rdf:type    kgc:Person;
     rdfs:label     "山の民"@ja;
     rdfs:label     "dwellers of mountain"@en;
     rdf:type    kgc:OFobj;
@@ -3796,9 +3809,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "落ちぶれる"@ja;
     rdfs:label     "fallLow"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Waterloo>
+    rdf:type    kgc:Place;
     rdfs:label     "ウォータールー"@ja;
-    rdfs:label     "Waterloo"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Waterloo"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hope>
     rdf:type    kgc:Action;
     rdfs:label     "願う"@ja;
@@ -3810,16 +3823,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Hair"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Davide>
+    rdf:type    kgc:Person;
     rdfs:label     "デイヴィド"@ja;
-    rdfs:label     "Davide"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Davide"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hate>
     rdf:type    kgc:Action;
     rdfs:label     "嫌う"@ja;
     rdfs:label     "hate"@en.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/_Nancy__>
-    rdfs:label     "「ナンシィ」"@ja;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/angry>
     rdf:type    kgc:Property;
     rdfs:label     "怒る"@ja;
@@ -3827,7 +3837,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/bend>
     rdf:type    kgc:Action;
     rdfs:label     "曲げる"@ja;
-    rdfs:label     "bend"@en.
+    rdfs:label     "bend"@en;
+    rdfs:label     "曲がる"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/fear>
     rdf:type    kgc:Action;
     rdfs:label     "恐れる"@ja;
@@ -3837,6 +3848,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "囲む"@ja;
     rdfs:label     "surround"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/room_of_Henry>
+    rdf:type    kgc:Place;
     rdfs:label     "ヘンリの部屋"@ja;
     rdfs:label     "room of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -3855,15 +3867,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "blunt weapon"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/dwelleers_of_mountain>
+    rdf:type    kgc:Person;
     rdfs:label     "山の民"@ja;
     rdfs:label     "dwelleers of mountain"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/dwelleers>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/mountain>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/coachman>
+    rdf:type    kgc:Person;
     rdfs:label     "御者"@ja;
-    rdfs:label     "coachman"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "coachman"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/weasel_OR_marten>
     rdf:type    kgc:Property;
     rdfs:label     "鼬や貂"@ja;
@@ -3876,16 +3889,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "together"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/5_paws>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "5つの肉球"@ja;
-    rdfs:label     "5 paws"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "5 paws"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Argue>
     rdfs:label     "Argue"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/England>
+    rdf:type    kgc:Place;
     rdfs:label     "イングランド"@ja;
-    rdfs:label     "England"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "England"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/support>
     rdf:type    kgc:Action;
     rdfs:label     "支える"@ja;
@@ -3894,6 +3907,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "size"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/first_battalion_of_Royal_Mallows>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロイヤル・マロウズの第一大隊"@ja;
     rdfs:label     "first battalion of Royal Mallows"@en;
     rdf:type    kgc:OFobj;
@@ -3903,10 +3917,14 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "勇者"@ja;
     rdfs:label     "hero"@en.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/Simpson>
-    rdfs:label     "シンプソン"@ja;
-    rdfs:label     "Simpson"@en;
+<http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy_>
+    rdfs:label     "「ナンシィ」"@ja;
+    rdfs:label     "Nancy!"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/Simpson>
+    rdf:type    kgc:Person;
+    rdfs:label     "シンプソン"@ja;
+    rdfs:label     "Simpson"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/first>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "first"@ja;
@@ -3916,21 +3934,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "sunshade"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/シンプソン>
+    rdf:type    kgc:Person;
     rdfs:label     "シンプソン"@ja;
-    rdfs:label     "シンプソン"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "シンプソン"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/fireplace>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "暖炉"@ja;
-    rdfs:label     "fireplace"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "fireplace"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/stop>
     rdf:type    kgc:Action;
     rdfs:label     "止める"@ja;
     rdfs:label     "stop"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Morison>
+    rdf:type    kgc:Person;
     rdfs:label     "モリソン"@ja;
-    rdfs:label     "Morison"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Morison"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Teddy>
     rdf:type    kgc:Property;
     rdfs:label     "テディ"@ja;
@@ -3939,27 +3957,28 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Speak"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/15-inch_body>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "15インチの前足と後ろ足の間の長さ"@ja;
-    rdfs:label     "15-inch body"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "15-inch body"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/beSurrounded>
     rdf:type    kgc:Action;
     rdfs:label     "囲まれる"@ja;
     rdfs:label     "beSurrounded"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/hair_of_beast>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "獣の毛"@ja;
     rdfs:label     "hair of beast"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/hair>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/beast>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Hudson_street>
+    rdf:type    kgc:Place;
     rdfs:label     "ハドソン街"@ja;
-    rdfs:label     "Hudson street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Hudson street"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Nepal>
+    rdf:type    kgc:Place;
     rdfs:label     "ネパール"@ja;
-    rdfs:label     "Nepal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Nepal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/keepAway>
     rdf:type    kgc:Action;
     rdfs:label     "離れる"@ja;
@@ -3968,13 +3987,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "incedent"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Teddy>
+    rdf:type    kgc:Animal;
     rdfs:label     "テディ"@ja;
-    rdfs:label     "Teddy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Teddy"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/help>
     rdfs:label     "助け"@ja;
     rdfs:label     "help"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/predicate/2_feet>
     rdf:type    kgc:Property;
     rdfs:label     "2フィート"@ja;
@@ -3988,15 +4007,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "稼ぐ"@ja;
     rdfs:label     "earn"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/secret_of_Henry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘンリの秘密"@ja;
     rdfs:label     "secret of Henry"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/secret>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/civilian>
+    rdf:type    kgc:Person;
     rdfs:label     "文民"@ja;
-    rdfs:label     "civilian"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "civilian"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notMeet>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4016,24 +4036,26 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "行く"@ja;
     rdfs:label     "go"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/weapon>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "武器"@ja;
-    rdfs:label     "weapon"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "weapon"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/weasel_OR_marten>
+    rdf:type    kgc:Animal;
     rdfs:label     "鼬や貂"@ja;
     rdfs:label     "weasel OR marten"@en;
     rdf:type    kgc:ORobj;
     kgc:orTarget    <http://kgc.knowledge-graph.jp/data/CrookedMan/weasel>;
     kgc:orTarget    <http://kgc.knowledge-graph.jp/data/CrookedMan/marten>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/performance>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "余興"@ja;
-    rdfs:label     "performance"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "performance"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/revenge>
     rdf:type    kgc:Action;
-    rdfs:label     "仇討ちをする"@ja;
+    rdfs:label     "やり返す"@ja;
     rdfs:label     "revenge"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/stride_of_beast>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "獣の歩幅"@ja;
     rdfs:label     "stride of beast"@en;
     rdf:type    kgc:OFobj;
@@ -4043,9 +4065,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "preface"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/tea>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "紅茶"@ja;
-    rdfs:label     "tea"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "tea"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/3_inches>
     rdf:type    kgc:Property;
     rdfs:label     "3インチ"@ja;
@@ -4055,12 +4077,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "分かれる"@ja;
     rdfs:label     "separate"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/door_of_living_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ドア"@ja;
     rdfs:label     "door of living room"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/door>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/lamp_of_living_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "居間の部屋のランプ"@ja;
     rdfs:label     "lamp of living room"@en;
     rdf:type    kgc:OFobj;
@@ -4071,9 +4095,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "幸福である"@ja;
     rdfs:label     "happy"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/cook>
+    rdf:type    kgc:Person;
     rdfs:label     "料理番"@ja;
-    rdfs:label     "cook"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cook"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/snake>
     rdf:type    kgc:Property;
     rdfs:label     "ヘビ"@ja;
@@ -4083,13 +4107,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "存在する"@ja;
     rdfs:label     "exist"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "椅子に"@ja;
-    rdfs:label     "chair"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "chair"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/garden>
+    rdf:type    kgc:Place;
     rdfs:label     "庭"@ja;
-    rdfs:label     "garden"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "garden"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy_AND_old_friends>
     rdfs:label     "Nancy AND old friends"@en;
     rdf:type    kgc:Object.
@@ -4101,10 +4125,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "行う"@ja;
     rdfs:label     "do"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Monday>
-    rdf:type    kgc:AbstractTime;
+    rdf:type    kgc:Person;
     rdfs:label     "月曜日"@ja;
-    rdfs:label     "Monday"@en.
+    rdfs:label     "Monday"@en;
+    rdf:type    kgc:AbstractTime.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/same_kind_of_sin>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "同じ種類の罪"@ja;
     rdfs:label     "same kind of sin"@en;
     rdf:type    kgc:OFobj;
@@ -4117,9 +4143,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Like"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Watts_Street_Church>
+    rdf:type    kgc:Place;
     rdfs:label     "ワット街の教会"@ja;
-    rdfs:label     "Watts Street Church"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watts Street Church"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/20_am_on_Monday>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "月曜日20時"@ja;
@@ -4132,15 +4158,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Contradict"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/criminal_of_incident>
+    rdf:type    kgc:Person;
     rdfs:label     "事件の犯人"@ja;
     rdfs:label     "criminal of incident"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/criminal>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/incident>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy>
+    rdf:type    kgc:Person;
     rdfs:label     "マーフィ"@ja;
-    rdfs:label     "Murphy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Murphy"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/run>
     rdf:type    kgc:Action;
     rdfs:label     "走る"@ja;
@@ -4157,7 +4184,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/daughter_of_ensign_sergeant>
     rdf:type    kgc:Property;
@@ -4168,9 +4195,10 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/ensign_sergeant>.
 <http://kgc.knowledge-graph.jp/data/predicate/overlook>
     rdf:type    kgc:Action;
-    rdfs:label     "見落としている"@ja;
+    rdfs:label     "見落とす"@ja;
     rdfs:label     "overlook"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/total_length_of_beast>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "獣の全長"@ja;
     rdfs:label     "total length of beast"@en;
     rdf:type    kgc:OFobj;
@@ -4184,6 +4212,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "first battalion"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/witness_of_Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズの立会人"@ja;
     rdfs:label     "witness of Holmes"@en;
     rdf:type    kgc:OFobj;
@@ -4211,15 +4240,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "イクヌーモン"@ja;
     rdfs:label     "ichneumon"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/progress_of_incedent>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件の進展"@ja;
     rdfs:label     "progress of incedent"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/progress>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/incedent>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Herny>
+    rdf:type    kgc:Person;
     rdfs:label     "ヘンリ"@ja;
-    rdfs:label     "Herny"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Herny"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotSpeak>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -4232,12 +4262,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "dead"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "要求する"@ja;
+    rdfs:label     "依頼する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/10000_rebels>
+    rdf:type    kgc:Person;
     rdfs:label     "一万人の凶暴な逆徒達"@ja;
-    rdfs:label     "10000 rebels"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "10000 rebels"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/ask>
     rdf:type    kgc:Action;
     rdfs:label     "尋ねる"@ja;
@@ -4247,6 +4277,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "駐留する"@ja;
     rdfs:label     "station"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/back_of_head_of_Berkeley>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "バークリの後頭部"@ja;
     rdfs:label     "back of head of Berkeley"@en;
     rdf:type    kgc:OFobj;
@@ -4258,7 +4289,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/like>;
-    rdfs:label     "嫌がる"@ja;
+    rdfs:label     "嫌いである"@ja;
     rdfs:label     "notLike"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/entertainer>
     rdf:type    kgc:Property;
@@ -4285,11 +4316,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "手品の時"@ja;
     rdfs:label     "magic"@en;
     rdfs:label     "手品で"@ja;
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手品"@ja.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/criminal>
+    rdf:type    kgc:Person;
     rdfs:label     "犯人"@ja;
-    rdfs:label     "criminal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "criminal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/GetAhead>
     rdfs:label     "GetAhead"@en;
     rdf:type    kgc:Object.
@@ -4306,16 +4338,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "震える"@ja;
     rdfs:label     "tremble"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/someone>
+    rdf:type    kgc:Person;
     rdfs:label     "誰か"@ja;
-    rdfs:label     "someone"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "someone"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Samuel>
     rdfs:label     "Samuel"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/1857-07-09>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "1857年7月9日"@ja;
-    rdfs:label     "1857-07-09"@en.
+    rdfs:label     "1857-07-09"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/survive>
     rdf:type    kgc:Action;
     rdfs:label     "生き延びる"@ja;
@@ -4325,9 +4357,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ついていく"@ja;
     rdfs:label     "keepUp"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/story>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "話"@ja;
-    rdfs:label     "story"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "story"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
     rdfs:label     "会う"@ja;
@@ -4348,6 +4380,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/one>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/the_Irish_regiments>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/character_of_Berkeley>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "バークリの性格"@ja;
     rdfs:label     "character of Berkeley"@en;
     rdf:type    kgc:OFobj;
@@ -4362,6 +4395,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "調べる"@ja;
     rdfs:label     "examine"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/foot_of_ermine>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "オコジョの足"@ja;
     rdfs:label     "foot of ermine"@en;
     rdf:type    kgc:OFobj;
@@ -4372,9 +4406,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "教養がある"@ja;
     rdfs:label     "well educated"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/resident>
+    rdf:type    kgc:Person;
     rdfs:label     "住人"@ja;
-    rdfs:label     "resident"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "resident"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/killing_Berkeley>
     rdfs:label     "killing Berkeley"@en;
     rdf:type    kgc:Object.
@@ -4387,10 +4421,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "接吻する"@ja;
     rdfs:label     "kiss"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/soldier>
+    rdf:type    kgc:Person;
     rdfs:label     "兵士"@ja;
     rdfs:label     "soldier"@en;
-    rdfs:label     "兵士たち"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "兵士たち"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/Go>
     rdfs:label     "Go"@en;
     rdf:type    kgc:Object.
@@ -4399,6 +4433,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "仲良し"@ja;
     rdfs:label     "good friends"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/owner_of_lodge>
+    rdf:type    kgc:Person;
     rdfs:label     "ハドソン街の下宿の大家の女"@ja;
     rdfs:label     "owner of lodge"@en;
     rdf:type    kgc:OFobj;
@@ -4406,9 +4441,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/owner>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/lodge>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/0.5_miles_from_the_northern_camp>
+    rdf:type    kgc:Place;
     rdfs:label     "北部キャンプから0.5マイル"@ja;
-    rdfs:label     "0.5 miles from the northern camp"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "0.5 miles from the northern camp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notice>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4425,25 +4460,26 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/former_sergeant>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/armies>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/bypath>
+    rdf:type    kgc:Place;
     rdfs:label     "抜け道"@ja;
     rdfs:label     "bypath"@en;
-    rdfs:label     "抜け道で"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "抜け道で"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/please>
     rdf:type    kgc:Action;
-    rdfs:label     "喜ぶ"@ja;
+    rdfs:label     "喜ばせる"@ja;
     rdfs:label     "please"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/nose_of_beast>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "獣の鼻"@ja;
     rdfs:label     "nose of beast"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/nose>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/beast>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/cobra>
+    rdf:type    kgc:Animal;
     rdfs:label     "コブラ"@ja;
     rdfs:label     "cobra"@en;
-    rdfs:label     "牙のないコブラ"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "牙のないコブラ"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/old_soldier>
     rdf:type    kgc:Property;
     rdfs:label     "老兵"@ja;
@@ -4459,7 +4495,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notContradict"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪れる"@ja;
+    rdfs:label     "訪ねる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -4468,9 +4504,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "存在しない"@ja;
     rdfs:label     "notExist"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Indian_rupee>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "インドのルピー"@ja;
-    rdfs:label     "Indian rupee"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Indian rupee"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/twice>
     rdfs:label     "2度"@ja;
     rdfs:label     "twice"@en;
@@ -4486,10 +4522,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "postscript"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/guest>
+    rdf:type    kgc:Person;
     rdfs:label     "客"@ja;
-    rdfs:label     "guest"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "guest"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/size_of_Garden>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "庭の広さ"@ja;
     rdfs:label     "size of Garden"@en;
     rdf:type    kgc:OFobj;
@@ -4504,6 +4541,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "丸める"@ja;
     rdfs:label     "round"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Indian_Rebellion>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "大反乱の活躍"@ja;
     rdfs:label     "Indian Rebellion"@en;
     rdf:type    kgc:AbstractTime;
@@ -4534,9 +4572,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "結婚する"@ja;
     rdfs:label     "marry"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/doctor>
+    rdf:type    kgc:Person;
     rdfs:label     "医者"@ja;
-    rdfs:label     "doctor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "doctor"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/show>
     rdf:type    kgc:Action;
     rdfs:label     "見せる"@ja;
@@ -4572,12 +4610,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "苦しむ"@ja;
     rdfs:label     "suffer"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/footprint_of_man>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "男の足跡"@ja;
     rdfs:label     "footprint of man"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/footprint>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/man>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/end_of_Darjeeling>
+    rdf:type    kgc:Place;
     rdfs:label     "ダージリンの先"@ja;
     rdfs:label     "end of Darjeeling"@en;
     rdf:type    kgc:OFobj;
@@ -4588,6 +4628,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "月曜日21時15分から"@ja;
     rdfs:label     "1887-07-06T21:15:00 ~"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/dining_room_of_lodge>
+    rdf:type    kgc:Place;
     rdfs:label     "兵士の食堂"@ja;
     rdfs:label     "dining room of lodge"@en;
     rdf:type    kgc:OFobj;
@@ -4605,6 +4646,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Respond"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/hair_of_Morrison>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "モリソンの髪"@ja;
     rdfs:label     "hair of Morrison"@en;
     rdf:type    kgc:OFobj;
@@ -4618,17 +4660,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "daughter"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/truth>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "真実"@ja;
-    rdfs:label     "truth"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "truth"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/beautiful>
     rdf:type    kgc:Property;
     rdfs:label     "美しい"@ja;
     rdfs:label     "beautiful"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/barrack>
+    rdf:type    kgc:Place;
     rdfs:label     "兵営"@ja;
-    rdfs:label     "barrack"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "barrack"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/monitor>
     rdf:type    kgc:Action;
     rdfs:label     "監視する"@ja;
@@ -4642,6 +4684,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "赤茶色"@ja;
     rdfs:label     "reddish brown"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/father_of_Nancy>
+    rdf:type    kgc:Person;
     rdfs:label     "ナンシィの父"@ja;
     rdfs:label     "father of Nancy"@en;
     rdf:type    kgc:OFobj;
@@ -4651,6 +4694,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Know"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Hair_of_Henry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘンリの髪"@ja;
     rdfs:label     "Hair of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -4661,12 +4705,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "連絡する"@ja;
     rdfs:label     "contact"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/episode_of_Uriah_and_Bathsheba>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ウリヤとバト・シェバの挿話"@ja;
     rdfs:label     "episode of Uriah and Bathsheba"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/episode>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Uriah_and_Bathsheba>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/voice_of_Nancy>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ナンシィの声"@ja;
     rdfs:label     "voice of Nancy"@en;
     rdf:type    kgc:OFobj;
@@ -4676,25 +4722,26 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "not持つ"@ja;
+    rdfs:label     "持たない"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/violent>
     rdf:type    kgc:Property;
     rdfs:label     "凶暴である"@ja;
     rdfs:label     "violent"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/2-inch_tear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "2インチの裂傷"@ja;
-    rdfs:label     "2-inch tear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "2-inch tear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "しようとする"@ja;
+    rdfs:label     "試みる"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/atonement>
     rdfs:label     "贖罪のため"@ja;
     rdfs:label     "atonement"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Berkeley>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "頭を"@ja;
     rdfs:label     "head of Berkeley"@en;
     rdf:type    kgc:OFobj;
@@ -4705,14 +4752,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "雄々しい性格となよなよした性格"@ja;
     rdfs:label     "heroic personallity"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/iron_fence>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鉄柵"@ja;
-    rdfs:label     "iron fence"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "iron fence"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/use>
     rdf:type    kgc:Action;
     rdfs:label     "使う"@ja;
     rdfs:label     "use"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/slave_of_dwellers_of_mountain>
+    rdf:type    kgc:Person;
     rdfs:label     "山の民の奴隷"@ja;
     rdfs:label     "slave of dwellers of mountain"@en;
     rdf:type    kgc:OFobj;
@@ -4721,6 +4769,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/dwellers>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/mountain>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/house_of_Henry>
+    rdf:type    kgc:Place;
     rdfs:label     "ヘンリの家"@ja;
     rdfs:label     "house of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -4750,13 +4799,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/house>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/common_sense>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "常識"@ja;
-    rdfs:label     "common sense"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "common sense"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Old_Testament>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "旧約聖書"@ja;
-    rdfs:label     "Old Testament"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Old Testament"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/important_event>
     rdfs:label     "important event"@en;
     rdf:type    kgc:Object.
@@ -4785,6 +4834,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "逮捕する"@ja;
     rdfs:label     "arrest"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/body_of_Henry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘンリの身体"@ja;
     rdfs:label     "body of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -4804,12 +4854,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/reveal>
     rdf:type    kgc:Action;
-    rdfs:label     "明かす"@ja;
+    rdfs:label     "明らかにする"@ja;
     rdfs:label     "reveal"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/mongoose>
+    rdf:type    kgc:Animal;
     rdfs:label     "マングース"@ja;
-    rdfs:label     "mongoose"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "mongoose"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/head>
     rdfs:label     "head"@en;
     rdf:type    kgc:Object.
@@ -4824,9 +4874,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fall"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/locked>
     rdf:type    kgc:Property;
-    rdfs:label     "施錠される"@ja;
+    rdfs:label     "施錠されている"@ja;
     rdfs:label     "locked"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/knee_of_Henry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "膝"@ja;
     rdfs:label     "knee of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -4836,14 +4887,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "lamp"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/police>
+    rdf:type    kgc:Person;
     rdfs:label     "警察"@ja;
-    rdfs:label     "police"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "police"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/box>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "箱"@ja;
     rdfs:label     "box"@en;
-    rdfs:label     "箱で"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "箱で"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/putInto>
     rdf:type    kgc:Action;
     rdfs:label     "入れる"@ja;
@@ -4859,12 +4910,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "中年夫婦の理想像"@ja;
     rdfs:label     "ideal of middle-aged couple"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/ideal>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/middle-aged_couple>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/slave>
     rdfs:label     "slave"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/meeting_of_the_St._George_union>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "聖ジョージ組合の会合"@ja;
     rdfs:label     "meeting of the St. George union"@en;
     rdf:type    kgc:OFobj;
@@ -4896,15 +4949,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/wall>
     rdfs:label     "塀"@ja;
     rdfs:label     "wall"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/On_Thursday_at_11_10>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "木曜日11時10分"@ja;
-    rdfs:label     "On Thursday at 11:10"@en.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/cage>
-    rdfs:label     "檻"@ja;
-    rdfs:label     "cage"@en;
+    rdfs:label     "On Thursday at 11:10"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/cage>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "檻"@ja;
+    rdfs:label     "cage"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/shout>
     rdf:type    kgc:Action;
     rdfs:label     "叫ぶ"@ja;
@@ -4915,21 +4968,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "kill"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/lead>
     rdf:type    kgc:Action;
-    rdfs:label     "率いる"@ja;
+    rdfs:label     "導く"@ja;
     rdfs:label     "lead"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Watson>
+    rdf:type    kgc:Person;
     rdfs:label     "ワトソン"@ja;
-    rdfs:label     "Watson"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watson"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/main_street>
+    rdf:type    kgc:Place;
     rdfs:label     "大通り"@ja;
     rdfs:label     "main street"@en;
-    rdfs:label     "大通りから"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "大通りから"@ja.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/solider>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "一兵卒"@ja;
-    rdfs:label     "solider"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "solider"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/not_bad_mood>
     rdf:type    kgc:Property;
     rdfs:label     "不機嫌ではない"@ja;
@@ -4939,9 +4992,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "昔なじみである"@ja;
     rdfs:label     "old friend"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Baker_Street>
+    rdf:type    kgc:Place;
     rdfs:label     "ベイカー街"@ja;
-    rdfs:label     "Baker Street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Baker Street"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sell>
     rdf:type    kgc:Action;
     rdfs:label     "売る"@ja;
@@ -4972,9 +5025,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "借りる"@ja;
     rdfs:label     "rent"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/senior_rank>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "将校階級"@ja;
-    rdfs:label     "senior rank"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "senior rank"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/friendly>
     rdfs:label     "仲良く"@ja;
     rdfs:label     "friendly"@en;
@@ -5019,6 +5072,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "木曜日"@ja;
     rdfs:label     "Thursday"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/footprint_of_beast>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "獣の足跡"@ja;
     rdfs:label     "footprint of beast"@en;
     rdf:type    kgc:OFobj;
@@ -5039,13 +5093,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "殺される"@ja;
     rdfs:label     "beKilled"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/child>
+    rdf:type    kgc:Person;
     rdfs:label     "子ども"@ja;
-    rdfs:label     "child"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "child"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/short_leg>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "短い足"@ja;
-    rdfs:label     "short leg"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "short leg"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotTakeAway>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -5061,43 +5115,44 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "抑える"@ja;
     rdfs:label     "suppress"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/main_stree>
+    rdf:type    kgc:Place;
     rdfs:label     "大通り"@ja;
-    rdfs:label     "main stree"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "main stree"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/teach>
     rdf:type    kgc:Action;
     rdfs:label     "教える"@ja;
     rdfs:label     "teach"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/whole_body>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "全身"@ja;
-    rdfs:label     "whole body"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "whole body"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/room_of_Nancy>
+    rdf:type    kgc:Place;
     rdfs:label     "ナンシィの部屋"@ja;
     rdfs:label     "room of Nancy"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/room>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/man>
+    rdf:type    kgc:Person;
     rdfs:label     "男"@ja;
-    rdfs:label     "man"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "man"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/give>
     rdf:type    kgc:Action;
     rdfs:label     "与える"@ja;
     rdfs:label     "give"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Aldershot>
+    rdf:type    kgc:Place;
     rdfs:label     "オールダショット"@ja;
-    rdfs:label     "Aldershot"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Aldershot"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/anyone>
+    rdf:type    kgc:Person;
     rdfs:label     "誰にも"@ja;
-    rdfs:label     "anyone"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "anyone"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Jane>
+    rdf:type    kgc:Person;
     rdfs:label     "ジェイン"@ja;
-    rdfs:label     "Jane"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Jane"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/young_woman>
     rdf:type    kgc:Property;
     rdfs:label     "若い女性である"@ja;
@@ -5118,17 +5173,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Understand"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Royal_Mallows>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロイヤル・マロウズ"@ja;
     rdfs:label     "Royal Mallows"@en;
-    rdfs:label     "ロイヤル・マロウズの中"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ロイヤル・マロウズの中"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/armies>
     rdfs:label     "armies"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/wrinkle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "しわ"@ja;
-    rdfs:label     "wrinkle"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "wrinkle"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/eye>
     rdfs:label     "eye"@en;
     rdf:type    kgc:Object.
@@ -5137,10 +5192,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "関係する"@ja;
     rdfs:label     "relate"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry>
+    rdf:type    kgc:Person;
     rdfs:label     "ヘンリ"@ja;
     rdfs:label     "Henry"@en;
-    rdfs:label     "ヘンリの体"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ヘンリの体"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
     rdfs:label     "聞く"@ja;
@@ -5164,7 +5220,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "したくない"@ja;
+    rdfs:label     "望まない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/witness>
     rdfs:label     "witness"@en;
@@ -5173,9 +5229,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ensign sergeant"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/incident>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件"@ja;
-    rdfs:label     "incident"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "incident"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/the_large_galass>
     rdfs:label     "the large galass"@en;
     rdf:type    kgc:Object.
@@ -5208,6 +5264,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "なる"@ja;
     rdfs:label     "become"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/important_event_of_incident>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件の重要な事象"@ja;
     rdfs:label     "important event of incident"@en;
     rdf:type    kgc:OFobj;
@@ -5218,10 +5275,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "終わる"@ja;
     rdfs:label     "end"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/dining_room>
+    rdf:type    kgc:Place;
     rdfs:label     "食堂"@ja;
-    rdfs:label     "dining room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "dining room"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/postscript_of_Samuel>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サムエル後書"@ja;
     rdfs:label     "postscript of Samuel"@en;
     rdf:type    kgc:OFobj;
@@ -5269,31 +5327,32 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "行ける"@ja;
     rdfs:label     "canGo"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/furnace_lattice>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "炉格子"@ja;
     rdfs:label     "furnace lattice"@en;
-    rdfs:label     "炉格子に"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "炉格子に"@ja.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>
+    rdf:type    kgc:Person;
     rdfs:label     "バークリ"@ja;
     rdfs:label     "Berkeley"@en;
-    rdfs:label     "バークリの顔"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "バークリの顔"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/notCriminal>
     rdf:type    kgc:Property;
     rdfs:label     "犯人ではない"@ja;
     rdfs:label     "notCriminal"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Punjab>
+    rdf:type    kgc:Place;
     rdfs:label     "パンジャブ"@ja;
-    rdfs:label     "Punjab"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Punjab"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/reckless>
     rdf:type    kgc:Property;
     rdfs:label     "無鉄砲である"@ja;
     rdfs:label     "reckless"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/house>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家"@ja;
-    rdfs:label     "house"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "house"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/extreme>
     rdfs:label     "極度に"@ja;
     rdfs:label     "extreme"@en;
@@ -5312,9 +5371,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "呼ばない"@ja;
     rdfs:label     "notCall"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/long_claws>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "長い爪"@ja;
-    rdfs:label     "long claws"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "long claws"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/GoUp>
     rdfs:label     "GoUp"@en;
     rdf:type    kgc:Object.
@@ -5329,12 +5388,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "集める"@ja;
     rdfs:label     "collect"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/eye_of_beast>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "獣の目"@ja;
     rdfs:label     "eye of beast"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/eye>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/beast>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/old_friends_of_Henry>
+    rdf:type    kgc:Person;
     rdfs:label     "ヘンリの昔なじみ"@ja;
     rdfs:label     "old friends of Henry"@en;
     rdf:type    kgc:OFobj;
@@ -5342,11 +5403,10 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry>.
 <http://kgc.knowledge-graph.jp/data/predicate/Have>
     rdfs:label     "Have"@en;
-    rdfs:label     "持つ"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上る"@ja;
+    rdfs:label     "上がる"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/die>
     rdf:type    kgc:Action;
@@ -5359,9 +5419,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "反応しない"@ja;
     rdfs:label     "notRespond"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Afghanistan>
+    rdf:type    kgc:Place;
     rdfs:label     "アフガン"@ja;
-    rdfs:label     "Afghanistan"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Afghanistan"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/mountain>
     rdfs:label     "mountain"@en;
     rdf:type    kgc:Object.
@@ -5388,6 +5448,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ようである"@ja;
     rdfs:label     "seem"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/company_of_first_battalion_of_Royal_Mallows>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロイヤル・マロウズの第一大隊の中隊"@ja;
     rdfs:label     "company of first battalion of Royal Mallows"@en;
     rdf:type    kgc:OFobj;
@@ -5396,6 +5457,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/first_battalion>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Royal_Mallows>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/large_glass_door_of_living_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "居間の部屋の大きなガラスの扉"@ja;
     rdfs:label     "large glass door of living room"@en;
     rdf:type    kgc:OFobj;
@@ -5403,9 +5465,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/large_glass_door>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/home>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家"@ja;
-    rdfs:label     "home"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "home"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/ermine>
     rdfs:label     "ermine"@en;
     rdf:type    kgc:Object.
@@ -5426,9 +5488,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "長細い"@ja;
     rdfs:label     "long"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/about_Henry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘンリのこと"@ja;
-    rdfs:label     "about Henry"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "about Henry"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Garden>
     rdfs:label     "Garden"@en;
     rdf:type    kgc:Object.
@@ -5437,7 +5499,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "立ち会う"@ja;
+    rdfs:label     "参加する"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/161>
     rdfs:label     "161"@en;
@@ -5459,15 +5521,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "拷問する"@ja;
     rdfs:label     "torture"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/window_of_living_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓"@ja;
     rdfs:label     "window of living room"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/window>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/love_relationship>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "恋愛関係"@ja;
-    rdfs:label     "love relationship"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "love relationship"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/face>
     rdf:type    kgc:Property;
     rdfs:label     "面している"@ja;
@@ -5490,17 +5553,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "話しかける"@ja;
     rdfs:label     "speak"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/gardern>
+    rdf:type    kgc:Place;
     rdfs:label     "庭"@ja;
-    rdfs:label     "gardern"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "gardern"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/bird>
+    rdf:type    kgc:Animal;
     rdfs:label     "鳥"@ja;
-    rdfs:label     "bird"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bird"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/strange_word>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "変な言葉"@ja;
-    rdfs:label     "strange word"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "strange word"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
     rdfs:label     "開く"@ja;
@@ -5520,20 +5583,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ブロンド"@ja;
     rdfs:label     "blonde"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/information>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "情報"@ja;
-    rdfs:label     "information"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "information"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/30_yards_from_the_main_street>
+    rdf:type    kgc:Place;
     rdfs:label     "大通りから30ヤード以内"@ja;
-    rdfs:label     "30 yards from the main street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "30 yards from the main street"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/window>
     rdfs:label     "window"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/guilt>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "罪悪感"@ja;
-    rdfs:label     "guilt"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "guilt"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/meeting>
     rdfs:label     "meeting"@en;
     rdf:type    kgc:Object.
@@ -5541,26 +5604,27 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Want"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Morrison>
+    rdf:type    kgc:Person;
     rdfs:label     "モリソン"@ja;
-    rdfs:label     "Morrison"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Morrison"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/dwellers>
     rdfs:label     "dwellers"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room>
+    rdf:type    kgc:Place;
     rdfs:label     "居間"@ja;
     rdfs:label     "living room"@en;
-    rdfs:label     "居間の部屋"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "居間の部屋"@ja.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/lie>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "嘘"@ja;
-    rdfs:label     "lie"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "lie"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Rasheen>
+    rdf:type    kgc:Place;
     rdfs:label     "ラシーン"@ja;
-    rdfs:label     "Rasheen"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Rasheen"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/door_of_the_large_galass>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "大きなガラスの扉"@ja;
     rdfs:label     "door of the large galass"@en;
     rdf:type    kgc:OFobj;
@@ -5571,9 +5635,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "連れていく"@ja;
     rdfs:label     "takeAlong"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Watts_Street>
+    rdf:type    kgc:Place;
     rdfs:label     "ワット街"@ja;
-    rdfs:label     "Watts Street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watts Street"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/See>
     rdfs:label     "See"@en;
     rdf:type    kgc:Object.
@@ -5591,6 +5655,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "key"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/in_front_of_Rasheen>
+    rdf:type    kgc:Place;
     rdfs:label     "ラシーンの前"@ja;
     rdfs:label     "in front of Rasheen"@en;
     rdf:type    kgc:OFobj;
@@ -5615,7 +5680,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "20:40 on Monday"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Wednesday_night>
     rdf:type    kgc:AbstractTime;

--- a/CrookedMan.ttl
+++ b/CrookedMan.ttl
@@ -2150,7 +2150,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/237a> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/237a>
     rdf:type    kgc:Situation ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/シンプソン> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Simpson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/monitor> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/238>
@@ -3933,10 +3933,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "日よけ"@ja;
     rdfs:label     "sunshade"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/シンプソン>
-    rdf:type    kgc:Person;
-    rdfs:label     "シンプソン"@ja;
-    rdfs:label     "シンプソン"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/fireplace>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "暖炉"@ja;

--- a/DancingMen.ttl
+++ b/DancingMen.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/DancingMen/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -1384,8 +1384,8 @@ kgc:Thought rdf:type owl:Class ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/DancingMen/cryptography> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/151>
     rdf:type    kgc:Situation ;
-    kgc:source  "踊る人形fは'E'を意味する"@ja ;
-    kgc:source  "Doll F means 'E'"@en ;
+    kgc:source  "踊る人形fはEを意味する"@ja ;
+    kgc:source  "Doll F means E"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_F> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/E> ;
@@ -1417,7 +1417,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/156>
     rdf:type    kgc:Situation ;
     kgc:source  "踊る人形Dは2番目と4番目にEを持つ"@ja ;
-    kgc:source  "The dancing dolls D has 'E' in the second and fourth position"@en ;
+    kgc:source  "The dancing dolls D has E in the second and fourth position"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_D> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/E> ;
@@ -1426,7 +1426,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/158>
     rdf:type    kgc:Thought ;
     kgc:source  "踊る人形Dはネヴァーを意味するかもしれない"@ja ;
-    kgc:source  "The dancing dolls D might mean 'NEVER'"@en ;
+    kgc:source  "The dancing dolls D might mean NEVER"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_D> ;
@@ -1435,8 +1435,8 @@ kgc:Thought rdf:type owl:Class ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DancingMen/156> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/159>
     rdf:type    kgc:Situation ;
-    kgc:source  "踊る人形Gは'N'、'V'、'R'を意味する"@ja ;
-    kgc:source  "The dancing dolls G means 'N', 'V', and 'R'"@en ;
+    kgc:source  "踊る人形GはN、V、Rを意味する"@ja ;
+    kgc:source  "The dancing dolls G means N, V, and R"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_G> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/N> ;
@@ -1478,8 +1478,8 @@ kgc:Thought rdf:type owl:Class ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/165>
     rdf:type    kgc:Statement ;
-    kgc:source  "踊る人形Xは'L'、'S'、'I'を含む"@ja ;
-    kgc:source  "The Dancing dolls X includes 'L', 'S', and 'I'"@en ;
+    kgc:source  "踊る人形XはL、S、Iを含む"@ja ;
+    kgc:source  "The Dancing dolls X includes L, S, and I"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/contain> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_X> ;
@@ -1491,8 +1491,8 @@ kgc:Thought rdf:type owl:Class ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DancingMen/162> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/166>
     rdf:type    kgc:Statement ;
-    kgc:source  "踊る人形Xは'ELSIE'を意味する"@ja ;
-    kgc:source  "The Dancing dolls X means 'ELSIE'"@en ;
+    kgc:source  "踊る人形XはELSIEを意味する"@ja ;
+    kgc:source  "The Dancing dolls X means ELSIE"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_X> ;
@@ -1500,24 +1500,24 @@ kgc:Thought rdf:type owl:Class ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DancingMen/165> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/167>
     rdf:type    kgc:Situation ;
-    kgc:source  "踊る人形Yは'COME'を意味する"@ja ;
-    kgc:source  "The Dancing dolls Y  means 'COME'"@en ;
+    kgc:source  "踊る人形YはCOMEを意味する"@ja ;
+    kgc:source  "The Dancing dolls Y  means COME"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/COME> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_Y> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DancingMen/167a> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/167a>
     rdf:type    kgc:Situation ;
-    kgc:source  "踊る人形Yは'E'を最後に持つ"@ja ;
-    kgc:source  "The Dancing dolls Y has 'E' at the end"@en ;
+    kgc:source  "踊る人形YはEを最後に持つ"@ja ;
+    kgc:source  "The Dancing dolls Y has E at the end"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_Y> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/E> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DancingMen/the_final_position_of_Dancing_dolls_Y> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/168>
     rdf:type    kgc:Situation ;
-    kgc:source  "踊る人形Yは'C'、'O'、'M'を含む"@ja ;
-    kgc:source  "The Dancing dolls Y includes 'C', 'O', and 'M'"@en ;
+    kgc:source  "踊る人形YはC、O、Mを含む"@ja ;
+    kgc:source  "The Dancing dolls Y includes C, O, and M"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/contain> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_Y> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/C> ;
@@ -1540,8 +1540,8 @@ kgc:Thought rdf:type owl:Class ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/DancingMen/three_times> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/169b>
     rdf:type    kgc:Situation ;
-    kgc:source  "文章Hは，'?M ?ERE ??E SL?NE?'を意味する"@ja ;
-    kgc:source  "The Sentence H means '?M ?ERE ??E SL?NE?'"@en ;
+    kgc:source  "文章Hは，?M ?ERE ??E SL?NE?を意味する"@ja ;
+    kgc:source  "The Sentence H means ?M ?ERE ??E SL?NE?"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_H> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/?M_?ERE_??E_SL?NE?> .
@@ -1562,16 +1562,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DancingMen/first_position_of_the_second_word_of_Sentence_H> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/172>
     rdf:type    kgc:Situation ;
-    kgc:source  "文章Hは'Am Here Abe Slaney'を意味する"@ja ;
-    kgc:source  "The Sentence H means 'Am Here Abe Slaney'"@en ;
+    kgc:source  "文章HはAm Here Abe Slaneyを意味する"@ja ;
+    kgc:source  "The Sentence H means Am Here Abe Slaney"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Am_Here_Abe_Slaney> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_H> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DancingMen/170> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/173>
     rdf:type    kgc:Situation ;
-    kgc:source  "文章Iは'At Elridge'を意味する"@ja ;
-    kgc:source  "The Sentence I means 'At Elridge'"@en ;
+    kgc:source  "文章IはAt Elridgeを意味する"@ja ;
+    kgc:source  "The Sentence I means At Elridge"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/At_Elridge> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_I> ;
@@ -1586,16 +1586,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/173b> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/173b>
     rdf:type    kgc:Situation ;
-    kgc:source  "文章Iが'T'と'G'を持つ"@ja ;
-    kgc:source  "The Sentence I has 'T' and 'G'"@en ;
+    kgc:source  "文章IがTとGを持つ"@ja ;
+    kgc:source  "The Sentence I has T and G"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_I> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/T> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/G> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/173c>
     rdf:type    kgc:Situation ;
-    kgc:source  "文章Iは'A? ELRI?ES'を意味する"@ja ;
-    kgc:source  "The Sentence I means 'A? ELRI?ES'"@en ;
+    kgc:source  "文章IはA? ELRI?ESを意味する"@ja ;
+    kgc:source  "The Sentence I means A? ELRI?ES"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mean> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_I> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/A?_ELRI?ES> .
@@ -2021,7 +2021,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/229>
     rdf:type    kgc:Situation ;
     kgc:source  "踊る人形Jはすぐに来いである"@ja ;
-    kgc:source  "Dancing dolls J means 'come soon at once'"@en ;
+    kgc:source  "Dancing dolls J means come soon at once"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Come_soon_at_once> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_J> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/230>
@@ -2054,9 +2054,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "father"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Willson>
+    rdf:type    kgc:Person;
     rdfs:label     "ウィルスン"@ja;
-    rdfs:label     "Willson"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Willson"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/tube>
     rdfs:label     "tube"@en;
     rdf:type    kgc:Object.
@@ -2100,6 +2100,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Shadow"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/window_of_study_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓"@ja;
     rdfs:label     "window of study room"@en;
     rdf:type    kgc:OFobj;
@@ -2110,9 +2111,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "desk"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Martin>
+    rdf:type    kgc:Person;
     rdfs:label     "マーティン警部"@ja;
-    rdfs:label     "Martin"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Martin"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/bring>
     rdf:type    kgc:Action;
     rdfs:label     "持っていく"@ja;
@@ -2125,14 +2126,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "June"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_I>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "文章I"@ja;
-    rdfs:label     "Sentence I"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Sentence I"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_H>
     rdfs:label     "文章H"@ja;
     rdfs:label     "Sentence H"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/DancingMen/gunfire>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "銃声"@ja;
     rdfs:label     "gunfire"@en;
     rdf:type    kgc:AbstractTime;
@@ -2159,18 +2161,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "face"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/tube_of_bullet>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "真鍮の筒"@ja;
     rdfs:label     "tube of bullet"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/tube>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/bullet>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/heart_of_Qubit>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "キュービットの心臓"@ja;
     rdfs:label     "heart of Qubit"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/heart>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Door_of_study_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "書斎の扉"@ja;
     rdfs:label     "Door of study room"@en;
     rdf:type    kgc:OFobj;
@@ -2183,10 +2188,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "翌朝"@ja;
     rdfs:label     "next morning"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Chicago>
+    rdf:type    kgc:Place;
     rdfs:label     "キュービット"@ja;
     rdfs:label     "Chicago"@en;
-    rdfs:label     "シカゴ"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "シカゴ"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Window_frame>
     rdfs:label     "Window frame"@en;
     rdf:type    kgc:Object.
@@ -2198,13 +2203,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "first position"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Norwich>
+    rdf:type    kgc:Place;
     rdfs:label     "ノリッジ"@ja;
-    rdfs:label     "Norwich"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Norwich"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Someone>
+    rdf:type    kgc:Person;
     rdfs:label     "何者か"@ja;
-    rdfs:label     "Someone"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Someone"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Sundial>
     rdfs:label     "Sundial"@en;
     rdf:type    kgc:Object.
@@ -2219,14 +2224,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "heart"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/New_face>
+    rdf:type    kgc:Person;
     rdfs:label     "新顔"@ja;
-    rdfs:label     "New_face"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "New_face"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Desk>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "卓"@ja;
     rdfs:label     "Desk"@en;
-    rdfs:label     "机"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "机"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/night>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "夜"@ja;
@@ -2240,9 +2245,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "現れる"@ja;
     rdfs:label     "appear"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Corridor>
+    rdf:type    kgc:Place;
     rdfs:label     "廊下"@ja;
-    rdfs:label     "Corridor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Corridor"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notEqualTo>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -2250,16 +2255,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ではない"@ja;
     rdfs:label     "notEqualTo"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_fourth_position>
+    rdf:type    kgc:Place;
     rdfs:label     "4番目"@ja;
-    rdfs:label     "the fourth position"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "the fourth position"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Signs_of_evil>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "災いの兆し"@ja;
     rdfs:label     "Signs of evil"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Signs>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/evil>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/door_of_Storage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "物置の扉"@ja;
     rdfs:label     "door of Storage"@en;
     rdf:type    kgc:OFobj;
@@ -2274,9 +2281,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "背が高い"@ja;
     rdfs:label     "tall"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Bad_memories>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "嫌な思い出"@ja;
-    rdfs:label     "Bad memories"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bad memories"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/close>
     rdf:type    kgc:Property;
     rdfs:label     "閉まっている"@ja;
@@ -2288,6 +2295,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "必要とする"@ja;
     rdfs:label     "need"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/home_of_Qubit>
+    rdf:type    kgc:Place;
     rdfs:label     "キュービット宅"@ja;
     rdfs:label     "home of Qubit"@en;
     rdf:type    kgc:OFobj;
@@ -2300,17 +2308,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "送らない"@ja;
     rdfs:label     "notSend"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Am_Here_Abe_Slaney>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "Am Here Abe Slaney"@ja;
-    rdfs:label     "Am Here Abe Slaney"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Am Here Abe Slaney"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/handcuffs>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手錠"@ja;
-    rdfs:label     "handcuffs"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "handcuffs"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Board_2>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "板2"@ja;
-    rdfs:label     "Board 2"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Board 2"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_final_position_of_Dancing_dolls_Y>
     rdfs:label     "最後"@ja;
     rdfs:label     "the final position of Dancing dolls Y"@en;
@@ -2318,15 +2326,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/the_final_position>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_Y>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/father_of_Elsie>
+    rdf:type    kgc:Person;
     rdfs:label     "エルシィの父親"@ja;
     rdfs:label     "father of Elsie"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/father>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Board_1>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "板1"@ja;
-    rdfs:label     "Board 1"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Board 1"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/throw>
     rdf:type    kgc:Action;
     rdfs:label     "投げる"@ja;
@@ -2349,27 +2358,27 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "know"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/take>
     rdf:type    kgc:Action;
-    rdfs:label     "取る"@ja;
+    rdfs:label     "持つ"@ja;
     rdfs:label     "take"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "嗅ぐ"@ja;
+    rdfs:label     "匂う"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/pencil>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鉛筆"@ja;
-    rdfs:label     "pencil"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "pencil"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/full>
     rdf:type    kgc:Property;
     rdfs:label     "充満する"@ja;
     rdfs:label     "full"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Glass_window>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ガラス窓"@ja;
-    rdfs:label     "Glass window"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Glass window"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "殴る"@ja;
+    rdfs:label     "打つ"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Identity>
     rdfs:label     "Identity"@en;
@@ -2378,9 +2387,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "horse boy"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Inside>
+    rdf:type    kgc:Place;
     rdfs:label     "内側"@ja;
-    rdfs:label     "Inside"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Inside"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/copy>
     rdf:type    kgc:Action;
     rdfs:label     "写し取る"@ja;
@@ -2389,20 +2398,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the final position"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>
+    rdf:type    kgc:Person;
     rdfs:label     "キュービット"@ja;
-    rdfs:label     "Qubit"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Qubit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着る"@ja;
+    rdfs:label     "着ている"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_H>
     rdfs:label     "Sentence H"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/fireplace>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "暖炉"@ja;
-    rdfs:label     "fireplace"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "fireplace"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/frame>
     rdfs:label     "frame"@en;
     rdf:type    kgc:Object.
@@ -2415,20 +2424,20 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/locked>
     rdf:type    kgc:Property;
-    rdfs:label     "施錠される"@ja;
+    rdfs:label     "施錠されている"@ja;
     rdfs:label     "locked"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Come_soon_at_once>
     rdf:type    kgc:Property;
     rdfs:label     "すぐに来い"@ja;
     rdfs:label     "Come soon at once"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/East_Ruston>
+    rdf:type    kgc:Place;
     rdfs:label     "東ラストン"@ja;
-    rdfs:label     "East Ruston"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "East Ruston"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Bedroom>
+    rdf:type    kgc:Place;
     rdfs:label     "寝室"@ja;
-    rdfs:label     "Bedroom"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bedroom"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notKnow>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -2436,9 +2445,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "知らない"@ja;
     rdfs:label     "notKnow"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/station>
+    rdf:type    kgc:Place;
     rdfs:label     "駅"@ja;
-    rdfs:label     "station"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "station"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/have>
     rdf:type    kgc:Action;
     rdfs:label     "持つ"@ja;
@@ -2454,27 +2463,28 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Hit"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/casual_wear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "普段着"@ja;
-    rdfs:label     "casual wear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "casual wear"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear_of_Qubit>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "キュービットの着衣"@ja;
     rdfs:label     "nightwear of Qubit"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/banknote>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "紙幣"@ja;
-    rdfs:label     "banknote"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "banknote"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/this_morning>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "今朝"@ja;
-    rdfs:label     "this morning"@en.
-<http://kgc.knowledge-graph.jp/data/DancingMen/ELSIE>
-    rdfs:label     "ELSIE"@ja;
-    rdfs:label     "ELSIE"@en;
+    rdfs:label     "this morning"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/DancingMen/ELSIE>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ELSIE"@ja;
+    rdfs:label     "ELSIE"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/kill>
     rdf:type    kgc:Action;
     rdfs:label     "殺す"@ja;
@@ -2484,17 +2494,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "裂ける"@ja;
     rdfs:label     "burst"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/home>
+    rdf:type    kgc:Place;
     rdfs:label     "家"@ja;
-    rdfs:label     "home"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "home"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
-    rdfs:label     "Holmes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Holmes"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/room>
+    rdf:type    kgc:Place;
     rdfs:label     "部屋"@ja;
-    rdfs:label     "room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "room"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/leave>
     rdf:type    kgc:Action;
     rdfs:label     "去る"@ja;
@@ -2508,40 +2518,42 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "見える"@ja;
     rdfs:label     "beSeen"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/COME>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "COME"@ja;
-    rdfs:label     "COME"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "COME"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/getOff>
     rdf:type    kgc:Action;
-    rdfs:label     "飛び降りる"@ja;
+    rdfs:label     "下車する"@ja;
     rdfs:label     "getOff"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/contain>
     rdf:type    kgc:Action;
     rdfs:label     "含む"@ja;
     rdfs:label     "contain"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/London>
+    rdf:type    kgc:Place;
     rdfs:label     "ロンドン"@ja;
-    rdfs:label     "London"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "London"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Alphabet>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "アルファベット"@ja;
-    rdfs:label     "Alphabet"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Alphabet"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/American>
     rdf:type    kgc:Property;
     rdfs:label     "アメリカ人"@ja;
     rdfs:label     "American"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie>
+    rdf:type    kgc:Person;
     rdfs:label     "エルシィ"@ja;
-    rdfs:label     "Elsie"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Elsie"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Window_frame_of_study_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓枠"@ja;
     rdfs:label     "Window frame of study room"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Window_frame>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/study_room>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/frame_of_window_of_study_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓枠"@ja;
     rdfs:label     "frame of window of study room"@en;
     rdf:type    kgc:OFobj;
@@ -2550,6 +2562,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/window>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/study_room>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_first_position_of_Sentence_H>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "文章Hの最初の位置"@ja;
     rdfs:label     "the first position of Sentence H"@en;
     rdf:type    kgc:OFobj;
@@ -2566,48 +2579,50 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "外れる"@ja;
     rdfs:label     "notHit"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/morning_after_2_days>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "2日後の朝"@ja;
-    rdfs:label     "morning after 2 days"@en.
+    rdfs:label     "morning after 2 days"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/outside>
+    rdf:type    kgc:Place;
     rdfs:label     "外"@ja;
-    rdfs:label     "outside"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "outside"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Watson>
+    rdf:type    kgc:Person;
     rdfs:label     "ワトソン"@ja;
-    rdfs:label     "Watson"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watson"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/2_00>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "午前2時頃"@ja;
-    rdfs:label     "2:00"@en.
+    rdfs:label     "2:00"@en;
+    rdf:type    kgc:AbstractTime.
 <http://kgc.knowledge-graph.jp/data/predicate/police_officer>
     rdf:type    kgc:Property;
     rdfs:label     "警察官"@ja;
     rdfs:label     "police officer"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/three_characters>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "三文字"@ja;
-    rdfs:label     "three characters"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "three characters"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/a_short_time>
     rdfs:label     "わずかな時間"@ja;
     rdfs:label     "a short time"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Horse_boy>
+    rdf:type    kgc:Person;
     rdfs:label     "馬番の少年"@ja;
-    rdfs:label     "Horse boy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Horse boy"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wakeUp>
     rdf:type    kgc:Action;
     rdfs:label     "起きる"@ja;
     rdfs:label     "wakeUp"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Traces_of_candles>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ローソクの流れ跡"@ja;
     rdfs:label     "Traces of candles"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Traces>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/candles>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/first_position_of_the_second_word_of_Sentence_H>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "文章Hの2つ目の位置"@ja;
     rdfs:label     "first position of the second word of Sentence H"@en;
     rdf:type    kgc:OFobj;
@@ -2623,9 +2638,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Force"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/investigation>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "捜査"@ja;
-    rdfs:label     "investigation"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "investigation"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/belong>
     rdf:type    kgc:Action;
     rdfs:label     "所属する"@ja;
@@ -2638,13 +2653,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "真っ青である"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Maid_room>
+    rdf:type    kgc:Place;
     rdfs:label     "自分たちの部屋"@ja;
-    rdfs:label     "Maid room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Maid room"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/New_York>
+    rdf:type    kgc:Place;
     rdfs:label     "ニューヨーク"@ja;
-    rdfs:label     "New York"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "New York"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_second_word>
     rdfs:label     "the second word"@en;
     rdf:type    kgc:Object.
@@ -2653,6 +2668,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "怒る"@ja;
     rdfs:label     "angry"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Message_of_Abe_Slaney>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "エイブ・スレイニの伝言"@ja;
     rdfs:label     "Message of Abe_Slaney"@en;
     rdf:type    kgc:OFobj;
@@ -2660,26 +2676,27 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney>.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受け取る"@ja;
+    rdfs:label     "受ける"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/face_of_Elsie>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "エルシィの顔"@ja;
     rdfs:label     "face of Elsie"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/face>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/NEVER>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "NEVER"@ja;
-    rdfs:label     "NEVER"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "NEVER"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/A>
     rdf:type    kgc:Property;
     rdfs:label     "A"@ja;
     rdfs:label     "A"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Bullet>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "弾"@ja;
-    rdfs:label     "Bullet"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bullet"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/H>
     rdf:type    kgc:Property;
     rdfs:label     "H"@ja;
@@ -2698,48 +2715,49 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Moved"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Window_of_study_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "部屋の窓"@ja;
     rdfs:label     "Window of study room"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Window>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/study_room>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/something>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "何か"@ja;
-    rdfs:label     "something"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "something"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/money>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "お金"@ja;
-    rdfs:label     "money"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "money"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_A>
     rdfs:label     "Dancing dolls A"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/pullOut>
     rdf:type    kgc:Action;
-    rdfs:label     "引きだす"@ja;
+    rdfs:label     "引き出す"@ja;
     rdfs:label     "pullOut"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Study_room>
+    rdf:type    kgc:Place;
     rdfs:label     "部屋"@ja;
     rdfs:label     "Study room"@en;
     rdfs:label     "書斎"@ja;
-    rdfs:label     "現場"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "現場"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/short>
     rdf:type    kgc:Property;
     rdfs:label     "短い"@ja;
     rdfs:label     "short"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/put>
     rdf:type    kgc:Action;
-    rdfs:label     "置く"@ja;
+    rdfs:label     "付ける"@ja;
     rdfs:label     "put"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/follow>
     rdf:type    kgc:Action;
     rdfs:label     "従う"@ja;
     rdfs:label     "follow"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_second_position>
+    rdf:type    kgc:Place;
     rdfs:label     "2番目"@ja;
-    rdfs:label     "the second position"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "the second position"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sit>
     rdf:type    kgc:Action;
     rdfs:label     "座る"@ja;
@@ -2749,27 +2767,28 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "止める"@ja;
     rdfs:label     "stop"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Doll>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "記号"@ja;
-    rdfs:label     "Doll"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Doll"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Chalk>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "チョーク"@ja;
-    rdfs:label     "Chalk"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Chalk"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Meaning_of_Dancing_dolls_A>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "文字の意味"@ja;
     rdfs:label     "Meaning of Dancing dolls A"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Meaning>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_A>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/V>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "V"@ja;
-    rdfs:label     "V"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "V"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/S>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "S"@ja;
-    rdfs:label     "S"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "S"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/bullets>
     rdfs:label     "bullets"@en;
     rdf:type    kgc:Object.
@@ -2781,78 +2800,79 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "evil"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/R>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "R"@ja;
-    rdfs:label     "R"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "R"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Message>
     rdfs:label     "Message"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/O>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "O"@ja;
-    rdfs:label     "O"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "O"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/M>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "M"@ja;
-    rdfs:label     "M"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "M"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/N>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "N"@ja;
-    rdfs:label     "N"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "N"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
     rdfs:label     "聞く"@ja;
     rdfs:label     "hear"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/L>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "L"@ja;
-    rdfs:label     "L"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "L"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/I>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "I"@ja;
-    rdfs:label     "I"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "I"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/American_postmark>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "アメリカの消印"@ja;
-    rdfs:label     "American postmark"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "American postmark"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/G>
     rdfs:label     "G"@ja;
     rdfs:label     "G"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Handgun>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "拳銃"@ja;
-    rdfs:label     "Handgun"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Handgun"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/E>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "E"@ja;
-    rdfs:label     "E"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "E"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/3_00>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "午前三時"@ja;
     rdfs:label     "3:00"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Criminal>
+    rdf:type    kgc:Person;
     rdfs:label     "犯人"@ja;
     rdfs:label     "Criminal"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Letter_Z>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙Z"@ja;
     rdfs:label     "Letter Z"@en;
     rdfs:label     "手紙"@ja;
-    rdfs:label     "返事"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "返事"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Letter_X>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙X"@ja;
-    rdfs:label     "Letter X"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Letter X"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Letter_Y>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙"@ja;
-    rdfs:label     "Letter Y"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Letter Y"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/North_Walsham>
+    rdf:type    kgc:Place;
     rdfs:label     "北ウォールシャム"@ja;
-    rdfs:label     "North Walsham"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "North Walsham"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/force>
     rdf:type    kgc:Action;
     rdfs:label     "追いやる"@ja;
@@ -2865,17 +2885,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "行く"@ja;
     rdfs:label     "go"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/handbag>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ハンドバッグ"@ja;
-    rdfs:label     "handbag"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "handbag"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "寝間着"@ja;
-    rdfs:label     "nightwear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "nightwear"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Third_person>
+    rdf:type    kgc:Person;
     rdfs:label     "第三の人物"@ja;
-    rdfs:label     "Third person"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Third person"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/mean>
     rdf:type    kgc:Action;
     rdfs:label     "意味する"@ja;
@@ -2888,9 +2908,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "動く"@ja;
     rdfs:label     "move"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/flag>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "旗"@ja;
-    rdfs:label     "flag"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "flag"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/walk>
     rdf:type    kgc:Action;
     rdfs:label     "歩く"@ja;
@@ -2904,14 +2924,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "驚く"@ja;
     rdfs:label     "beSurprised"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/character>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "文字"@ja;
-    rdfs:label     "character"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "character"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/find>
     rdf:type    kgc:Action;
     rdfs:label     "見つける"@ja;
     rdfs:label     "find"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/desk_of_study_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "書斎の机"@ja;
     rdfs:label     "desk of study room"@en;
     rdf:type    kgc:OFobj;
@@ -2922,9 +2943,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "死んでいない"@ja;
     rdfs:label     "notDead"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/dolls>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "人形"@ja;
-    rdfs:label     "dolls"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "dolls"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/shutUp>
     rdf:type    kgc:Action;
     rdfs:label     "黙っている"@ja;
@@ -2937,23 +2958,25 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "渡す"@ja;
     rdfs:label     "handOver"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/gown>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ガウン"@ja;
-    rdfs:label     "gown"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "gown"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形"@ja;
     rdfs:label     "Dancing dolls"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Traces_of_bullets>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "銃弾の痕跡"@ja;
     rdfs:label     "Traces of bullets"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Traces>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/bullets>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Letter_L>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙"@ja;
-    rdfs:label     "Letter L"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Letter L"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/write>
     rdf:type    kgc:Action;
     rdfs:label     "書く"@ja;
@@ -2975,23 +2998,23 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "乱れる"@ja;
     rdfs:label     "disturb"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Norfolk>
+    rdf:type    kgc:Place;
     rdfs:label     "ノーフォーク州"@ja;
     rdfs:label     "Norfolk"@en;
-    rdfs:label     "ノーフォーク"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ノーフォーク"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/window>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓際"@ja;
     rdfs:label     "window"@en;
-    rdfs:label     "窓"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "窓"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/C>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "C"@ja;
-    rdfs:label     "C"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "C"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/America>
+    rdf:type    kgc:Place;
     rdfs:label     "アメリカ"@ja;
-    rdfs:label     "America"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "America"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Storage>
     rdfs:label     "Storage"@en;
     rdf:type    kgc:Object.
@@ -3004,10 +3027,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "物分かり良い"@ja;
     rdfs:label     "wellUnderstood"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney>
+    rdf:type    kgc:Person;
     rdfs:label     "エイブ・スレイニ"@ja;
     rdfs:label     "Abe_Slaney"@en;
-    rdfs:label     "エイブスレイニ"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "エイブスレイニ"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/old_family>
     rdf:type    kgc:Property;
     rdfs:label     "旧家"@ja;
@@ -3028,13 +3051,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/findings>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "所見"@ja;
-    rdfs:label     "findings"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "findings"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Maid>
+    rdf:type    kgc:Person;
     rdfs:label     "女中"@ja;
-    rdfs:label     "Maid"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Maid"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/enter>
     rdf:type    kgc:Action;
     rdfs:label     "入る"@ja;
@@ -3044,7 +3067,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/last_year>
     rdf:type    kgc:AbstractTime;
@@ -3054,6 +3077,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "bullet"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/sundial_of_garden>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "庭の日時計"@ja;
     rdfs:label     "sundial of garden"@en;
     rdf:type    kgc:OFobj;
@@ -3064,10 +3088,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "小さい"@ja;
     rdfs:label     "small"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Local_doctor>
+    rdf:type    kgc:Person;
     rdfs:label     "地元の医者"@ja;
     rdfs:label     "Local doctor"@en;
-    rdfs:label     "Local_doctor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Local_doctor"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/window_of_study_room>
     rdfs:label     "window of study room"@en;
     rdf:type    kgc:OFobj;
@@ -3082,6 +3106,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "3日後の朝"@ja;
     rdfs:label     "3 days later"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Pebble_of_sundial>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "日時計の小石"@ja;
     rdfs:label     "Pebble of sundial"@en;
     rdf:type    kgc:OFobj;
@@ -3103,9 +3128,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "4時"@ja;
     rdfs:label     "4:00"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/telegram>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "電報"@ja;
-    rdfs:label     "telegram"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "telegram"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/2_times>
     rdfs:label     "2回"@ja;
     rdfs:label     "2 times"@en;
@@ -3135,7 +3160,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "要求する"@ja;
+    rdfs:label     "依頼する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_second_day>
     rdfs:label     "the second day"@en;
@@ -3145,19 +3170,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "守る"@ja;
     rdfs:label     "protect"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Candle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ローソク"@ja;
-    rdfs:label     "Candle"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Candle"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Character_C2>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "文字C2"@ja;
-    rdfs:label     "Character C2"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Character C2"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Elridge>
+    rdf:type    kgc:Place;
     rdfs:label     "エルリッジ"@ja;
     rdfs:label     "Elridge"@en;
     rdfs:label     "エルリッジ農場"@ja;
-    rdfs:label     "エルリッジ農場の地下室"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "エルリッジ農場の地下室"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_first_position>
     rdfs:label     "the first position"@en;
     rdf:type    kgc:Object.
@@ -3171,11 +3196,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "滞在する"@ja;
+    rdfs:label     "留まる"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/stand>
     rdf:type    kgc:Action;
-    rdfs:label     "立つ"@ja;
+    rdfs:label     "立てかける"@ja;
     rdfs:label     "stand"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Traces>
     rdfs:label     "Traces"@en;
@@ -3192,6 +3217,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "呼ぶ"@ja;
     rdfs:label     "call"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/three_sides_of_study_room>
+    rdf:type    kgc:Place;
     rdfs:label     "書斎の三方"@ja;
     rdfs:label     "three sides of study room"@en;
     rdf:type    kgc:OFobj;
@@ -3205,6 +3231,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "three sides"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Smell_of_gunfire>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "火薬のにおい"@ja;
     rdfs:label     "Smell of gunfire"@en;
     rdf:type    kgc:OFobj;
@@ -3226,9 +3253,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/end>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/June>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/note>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "書き付け"@ja;
-    rdfs:label     "note"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "note"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/see>
     rdf:type    kgc:Action;
     rdfs:label     "見る"@ja;
@@ -3247,13 +3274,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "強要しない"@ja;
     rdfs:label     "notForce"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/One_minute_after_gunfire>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "銃声の1分後"@ja;
-    rdfs:label     "One minute after gunfire"@en.
-<http://kgc.knowledge-graph.jp/data/DancingMen/front>
-    rdfs:label     "前"@ja;
-    rdfs:label     "front"@en;
+    rdfs:label     "One minute after gunfire"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/DancingMen/front>
+    rdf:type    kgc:Place;
+    rdfs:label     "前"@ja;
+    rdfs:label     "front"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Past>
     rdfs:label     "Past"@en;
     rdf:type    kgc:Object.
@@ -3262,40 +3289,41 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "許す"@ja;
     rdfs:label     "permit"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/smoke>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "煙"@ja;
-    rdfs:label     "smoke"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "smoke"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_F>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形f"@ja;
     rdfs:label     "Dancing dolls F"@en;
-    rdfs:label     "踊る人形F"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "踊る人形F"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/bullet_of_Qubit>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "キュービットの弾"@ja;
     rdfs:label     "bullet of Qubit"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/bullet>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_E>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形E"@ja;
     rdfs:label     "Dancing dolls E"@en;
-    rdfs:label     "踊る人形e"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "踊る人形e"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_D>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形d"@ja;
     rdfs:label     "Dancing dolls D"@en;
-    rdfs:label     "踊る人形D"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "踊る人形D"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_C>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形c"@ja;
     rdfs:label     "Dancing dolls C"@en;
-    rdfs:label     "踊る人形C"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "踊る人形C"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_J>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形J"@ja;
     rdfs:label     "Dancing dolls J"@en;
-    rdfs:label     "踊る人形"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "踊る人形"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/crouch>
     rdf:type    kgc:Action;
     rdfs:label     "うずくまる"@ja;
@@ -3307,9 +3335,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "気づく"@ja;
     rdfs:label     "notice"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_G>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形G"@ja;
-    rdfs:label     "Dancing dolls G"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dancing dolls G"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/lighted>
     rdf:type    kgc:Property;
     rdfs:label     "灯っている"@ja;
@@ -3318,34 +3346,36 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Pebble"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_B>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形b"@ja;
-    rdfs:label     "Dancing dolls B"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dancing dolls B"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Sundial_of_garden>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "日時計"@ja;
     rdfs:label     "Sundial of garden"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Sundial>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/garden>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/At_Elridge>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "At Elridge"@ja;
-    rdfs:label     "At Elridge"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "At Elridge"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_A>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形A"@ja;
     rdfs:label     "Dancing dolls A"@en;
     rdfs:label     "文字"@ja;
-    rdfs:label     "踊る人形a"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "踊る人形a"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Bookshelf>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "本棚"@ja;
-    rdfs:label     "Bookshelf"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bookshelf"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/bePleased>
     rdf:type    kgc:Action;
     rdfs:label     "喜ぶ"@ja;
     rdfs:label     "bePleased"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Shadow_of_storage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "物置の影"@ja;
     rdfs:label     "Shadow of storage"@en;
     rdf:type    kgc:OFobj;
@@ -3356,14 +3386,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "暗号"@ja;
     rdfs:label     "cipher"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Neighborhood>
+    rdf:type    kgc:Place;
     rdfs:label     "近所"@ja;
-    rdfs:label     "Neighborhood"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Neighborhood"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/garden>
+    rdf:type    kgc:Place;
     rdfs:label     "庭"@ja;
     rdfs:label     "garden"@en;
-    rdfs:label     "屋外"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "屋外"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/notMoved>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -3371,9 +3401,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "動かされていない"@ja;
     rdfs:label     "notMoved"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_Y>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形Y"@ja;
-    rdfs:label     "Dancing dolls Y"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dancing dolls Y"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/gentle>
     rdf:type    kgc:Property;
     rdfs:label     "紳士である"@ja;
@@ -3383,25 +3413,26 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "先週火曜日"@ja;
     rdfs:label     "last Tuesday"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_X>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形X"@ja;
-    rdfs:label     "Dancing dolls X"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dancing dolls X"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/moonlighted>
     rdf:type    kgc:Property;
     rdfs:label     "月明かりだけである"@ja;
     rdfs:label     "moonlighted"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/study_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "書斎"@ja;
     rdfs:label     "study room"@en;
+    rdf:type    kgc:Place;
     rdfs:label     "部屋"@ja;
-    rdfs:label     "室内"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "室内"@ja.
 <http://kgc.knowledge-graph.jp/data/DancingMen/end>
     rdfs:label     "end"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪れる"@ja;
+    rdfs:label     "訪ねる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -3410,18 +3441,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "存在しない"@ja;
     rdfs:label     "notExist"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/flower_bed>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "花壇"@ja;
-    rdfs:label     "flower bed"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "flower bed"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/prayer>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "神に合う覚悟"@ja;
-    rdfs:label     "prayer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "prayer"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Threat>
     rdfs:label     "脅し"@ja;
     rdfs:label     "Threat"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Past_of_Elsie>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "エルシィの過去"@ja;
     rdfs:label     "Past of Elsie"@en;
     rdf:type    kgc:OFobj;
@@ -3430,30 +3462,31 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/Past>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/male_footprints>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "男性の足跡"@ja;
-    rdfs:label     "male footprints"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "male footprints"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Charactor_C1>
     rdfs:label     "文字C1"@ja;
     rdfs:label     "Charactor C1"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/DancingMen/paper>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "紙"@ja;
-    rdfs:label     "paper"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "paper"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/promise>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "約束"@ja;
-    rdfs:label     "promise"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "promise"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hurt>
     rdf:type    kgc:Action;
-    rdfs:label     "傷つける"@ja;
+    rdfs:label     "怪我する"@ja;
     rdfs:label     "hurt"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Identity_of_Abe_Slaney>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "エイブ・スレイニの正体"@ja;
     rdfs:label     "Identity of Abe_Slaney"@en;
     rdf:type    kgc:OFobj;

--- a/DevilsFoot.ttl
+++ b/DevilsFoot.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -2706,6 +2706,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Mortimer was fearful"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/fearful> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/face_of_fear> ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/DevilsFoot/266> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/266>
     rdf:type    kgc:Situation ;
@@ -4762,10 +4763,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda>
     rdfs:label     "ブレンダ"@ja;
     rdfs:label     "Brenda"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/predicate/bring>
     rdf:type    kgc:Action;
-    rdfs:label     "持っていく"@ja;
+    rdfs:label     "連れていく"@ja;
     rdfs:label     "bring"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/living_room>
     rdfs:label     "居間"@ja;
@@ -4831,14 +4832,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "曖昧である"@ja;
     rdfs:label     "ambiguous"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Within_5_minutes>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "5分以内"@ja;
-    rdfs:label     "Within 5 minutes"@en.
+    rdfs:label     "Within 5 minutes"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/opinion>
     rdfs:label     "opinion"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Morning_of_the_first_day>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "1日目の朝"@ja;
     rdfs:label     "Morning of the first day"@en;
     rdf:type    kgc:OFobj;
@@ -4877,7 +4877,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/Mortimer>.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "徘徊する"@ja;
+    rdfs:label     "歩き回る"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/laws>
     rdfs:label     "laws"@en;
@@ -4887,9 +4887,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Father"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Within_a_few_minutes>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "数分以内"@ja;
-    rdfs:label     "Within a few minutes"@en.
+    rdfs:label     "Within a few minutes"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cause>
     rdfs:label     "原因"@ja;
     rdfs:label     "Cause"@en;
@@ -4911,9 +4911,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Motivation>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/case>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Doctor_Richard>
+    rdf:type    kgc:Person;
     rdfs:label     "ドクター・リチャード"@ja;
-    rdfs:label     "Doctor Richard"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Doctor Richard"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/After_death_of_Brenda_>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "ブレンダの死後"@ja;
@@ -5145,19 +5145,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "madness"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/card_game>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "カードの最中"@ja;
-    rdfs:label     "card game"@en.
+    rdfs:label     "card game"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/create>
     rdf:type    kgc:Action;
-    rdfs:label     "練る"@ja;
+    rdfs:label     "創造する"@ja;
     rdfs:label     "create"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/note>
     rdfs:label     "note"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/turnOn>
     rdf:type    kgc:Action;
-    rdfs:label     "灯す"@ja;
+    rdfs:label     "点灯する"@ja;
     rdfs:label     "turnOn"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/sample>
     rdfs:label     "sample"@en;
@@ -5245,8 +5245,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/combustion>
     rdfs:label     "燃焼"@ja;
     rdfs:label     "combustion"@en;
-    rdf:type    kgc:AbstractTime;
-    rdfs:label     "燃焼時"@ja.
+    rdfs:label     "燃焼時"@ja;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Morning>
     rdfs:label     "Morning"@en;
     rdf:type    kgc:Object.
@@ -5310,16 +5310,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/1897>.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受け取る"@ja;
+    rdfs:label     "受ける"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Four_men>
     rdfs:label     "4人の男"@ja;
     rdfs:label     "Four men"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife>
+    rdf:type    kgc:Person;
     rdfs:label     "前妻"@ja;
-    rdfs:label     "Former wife"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Former wife"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer_sImmediate_family>
     rdfs:label     "モーティマーの肉親"@ja;
     rdfs:label     "Mortimer'sImmediate family"@en;
@@ -5434,8 +5434,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "putOn"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fearful>
     rdf:type    kgc:Property;
-    rdfs:label     "恐怖の表情"@ja;
-    rdfs:label     "fearful"@en.
+    rdfs:label     "持つ"@ja;
+    rdfs:label     "fearful"@en;
+    rdfs:label     "恐怖の表情"@ja.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/exterior_of_Exhaust>
     rdfs:label     "排煙部の外装"@ja;
     rdfs:label     "exterior of Exhaust"@en;
@@ -5475,7 +5476,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考える"@ja;
+    rdfs:label     "考慮する"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/fireplace>
     rdfs:label     "暖炉"@ja;
@@ -5509,7 +5510,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/crush>
     rdf:type    kgc:Action;
-    rdfs:label     "粉砕する"@ja;
+    rdfs:label     "砕く"@ja;
     rdfs:label     "crush"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notGenerous>
     rdf:type    kgc:Action;
@@ -5560,7 +5561,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "gravel"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/separate>
     rdf:type    kgc:Action;
-    rdfs:label     "分かれる"@ja;
+    rdfs:label     "別れる"@ja;
     rdfs:label     "separate"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/In_the_room>
     rdfs:label     "部屋の中"@ja;
@@ -5609,9 +5610,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "forehead"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Toridan_Wasa>
+    rdf:type    kgc:Place;
     rdfs:label     "トリダニック・ワーサ"@ja;
-    rdfs:label     "Toridan Wasa"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Toridan Wasa"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Hoist>
     rdfs:label     "ホイスト"@ja;
     rdfs:label     "Hoist"@en;
@@ -5699,10 +5700,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/enter>
     rdf:type    kgc:Action;
     rdfs:label     "入る"@ja;
-    rdfs:label     "enter"@en.
+    rdfs:label     "enter"@en;
+    rdfs:label     "入ってくる"@ja;
+    rdfs:label     "行く"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/hall>
     rdfs:label     "広間から"@ja;
@@ -5793,9 +5796,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Grassland"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Five_minutes_later>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "5分後"@ja;
-    rdfs:label     "Five minutes later"@en.
+    rdfs:label     "Five minutes later"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/feet_of_Mortimer>
     rdfs:label     "モーティマーの手足"@ja;
     rdfs:label     "feet of Mortimer"@en;
@@ -5859,7 +5862,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "要求する"@ja;
+    rdfs:label     "依頼する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Behind_you>
     rdfs:label     "後ろ手で"@ja;
@@ -5933,7 +5936,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/beLocked>
     rdf:type    kgc:Action;
-    rdfs:label     "鍵がかかっている"@ja;
+    rdfs:label     "施錠される"@ja;
     rdfs:label     "beLocked"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Servant>
     rdfs:label     "使用人"@ja;
@@ -5957,9 +5960,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "昨日の夜"@ja;
     rdfs:label     "Yesterday night"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Watson>
+    rdf:type    kgc:Person;
     rdfs:label     "ワトソン"@ja;
-    rdfs:label     "Watson"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watson"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
     rdfs:label     "会う"@ja;
@@ -6011,7 +6014,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/rant>
     rdf:type    kgc:Action;
-    rdfs:label     "叫ぶ"@ja;
+    rdfs:label     "わめく"@ja;
     rdfs:label     "rant"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sufficient_funds>
     rdfs:label     "十分な資金"@ja;
@@ -6046,9 +6049,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/note>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Immediately_after_breakfast_on_March_16>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "3月16日朝食直後"@ja;
-    rdfs:label     "Immediately after breakfast on March 16"@en.
+    rdfs:label     "Immediately after breakfast on March 16"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/recommend>
     rdf:type    kgc:Action;
     rdfs:label     "勧める"@ja;
@@ -6064,9 +6067,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "death"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/When_the_sun_rises>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "日が昇る頃"@ja;
-    rdfs:label     "When the sun rises"@en.
+    rdfs:label     "When the sun rises"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/money>
     rdfs:label     "お金"@ja;
     rdfs:label     "money"@en;
@@ -6086,7 +6089,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Many years ago"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪れる"@ja;
+    rdfs:label     "訪ねる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -6125,7 +6128,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Owen>
     rdfs:label     "オーウェン"@ja;
     rdfs:label     "Owen"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Living_room>
     rdfs:label     "Living room"@en;
     rdf:type    kgc:Object.
@@ -6134,7 +6137,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/left>
     rdf:type    kgc:Action;
-    rdfs:label     "出ていく"@ja;
+    rdfs:label     "出る"@ja;
     rdfs:label     "left"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/takeWalk>
     rdf:type    kgc:Action;
@@ -6143,11 +6146,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/pass>
     rdf:type    kgc:Action;
     rdfs:label     "経過している"@ja;
-    rdfs:label     "pass"@en.
+    rdfs:label     "pass"@en;
+    rdfs:label     "すれ違う"@ja.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
-    rdfs:label     "Holmes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Holmes"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Long_time_ago>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "昔"@ja;
@@ -6194,6 +6198,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Sleep"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Pordeux_Bay>
+    rdf:type    kgc:Place;
     rdfs:label     "ポルデュー湾のコテージ"@ja;
     rdfs:label     "cottage of Pordeux Bay"@en;
     rdf:type    kgc:OFobj;
@@ -6225,7 +6230,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "錫鉱夫"@ja;
     rdfs:label     "Tin miner"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/night_of_Yesterday>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "昨日の夜"@ja;
     rdfs:label     "night of Yesterday"@en;
     rdf:type    kgc:OFobj;
@@ -6386,7 +6390,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/Ready-made>
     rdf:type    kgc:Property;
-    rdfs:label     "既製品だった"@ja;
+    rdfs:label     "既製品"@ja;
     rdfs:label     "Ready-made"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/This_afternoon>
     rdf:type    kgc:AbstractTime;
@@ -6406,7 +6410,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "not持つ"@ja;
+    rdfs:label     "持たない"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/retire>
     rdf:type    kgc:Action;
@@ -6449,7 +6453,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goDown>
     rdf:type    kgc:Action;
-    rdfs:label     "降りる"@ja;
+    rdfs:label     "下りる"@ja;
     rdfs:label     "goDown"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/10_15_past>
     rdf:type    kgc:AbstractTime;
@@ -6501,7 +6505,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "think"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "嗅ぐ"@ja;
+    rdfs:label     "匂う"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/know>
     rdf:type    kgc:Action;
@@ -6524,9 +6528,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "sing"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着る"@ja;
+    rdfs:label     "着ている"@ja;
     rdfs:label     "wear"@en;
-    rdf:type    kgc:Action.
+    rdf:type    kgc:Action;
+    rdfs:label     "着る"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotSleep>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -6535,7 +6540,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cannotSleep"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/First_discoverer>
     rdf:type    kgc:Property;
-    rdfs:label     "第一発見者だった"@ja;
+    rdfs:label     "第一発見者"@ja;
     rdfs:label     "First discoverer"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fall>
     rdf:type    kgc:Action;
@@ -6674,7 +6679,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cook"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/contain>
     rdf:type    kgc:Action;
-    rdfs:label     "含む"@ja;
+    rdfs:label     "存在する"@ja;
     rdfs:label     "contain"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Motivation>
     rdfs:label     "Motivation"@en;
@@ -6782,7 +6787,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/silence>
     rdf:type    kgc:Action;
-    rdfs:label     "黙る"@ja;
+    rdfs:label     "沈黙する"@ja;
     rdfs:label     "silence"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/remember>
     rdf:type    kgc:Action;
@@ -6793,7 +6798,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/comeDown>
     rdf:type    kgc:Action;
-    rdfs:label     "下りてくる"@ja;
+    rdfs:label     "降りる"@ja;
     rdfs:label     "comeDown"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Outside_of_window>
     rdfs:label     "窓の外"@ja;
@@ -6991,7 +6996,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/the_hotel_Standale_stay_at_Plymouth>.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "集中している"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/property>
     rdfs:label     "財産"@ja;
@@ -7002,7 +7007,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/lookAround>
     rdf:type    kgc:Action;
-    rdfs:label     "ながめ回す"@ja;
+    rdfs:label     "見まわす"@ja;
     rdfs:label     "lookAround"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Emergency_message>
     rdfs:label     "緊急メッセージ"@ja;
@@ -7020,9 +7025,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Emotion"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/early_morning>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "朝早く"@ja;
-    rdfs:label     "early morning"@en.
+    rdfs:label     "early morning"@en;
+    rdf:type    kgc:AbstractTime.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Case_2>
     rdfs:label     "事件"@ja;
     rdfs:label     "Case 2"@en;
@@ -7039,7 +7044,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "したくない"@ja;
+    rdfs:label     "望まない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/After_death>
     rdfs:label     "After death"@en;
@@ -7053,9 +7058,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Quickly"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/After_his_exit>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "彼の退出後"@ja;
-    rdfs:label     "After his exit"@en.
+    rdfs:label     "After his exit"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotDo>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -7069,15 +7074,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/George>
     rdfs:label     "ジョージ"@ja;
     rdfs:label     "George"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/predicate/burn>
     rdf:type    kgc:Action;
-    rdfs:label     "燃やされる"@ja;
-    rdfs:label     "burn"@en.
+    rdfs:label     "燃える"@ja;
+    rdfs:label     "burn"@en;
+    rdfs:label     "燃やされる"@ja.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Toridnik_Wasa>
     rdfs:label     "トリダニック・ワーサ"@ja;
     rdfs:label     "Toridnik Wasa"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place.
 <http://kgc.knowledge-graph.jp/data/predicate/Agree>
     rdfs:label     "Agree"@en;
     rdf:type    kgc:Object.
@@ -7087,7 +7093,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/arrive>
     rdf:type    kgc:Action;
     rdfs:label     "到着する"@ja;
-    rdfs:label     "arrive"@en.
+    rdfs:label     "arrive"@en;
+    rdfs:label     "来る"@ja.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottages>
     rdfs:label     "cottages"@en;
     rdf:type    kgc:Object.
@@ -7162,8 +7169,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda>.
 <http://kgc.knowledge-graph.jp/data/predicate/walk>
     rdf:type    kgc:Action;
-    rdfs:label     "歩く"@ja;
-    rdfs:label     "walk"@en.
+    rdfs:label     "散歩する"@ja;
+    rdfs:label     "walk"@en;
+    rdfs:label     "歩く"@ja.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/garden_of_pastoral_hall>
     rdfs:label     "牧師館の庭"@ja;
     rdfs:label     "garden of pastoral hall"@en;
@@ -7264,7 +7272,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "tragic"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Have>
     rdfs:label     "Have"@en;
-    rdfs:label     "持つ"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/fire>
     rdfs:label     "火"@ja;
@@ -7283,7 +7290,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/George>.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上る"@ja;
+    rdfs:label     "上がる"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/die>
     rdf:type    kgc:Action;
@@ -7357,9 +7364,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Case 1"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Yesterday_evening>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "昨日の晩"@ja;
-    rdfs:label     "Yesterday evening"@en.
+    rdfs:label     "Yesterday evening"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/shock>
     rdfs:label     "ショック"@ja;
     rdfs:label     "shock"@en;
@@ -7419,7 +7426,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "滞在する"@ja;
+    rdfs:label     "留まる"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/opinion_of_Brenda>
     rdfs:label     "ブレンダの意見"@ja;
@@ -7482,24 +7489,25 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "呼ぶ"@ja;
     rdfs:label     "call"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay>
+    rdf:type    kgc:Person;
     rdfs:label     "ラウンドヘイ"@ja;
-    rdfs:label     "Roundhay"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Roundhay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/greedy>
     rdf:type    kgc:Property;
     rdfs:label     "欲深い"@ja;
     rdfs:label     "greedy"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/What_year>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "何年"@ja;
-    rdfs:label     "What year"@en.
+    rdfs:label     "What year"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale_s_guess>
     rdfs:label     "Standale's guess"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
     rdfs:label     "開く"@ja;
-    rdfs:label     "open"@en.
+    rdfs:label     "open"@en;
+    rdfs:label     "開ける"@ja.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Exterior>
     rdfs:label     "Exterior"@en;
     rdf:type    kgc:Object.
@@ -7585,9 +7593,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Evil thing"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/last>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "最後"@ja;
-    rdfs:label     "last"@en.
+    rdfs:label     "last"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/beBorn>
     rdf:type    kgc:Action;
     rdfs:label     "生まれる"@ja;
@@ -7691,7 +7699,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notHear>
     rdf:type    kgc:Action;
@@ -7710,6 +7718,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "both sides"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer>
+    rdf:type    kgc:Person;
     rdfs:label     "モーティマー"@ja;
-    rdfs:label     "Mortimer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Mortimer"@en.

--- a/ResidentPatient.ttl
+++ b/ResidentPatient.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -390,7 +390,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Percy Trevelyan lives in Brooklyn, the city four hundred and three address"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/Percy_Trevelyan> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/ResidentPatient/_> .
+    kgc:where   <http://kgc.knowledge-graph.jp/data/ResidentPatient/403_Brooklyn_Street> .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/024>
     rdf:type    kgc:Situation ;
     kgc:source  "ワトソンは以下を確認した"@ja ;
@@ -429,11 +429,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ResidentPatient/030> .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/028>
     rdf:type    kgc:Situation ;
-    kgc:source  "'妙な事件がパーシィ・トリヴェリアンの自宅で立て続けに起こった"@ja .
+    kgc:source  "妙な事件がパーシィ・トリヴェリアンの自宅で立て続けに起こった"@ja .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/028>
     rdf:type    kgc:Statement ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/StrangeIncident> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/StrangeIncident> .
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/028>
+    rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/happen> .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/028>
     rdf:type    kgc:Situation ;
@@ -809,7 +811,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/051> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/052> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/053> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/strange> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/strange> .
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/#REF_>
+    rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ResidentPatient/055> .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/055>
     rdf:type    kgc:Situation ;
@@ -1653,10 +1657,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/153>
     rdf:type    kgc:Situation ;
     kgc:source  "触られたものや盗まれたものはなかった"@ja ;
-    kgc:source  "'"@en .
+    kgc:source  "Nothing was touched or stolen"@en .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/153>
     rdf:type    kgc:Situation ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/touched> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/touched> .
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/153>
+    rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/stolen> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notExist> .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/154>
@@ -1939,7 +1945,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/186>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはもの問いたげな様子であった"@ja ;
-    kgc:source  "'"@en .
+    kgc:source  "Holmes seemed to be asking"@en .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/186>
     rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/Holmes> ;
@@ -2060,7 +2066,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "初老の男は強硬症の振りをした"@ja ;
     kgc:source  "An elderly man was pretending of catalepsy"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ResidentPatient/Elderly_man> ;
-    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pretend> ;
+    kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pretend> .
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/199>
+    rdf:type    kgc:Situation ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ResidentPatient/catalepsy> .
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/200>
     rdf:type    kgc:Situation ;
@@ -3164,13 +3172,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "言う"@ja;
     rdfs:label     "say"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/screw>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ねじ"@ja;
-    rdfs:label     "screw"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "screw"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Cartwright>
+    rdf:type    kgc:Person;
     rdfs:label     "カートライト"@ja;
-    rdfs:label     "Cartwright"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Cartwright"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Some>
     rdfs:label     "Some"@en;
     rdf:type    kgc:Object.
@@ -3191,16 +3199,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "やがて"@ja;
     rdfs:label     "soon"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_morning_of_the_next_day>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "次の日の朝"@ja;
     rdfs:label     "The morning of the next day"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_morning>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_next_day>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Baker_Street>
+    rdf:type    kgc:Place;
     rdfs:label     "ベイカー街"@ja;
-    rdfs:label     "Baker Street"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Baker Street"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/symptoms>
     rdfs:label     "症状"@ja;
     rdfs:label     "symptoms"@en;
@@ -3232,14 +3239,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "無表情である"@ja;
     rdfs:label     "expressionless"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Corpses_enclosed_the_neck>
+    rdf:type    kgc:Person;
     rdfs:label     "首をくくった死体"@ja;
-    rdfs:label     "Corpses enclosed the neck"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Corpses enclosed the neck"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/spoil>
     rdf:type    kgc:Action;
     rdfs:label     "損なう"@ja;
     rdfs:label     "spoil"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/end_of_a_line>
+    rdf:type    kgc:Place;
     rdfs:label     "最後尾"@ja;
     rdfs:label     "end of a line"@en;
     rdf:type    kgc:OFobj;
@@ -3254,10 +3262,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "招き入れる"@ja;
     rdfs:label     "inviteIn"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Same_time_tonight>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "今晩の同じ時刻"@ja;
-    rdfs:label     "Same time tonight"@en.
+    rdfs:label     "Same time tonight"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Wall_of_Blessington_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブレッシントンの部屋の壁"@ja;
     rdfs:label     "Wall of Blessington room"@en;
     rdf:type    kgc:OFobj;
@@ -3274,16 +3283,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "成功する"@ja;
     rdfs:label     "succeed"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Hand_of_Percy_Trevelyan>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "パーシィ・トリヴェリアンの手"@ja;
     rdfs:label     "Hand of Percy Trevelyan"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Hand>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Percy_Trevelyan>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Wide_stairs>
+    rdf:type    kgc:Place;
     rdfs:label     "広い階段"@ja;
-    rdfs:label     "Wide stairs"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Wide stairs"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Expression_of_Percy_Trevelyan>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "パーシィ・トリヴェリアンの表情"@ja;
     rdfs:label     "Expression of Percy Trevelyan"@en;
     rdf:type    kgc:OFobj;
@@ -3293,12 +3304,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Imprisonment"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Furniture>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "調度"@ja;
-    rdfs:label     "Furniture"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Furniture"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "徘徊する"@ja;
+    rdfs:label     "歩き回る"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Helper_boy>
     rdf:type    kgc:Property;
@@ -3315,9 +3326,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Rigid condition"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/while_Examination>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "診察中"@ja;
-    rdfs:label     "while Examination"@en.
+    rdfs:label     "while Examination"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Instead>
     rdfs:label     "Instead"@en;
     rdf:type    kgc:Object.
@@ -3334,6 +3345,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "神経質である"@ja;
     rdfs:label     "nervous"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/face_of_young_man>
+    rdf:type    kgc:Person;
     rdfs:label     "若い男の顔"@ja;
     rdfs:label     "face of young man"@en;
     rdf:type    kgc:OFobj;
@@ -3343,17 +3355,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Four"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Examination_room>
+    rdf:type    kgc:Place;
     rdfs:label     "診察室"@ja;
-    rdfs:label     "Examination room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Examination room"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/imported>
     rdf:type    kgc:Property;
     rdfs:label     "輸入された代物である"@ja;
     rdfs:label     "imported"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Sutton>
+    rdf:type    kgc:Person;
     rdfs:label     "サットン"@ja;
-    rdfs:label     "Sutton"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Sutton"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Sounds>
     rdfs:label     "物音"@ja;
     rdfs:label     "Sounds"@en;
@@ -3366,6 +3378,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "取り付けなければならない"@ja;
     rdfs:label     "mustAttach"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Face_of_elderly_man>
+    rdf:type    kgc:Person;
     rdfs:label     "初老の男の顔"@ja;
     rdfs:label     "Face of elderly man"@en;
     rdf:type    kgc:OFobj;
@@ -3383,7 +3396,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/tall>
     rdf:type    kgc:Property;
-    rdfs:label     "背が高い"@ja;
+    rdfs:label     "高い"@ja;
     rdfs:label     "tall"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/cigar_pipe>
     rdfs:label     "葉巻パイプ"@ja;
@@ -3394,12 +3407,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/obtain>
     rdf:type    kgc:Action;
-    rdfs:label     "得する"@ja;
+    rdfs:label     "手に入れる"@ja;
     rdfs:label     "obtain"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/police_officer>
+    rdf:type    kgc:Person;
     rdfs:label     "警察官"@ja;
-    rdfs:label     "police officer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "police officer"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_Russian_parent_and_child>
     rdfs:label     "the Russian parent and child"@en;
     rdf:type    kgc:Object.
@@ -3408,9 +3421,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "閉まっている"@ja;
     rdfs:label     "close"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Every_night,_same_time>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "毎晩、同じ時間"@ja;
-    rdfs:label     "Every night, same time"@en.
+    rdfs:label     "Every night, same time"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/need>
     rdf:type    kgc:Property;
     rdfs:label     "必要とする"@ja;
@@ -3421,17 +3434,14 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/end>
     rdfs:label     "end"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ResidentPatient/_>
-    rdfs:label     "ブルックリン街四〇三番地"@ja;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/scary>
     rdf:type    kgc:Property;
     rdfs:label     "恐ろしげである"@ja;
     rdfs:label     "scary"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Someone>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "誰か"@ja;
-    rdfs:label     "Someone"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Someone"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/lack>
     rdf:type    kgc:Property;
     rdfs:label     "欠ける"@ja;
@@ -3499,6 +3509,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "待つ"@ja;
     rdfs:label     "wait"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/hand_of_Young_man>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "若い男の手"@ja;
     rdfs:label     "hand of Young man"@en;
     rdf:type    kgc:OFobj;
@@ -3520,9 +3531,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "救う"@ja;
     rdfs:label     "save"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Ten_years_later>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "10年後"@ja;
-    rdfs:label     "Ten years later"@en.
+    rdfs:label     "Ten years later"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/notKnow>
     rdf:type    kgc:Property;
     rdfs:label     "知らない"@ja;
@@ -3554,19 +3565,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Hand"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Elderly_man_and_Young_man>
+    rdf:type    kgc:Person;
     rdfs:label     "初老の男と若い男"@ja;
-    rdfs:label     "Elderly man and Young man"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Elderly man and Young man"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Moderator_of_Tobin>
+    rdf:type    kgc:Person;
     rdfs:label     "トウビンという管理人"@ja;
     rdfs:label     "Moderator of Tobin"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Moderator>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Tobin>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Russian_nobility>
+    rdf:type    kgc:Person;
     rdfs:label     "ロシア貴族"@ja;
-    rdfs:label     "Russian nobility"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Russian nobility"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Sutton>
     rdf:type    kgc:Property;
     rdfs:label     "サットン"@ja;
@@ -3588,13 +3600,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Event"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington_bedroom>
+    rdf:type    kgc:Place;
     rdfs:label     "ブレッシントンの寝室"@ja;
-    rdfs:label     "Blessington bedroom"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Blessington bedroom"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/middle>
+    rdf:type    kgc:Place;
     rdfs:label     "真ん中"@ja;
-    rdfs:label     "middle"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "middle"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_contents_of_Circular>
     rdfs:label     "通達の内容"@ja;
     rdfs:label     "The contents of Circular"@en;
@@ -3612,9 +3624,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "覗く"@ja;
     rdfs:label     "peep"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_third_person>
+    rdf:type    kgc:Person;
     rdfs:label     "3番目の人物"@ja;
-    rdfs:label     "The third person"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "The third person"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/leave>
     rdf:type    kgc:Action;
     rdfs:label     "去る"@ja;
@@ -3627,9 +3639,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the major events"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Clinic>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "医院"@ja;
-    rdfs:label     "Clinic"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Clinic"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_length>
     rdfs:label     "the length"@en;
     rdf:type    kgc:Object.
@@ -3637,15 +3649,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "catalepsy"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Gold_to_hire_the_appearance_of_a_good_coach>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "体裁の良い馬車を雇う金"@ja;
     rdfs:label     "Gold to hire the appearance of a good coach"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Gold_to_hire_the_appearance>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/a_good_coach>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/bed>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "寝台"@ja;
-    rdfs:label     "bed"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bed"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/unexpected_events>
     rdfs:label     "思いがけない出来事"@ja;
     rdfs:label     "unexpected events"@en;
@@ -3655,17 +3668,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "外出中である"@ja;
     rdfs:label     "out"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Specified_time>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "指定の時刻"@ja;
-    rdfs:label     "Specified time"@en.
-<http://kgc.knowledge-graph.jp/data/ResidentPatient/Brook_Street>
-    rdfs:label     "ブルック街"@ja;
-    rdfs:label     "Brook Street"@en;
+    rdfs:label     "Specified time"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/Brook_Street>
+    rdf:type    kgc:Place;
+    rdfs:label     "ブルック街"@ja;
+    rdfs:label     "Brook Street"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington>
     rdfs:label     "Blessington"@en;
-    rdfs:label     "ブレッシントン"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person;
+    rdfs:label     "ブレッシントン"@ja.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Director_of_doctor>
     rdfs:label     "医者の監督"@ja;
     rdfs:label     "Director of doctor"@en;
@@ -3673,15 +3686,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Director>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/doctor>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Door_of_the_hall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "広間の戸"@ja;
     rdfs:label     "Door of the hall"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Door>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_hall>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Near_the_corpse>
+    rdf:type    kgc:Place;
     rdfs:label     "死体のそば"@ja;
-    rdfs:label     "Near the corpse"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Near the corpse"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Blessington>
     rdf:type    kgc:Property;
     rdfs:label     "ブレッシントン"@ja;
@@ -3691,14 +3705,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "警察官"@ja;
     rdfs:label     "police officer"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Percy_Trevelyan>
+    rdf:type    kgc:Person;
     rdfs:label     "パーシィ・トリヴェリアン"@ja;
     rdfs:label     "Percy Trevelyan"@en;
-    rdfs:label     "パーシィ・トリヴェリアンの顔色"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "パーシィ・トリヴェリアンの顔色"@ja.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/invader>
+    rdf:type    kgc:Person;
     rdfs:label     "侵入者"@ja;
-    rdfs:label     "invader"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "invader"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Daily_routine>
     rdfs:label     "Daily routine"@en;
     rdf:type    kgc:Object.
@@ -3708,12 +3722,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hide"@en;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Robbery_of_the_indentation>
+    rdf:type    kgc:Person;
     rdfs:label     "押し込みの強盗"@ja;
     rdfs:label     "Robbery of the indentation"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Robbery>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_indentation>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Evidence_of_the_major_events_of_Worthingdon_bank>
+    rdf:type    kgc:Person;
     rdfs:label     "ワーシンドン銀行の大事件の証拠"@ja;
     rdfs:label     "Evidence of the major events of Worthingdon bank"@en;
     rdf:type    kgc:OFobj;
@@ -3745,18 +3761,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受け取る"@ja;
+    rdfs:label     "受ける"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Among_the_keyhole>
+    rdf:type    kgc:Place;
     rdfs:label     "鍵穴のなか"@ja;
-    rdfs:label     "Among the keyhole"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Among the keyhole"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/those>
     rdfs:label     "those"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/overlap>
     rdf:type    kgc:Property;
-    rdfs:label     "重なった"@ja;
+    rdfs:label     "重なる"@ja;
     rdfs:label     "overlap"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/intend>
     rdf:type    kgc:Action;
@@ -3766,9 +3782,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Room"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/waiting_room>
+    rdf:type    kgc:Place;
     rdfs:label     "待合室"@ja;
-    rdfs:label     "waiting room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "waiting room"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/a_line>
     rdfs:label     "a line"@en;
     rdf:type    kgc:Object.
@@ -3781,29 +3797,30 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Stretched back"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/last_night>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "昨夜"@ja;
-    rdfs:label     "last night"@en.
+    rdfs:label     "last night"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Cigar_purse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "葉巻入れ"@ja;
     rdfs:label     "Cigar purse"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Sleepwear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "寝間着"@ja;
-    rdfs:label     "Sleepwear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Sleepwear"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Own_identity>
     rdfs:label     "自身の素性"@ja;
     rdfs:label     "Own identity"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Aspiring_specialists>
+    rdf:type    kgc:Person;
     rdfs:label     "志ある専門医"@ja;
-    rdfs:label     "Aspiring specialists"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Aspiring specialists"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/touched>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "触れられたもの"@ja;
-    rdfs:label     "touched"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "touched"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Consultation_of_Blessington>
     rdfs:label     "ブレッシントンの相談"@ja;
     rdfs:label     "Consultation of Blessington"@en;
@@ -3825,6 +3842,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cigar butts"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Four_of_cigar_butts>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "4つの葉巻の吸い殻"@ja;
     rdfs:label     "Four of cigar butts"@en;
     rdf:type    kgc:OFobj;
@@ -3842,43 +3860,43 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "止める"@ja;
     rdfs:label     "stop"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Lanner_Inspector>
+    rdf:type    kgc:Person;
     rdfs:label     "ラーナ警部"@ja;
-    rdfs:label     "Lanner Inspector"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Lanner Inspector"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Worthington_bank_Robbers>
+    rdf:type    kgc:Person;
     rdfs:label     "ワージントン銀行の強盗団"@ja;
-    rdfs:label     "Worthington bank Robbers"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Worthington bank Robbers"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/command>
     rdf:type    kgc:Action;
-    rdfs:label     "指揮を執る"@ja;
+    rdfs:label     "命令する"@ja;
     rdfs:label     "command"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Own_room_safe>
+    rdf:type    kgc:Place;
     rdfs:label     "自身の部屋の金庫"@ja;
-    rdfs:label     "Own room safe"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Own room safe"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Stairs>
+    rdf:type    kgc:Place;
     rdfs:label     "階段"@ja;
-    rdfs:label     "Stairs"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Stairs"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/note>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/e>;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "メモする"@ja;
     rdfs:label     "note"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "椅子"@ja;
-    rdfs:label     "Chair"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Chair"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/something>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "何か"@ja;
-    rdfs:label     "something"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "something"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Street_address>
+    rdf:type    kgc:Place;
     rdfs:label     "住所"@ja;
-    rdfs:label     "Street address"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Street address"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Tell>
     rdfs:label     "Tell"@en;
     rdf:type    kgc:Object.
@@ -3900,7 +3918,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "steal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/revenge>
     rdf:type    kgc:Action;
-    rdfs:label     "仇討ちをする"@ja;
+    rdfs:label     "やり返す"@ja;
     rdfs:label     "revenge"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Body_temperature>
     rdfs:label     "Body temperature"@en;
@@ -3936,16 +3954,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hand"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/3_hours_ago>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "三時間前"@ja;
-    rdfs:label     "3 hours ago"@en.
+    rdfs:label     "3 hours ago"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Worthingdon_bank>
     rdfs:label     "Worthingdon bank"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "葉巻"@ja;
-    rdfs:label     "cigar"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cigar"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Mere_theft>
     rdfs:label     "単なる窃盗"@ja;
     rdfs:label     "Mere theft"@en;
@@ -3975,10 +3993,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Larger than the footprint"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Front_door>
+    rdf:type    kgc:Place;
     rdfs:label     "正面玄関"@ja;
-    rdfs:label     "Front door"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Front door"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Some_of_the_cities_of_the_jacket>
+    rdf:type    kgc:Place;
     rdfs:label     "上着のかくしのなか"@ja;
     rdfs:label     "Some of the cities of the jacket"@en;
     rdf:type    kgc:OFobj;
@@ -3987,9 +4006,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_cities>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_jacket>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/paper_about_neurological_disorders>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "神経障害についての論文"@ja;
-    rdfs:label     "paper about neurological disorders"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "paper about neurological disorders"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/ice>
     rdfs:label     "ice"@en;
     rdf:type    kgc:Object.
@@ -4006,37 +4025,38 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/enter>
     rdf:type    kgc:Action;
     rdfs:label     "入る"@ja;
-    rdfs:label     "enter"@en.
+    rdfs:label     "enter"@en;
+    rdfs:label     "入れる"@ja.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/house>
+    rdf:type    kgc:Place;
     rdfs:label     "家の中"@ja;
-    rdfs:label     "house"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "house"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/living_expenses>
     rdfs:label     "living expenses"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/letter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙"@ja;
-    rdfs:label     "letter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "letter"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/neck>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "首"@ja;
-    rdfs:label     "neck"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "neck"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/carpet>
     rdfs:label     "carpet"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/5_am>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "朝５時"@ja;
-    rdfs:label     "5 am"@en.
-<http://kgc.knowledge-graph.jp/data/ResidentPatient/5th_man>
-    rdfs:label     "5人目の男"@ja;
-    rdfs:label     "5th man"@en;
+    rdfs:label     "5 am"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/5th_man>
+    rdf:type    kgc:Person;
+    rdfs:label     "5人目の男"@ja;
+    rdfs:label     "5th man"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/question>
     rdfs:label     "question"@en;
     rdf:type    kgc:Object.
@@ -4058,9 +4078,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "date"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/door>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "扉"@ja;
-    rdfs:label     "door"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "door"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/dead>
     rdf:type    kgc:Property;
     rdfs:label     "死んでいる"@ja;
@@ -4078,7 +4098,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "要求する"@ja;
+    rdfs:label     "依頼する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/invest>
     rdf:type    kgc:Action;
@@ -4094,21 +4114,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "信用しない"@ja;
     rdfs:label     "notTrust"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/tobacco>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "煙草"@ja;
-    rdfs:label     "tobacco"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "tobacco"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Source_Date>
     rdfs:label     "出所日"@ja;
     rdfs:label     "Source Date"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_best_two_rooms_located_on_the_second_floor>
+    rdf:type    kgc:Place;
     rdfs:label     "二階にある一番良い部屋二室"@ja;
-    rdfs:label     "The best two rooms located on the second floor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "The best two rooms located on the second floor"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/After_exiting>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "出た後"@ja;
-    rdfs:label     "After exiting"@en.
+    rdfs:label     "After exiting"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/shouldVisit>
     rdf:type    kgc:Property;
     rdfs:label     "訪問すべき"@ja;
@@ -4165,6 +4185,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "伝えない"@ja;
     rdfs:label     "notTell"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Two-thirds_of_earnings>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "稼ぎの３分の２"@ja;
     rdfs:label     "Two-thirds of earnings"@en;
     rdf:type    kgc:OFobj;
@@ -4185,6 +4206,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Robbery"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_rest_of_the_gold>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "残りの金"@ja;
     rdfs:label     "The rest of the gold"@en;
     rdf:type    kgc:OFobj;
@@ -4211,6 +4233,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "勧める"@ja;
     rdfs:label     "recommend"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Money_of_Blessington>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブレッシントンの金"@ja;
     rdfs:label     "Money of Blessington"@en;
     rdf:type    kgc:OFobj;
@@ -4226,9 +4249,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "用意できない"@ja;
     rdfs:label     "cannotProvide"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/discovery>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "発見時"@ja;
-    rdfs:label     "discovery"@en.
+    rdfs:label     "discovery"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/manage>
     rdf:type    kgc:Action;
     rdfs:label     "管理する"@ja;
@@ -4238,12 +4261,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "萎える"@ja;
     rdfs:label     "wither"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/black_trousers>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "黒めのズボン"@ja;
-    rdfs:label     "black trousers"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "black trousers"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪れる"@ja;
+    rdfs:label     "訪ねる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -4257,20 +4280,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "飛び込む"@ja;
     rdfs:label     "jumpInto"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Outpatients>
+    rdf:type    kgc:Person;
     rdfs:label     "外来の患者"@ja;
-    rdfs:label     "Outpatients"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Outpatients"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington_bed>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブレッシントンの寝台"@ja;
-    rdfs:label     "Blessington bed"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Blessington bed"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/a_good_coach>
     rdfs:label     "a good coach"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/living_person>
+    rdf:type    kgc:Person;
     rdfs:label     "同居者"@ja;
-    rdfs:label     "living person"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "living person"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Answer>
     rdfs:label     "Answer"@en;
     rdf:type    kgc:Object.
@@ -4282,13 +4305,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Story"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Helper_boy>
+    rdf:type    kgc:Person;
     rdfs:label     "手伝いの少年"@ja;
-    rdfs:label     "Helper boy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Helper boy"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Means>
     rdfs:label     "Means"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Dress_of_Percy_Trevelyan>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "パーシィ・トリヴェリアンの服装"@ja;
     rdfs:label     "Dress of Percy Trevelyan"@en;
     rdf:type    kgc:OFobj;
@@ -4308,6 +4332,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "静まる"@ja;
     rdfs:label     "subside"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/chest_of_Young_man>
+    rdf:type    kgc:Person;
     rdfs:label     "若い男の胸"@ja;
     rdfs:label     "chest of Young man"@en;
     rdf:type    kgc:OFobj;
@@ -4320,14 +4345,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Guess>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Watson>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Black_frock_coat>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "黒いフロック・コート"@ja;
-    rdfs:label     "Black frock coat"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Black frock coat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotFind>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つからない"@ja;
+    rdfs:label     "見つけられない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Young_man>
     rdfs:label     "Young man"@en;
@@ -4368,6 +4393,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "落とす"@ja;
     rdfs:label     "drop"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/butts_of_Cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "吸い殻の葉巻"@ja;
     rdfs:label     "butts of Cigar"@en;
     rdf:type    kgc:OFobj;
@@ -4377,9 +4403,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Tobin"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Few_weeks_ago>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "何週間か前"@ja;
-    rdfs:label     "Few weeks ago"@en.
+    rdfs:label     "Few weeks ago"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_strength>
     rdfs:label     "The strength"@en;
     rdf:type    kgc:Object.
@@ -4393,7 +4419,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "two butts"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Pm_six_of_the_next_day_tens_of_around_five_minutes>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "次の日の午後六時十五分頃"@ja;
     rdfs:label     "Pm six of the next day tens of around five minutes"@en;
     rdf:type    kgc:OFobj;
@@ -4411,6 +4436,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the incident"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/One_of_the_cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "一本の葉巻"@ja;
     rdfs:label     "One of the cigar"@en;
     rdf:type    kgc:OFobj;
@@ -4427,32 +4453,31 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "取りに行く"@ja;
     rdfs:label     "goToGet"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Expenditure_for_furnishings>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "調度のための支出"@ja;
-    rdfs:label     "Expenditure for furnishings"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Expenditure for furnishings"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Time_of_the_incident>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "事件の時"@ja;
     rdfs:label     "Time of the incident"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Time>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_incident>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/1875>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "１８７５年"@ja;
-    rdfs:label     "1875"@en.
+    rdfs:label     "1875"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Two-thirds>
     rdfs:label     "Two-thirds"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/shoulder>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "肩"@ja;
-    rdfs:label     "shoulder"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "shoulder"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notHave>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "not持つ"@ja;
+    rdfs:label     "持たない"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/new>
     rdf:type    kgc:Property;
@@ -4475,12 +4500,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ではない"@ja;
     rdfs:label     "notEqualTo"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Pistol>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "拳銃"@ja;
-    rdfs:label     "Pistol"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Pistol"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "しようとする"@ja;
+    rdfs:label     "試みる"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notListen>
     rdf:type    kgc:Action;
@@ -4499,9 +4524,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "tools hanging stand"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/others>
+    rdf:type    kgc:Person;
     rdfs:label     "初老の男と若い男とそれ以外の男"@ja;
-    rdfs:label     "others"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "others"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Again>
     rdfs:label     "再び"@ja;
     rdfs:label     "Again"@en;
@@ -4510,9 +4535,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Voice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Scratch>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "引っかき傷"@ja;
-    rdfs:label     "Scratch"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Scratch"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/StrangeIncident>
     rdfs:label     "妙な事件"@ja;
     rdfs:label     "StrangeIncident"@en;
@@ -4522,14 +4547,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "使う"@ja;
     rdfs:label     "use"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/within_25_minutes>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "出発して25分以内"@ja;
-    rdfs:label     "within 25 minutes"@en.
+    rdfs:label     "within 25 minutes"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/thin>
     rdf:type    kgc:Property;
     rdfs:label     "細い"@ja;
     rdfs:label     "thin"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Room_of_Percy_Trevelyan>
+    rdf:type    kgc:Place;
     rdfs:label     "パーシィ・トリヴェリアンの部屋"@ja;
     rdfs:label     "Room of Percy Trevelyan"@en;
     rdf:type    kgc:OFobj;
@@ -4540,20 +4566,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "すくめる"@ja;
     rdfs:label     "shrug"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/West_End_neighborhood>
+    rdf:type    kgc:Place;
     rdfs:label     "ウエスト・エンド界隈"@ja;
-    rdfs:label     "West End neighborhood"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "West End neighborhood"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/7,000_lbs>
     rdfs:label     "７０００ポンド"@ja;
     rdfs:label     "7,000 lbs"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Money>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "金"@ja;
-    rdfs:label     "Money"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Money"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/miserably>
     rdf:type    kgc:Property;
-    rdfs:label     "無残であった"@ja;
+    rdfs:label     "無残である"@ja;
     rdfs:label     "miserably"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/think>
     rdf:type    kgc:Action;
@@ -4565,7 +4591,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "know"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "嗅ぐ"@ja;
+    rdfs:label     "匂う"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/align>
     rdf:type    kgc:Action;
@@ -4575,13 +4601,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "The contents"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/after_5_minutes>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "5分後"@ja;
-    rdfs:label     "after 5 minutes"@en.
-<http://kgc.knowledge-graph.jp/data/ResidentPatient/lead>
-    rdfs:label     "先頭"@ja;
-    rdfs:label     "lead"@en;
+    rdfs:label     "after 5 minutes"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/lead>
+    rdf:type    kgc:Place;
+    rdfs:label     "先頭"@ja;
+    rdfs:label     "lead"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Seem>
     rdfs:label     "Seem"@en;
     rdf:type    kgc:Object.
@@ -4598,16 +4624,16 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/reveal>
     rdf:type    kgc:Action;
-    rdfs:label     "明かす"@ja;
+    rdfs:label     "明らかにする"@ja;
     rdfs:label     "reveal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着る"@ja;
+    rdfs:label     "着ている"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Account_book>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "帳簿"@ja;
-    rdfs:label     "Account book"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Account book"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_morning>
     rdfs:label     "The morning"@en;
     rdf:type    kgc:Object.
@@ -4632,9 +4658,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "獲得する"@ja;
     rdfs:label     "gain"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Brook_Street_house>
+    rdf:type    kgc:Place;
     rdfs:label     "ブルック街の住まい"@ja;
-    rdfs:label     "Brook Street house"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Brook Street house"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/weak>
     rdf:type    kgc:Property;
     rdfs:label     "弱い"@ja;
@@ -4679,17 +4705,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "叫ぶ"@ja;
     rdfs:label     "shout"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Footprint_of_carpet>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "絨毯の足跡"@ja;
     rdfs:label     "Footprint of carpet"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Footprint>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/carpet>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Young_man>
+    rdf:type    kgc:Person;
     rdfs:label     "若い男"@ja;
     rdfs:label     "Young man"@en;
     rdfs:label     "若い男の背"@ja;
-    rdfs:label     "初老の男と若い男とそれ以外の男"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "初老の男と若い男とそれ以外の男"@ja.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Doctor>
     rdfs:label     "医者"@ja;
     rdfs:label     "Doctor"@en;
@@ -4704,9 +4731,10 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_cities>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_jacket>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington_room>
+    rdf:type    kgc:Place;
     rdfs:label     "ブレッシントンの部屋"@ja;
     rdfs:label     "Blessington room"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/conviction>
     rdfs:label     "conviction"@en;
     rdf:type    kgc:Object.
@@ -4717,6 +4745,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/study>
     rdfs:label     "study"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ResidentPatient/403_Brooklyn_Street>
+    rdf:type    kgc:Place;
+    rdfs:label     "ブルックリン街四〇三番地"@ja;
+    rdfs:label     "403 Brooklyn Street"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Means_of_conviction>
     rdfs:label     "断罪の手段"@ja;
     rdfs:label     "Means of conviction"@en;
@@ -4731,9 +4763,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "butts"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Conspirators>
+    rdf:type    kgc:Person;
     rdfs:label     "共謀者"@ja;
-    rdfs:label     "Conspirators"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Conspirators"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_next_day_tens>
     rdfs:label     "the next day tens"@en;
     rdf:type    kgc:Object.
@@ -4745,10 +4777,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Notification"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Elderly_man>
+    rdf:type    kgc:Person;
     rdfs:label     "初老の男"@ja;
     rdfs:label     "Elderly man"@en;
-    rdfs:label     "初老の男と若い男とそれ以外の男"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "初老の男と若い男とそれ以外の男"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/sober>
     rdf:type    kgc:Property;
     rdfs:label     "地味である"@ja;
@@ -4758,15 +4790,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ハバナの香りがする"@ja;
     rdfs:label     "Habana flavored"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/until_3_o_clock>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "3時までに"@ja;
-    rdfs:label     "until 3 o'clock"@en.
+    rdfs:label     "until 3 o'clock"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/e>
     rdfs:label     "e"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/pale>
     rdf:type    kgc:Property;
-    rdfs:label     "真っ青である"@ja;
+    rdfs:label     "悪い"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/5_people>
     rdfs:label     "5人"@ja;
@@ -4777,9 +4809,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "悩む"@ja;
     rdfs:label     "worry"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/cadaver>
+    rdf:type    kgc:Person;
     rdfs:label     "死体"@ja;
-    rdfs:label     "cadaver"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cadaver"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/in_residence>
     rdf:type    kgc:Action;
     rdfs:label     "在留中である"@ja;
@@ -4789,9 +4821,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "挨拶する"@ja;
     rdfs:label     "greet"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Nitrous_acid_aluminum>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "亜硝酸アルミ"@ja;
-    rdfs:label     "Nitrous acid aluminum"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Nitrous acid aluminum"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/question_of_Holmes>
     rdfs:label     "ホームズの質問"@ja;
     rdfs:label     "question of Holmes"@en;
@@ -4811,9 +4843,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "happen"@en;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/always>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "常時"@ja;
-    rdfs:label     "always"@en.
+    rdfs:label     "always"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington_room>
     rdfs:label     "Blessington room"@en;
     rdf:type    kgc:Object.
@@ -4842,17 +4874,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Doctors"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/screwdriver>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ねじ回し"@ja;
-    rdfs:label     "screwdriver"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "screwdriver"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fail>
     rdf:type    kgc:Action;
     rdfs:label     "失敗する"@ja;
     rdfs:label     "fail"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Ash>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "灰"@ja;
-    rdfs:label     "Ash"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Ash"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Hanging_tied_a_string_to_the_bracket>
     rdfs:label     "金具に紐を結びつけてぶら下がって"@ja;
     rdfs:label     "Hanging tied a string to the bracket"@en;
@@ -4869,9 +4901,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "来る"@ja;
     rdfs:label     "come"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Twelve_city_near_Cavendish_Square>
+    rdf:type    kgc:Place;
     rdfs:label     "キャヴェンディッシュ・スクエア付近の十二の街"@ja;
-    rdfs:label     "Twelve city near Cavendish Square"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Twelve city near Cavendish Square"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Cartwright>
     rdf:type    kgc:Property;
     rdfs:label     "カートライトという"@ja;
@@ -4881,9 +4913,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "医者"@ja;
     rdfs:label     "doctor"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Wash_basin>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "洗面台"@ja;
-    rdfs:label     "Wash basin"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Wash basin"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Imprisonment_of_14_years>
     rdfs:label     "14年の禁錮"@ja;
     rdfs:label     "Imprisonment of 14 years"@en;
@@ -4891,6 +4923,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Imprisonment>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/14_years>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_identity_of_the_intruder>
+    rdf:type    kgc:Person;
     rdfs:label     "侵入者の正体"@ja;
     rdfs:label     "The identity of the intruder"@en;
     rdf:type    kgc:OFobj;
@@ -4904,9 +4937,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "自身のためのもの"@ja;
     rdfs:label     "for its own"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Door_key>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "戸の鍵"@ja;
-    rdfs:label     "Door key"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Door key"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/One>
     rdfs:label     "One"@en;
     rdf:type    kgc:Object.
@@ -4937,17 +4970,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "落ち着かない"@ja;
     rdfs:label     "restless"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/House>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家"@ja;
-    rdfs:label     "House"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "House"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sit>
     rdf:type    kgc:Action;
     rdfs:label     "座る"@ja;
     rdfs:label     "sit"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Downstairs_in_the_laboratory>
+    rdf:type    kgc:Place;
     rdfs:label     "階下の実験室"@ja;
-    rdfs:label     "Downstairs in the laboratory"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Downstairs in the laboratory"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/feelBad>
     rdf:type    kgc:Action;
     rdfs:label     "気を悪くする"@ja;
@@ -4968,19 +5001,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Young man"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Windows_and_doors>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "窓や扉"@ja;
-    rdfs:label     "Windows and doors"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Windows and doors"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Major_event_of_Worthingdon_bank>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "ワーシンドン銀行の大事件"@ja;
     rdfs:label     "Major event of Worthingdon bank"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:Person;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Major_event>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Worthingdon_bank>.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "集中している"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
@@ -4991,6 +5024,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "medical examination"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Out_of_the_window>
+    rdf:type    kgc:Place;
     rdfs:label     "窓の外"@ja;
     rdfs:label     "Out of the window"@en;
     rdf:type    kgc:OFobj;
@@ -5014,9 +5048,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "届く"@ja.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "残っていた葉巻"@ja;
-    rdfs:label     "Cigar"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Cigar"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Man_entered_the_room>
     rdfs:label     "Man entered the room"@en;
     rdf:type    kgc:Object.
@@ -5024,9 +5058,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "member"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/tieSlightlyWithColor>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "わずかに色のあるネクタイ"@ja;
-    rdfs:label     "tieSlightlyWithColor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "tieSlightlyWithColor"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/People>
     rdfs:label     "人々"@ja;
     rdfs:label     "People"@en;
@@ -5043,17 +5077,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "である"@ja;
     rdfs:label     "equalTo"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/East_Indies_colonial>
+    rdf:type    kgc:Place;
     rdfs:label     "東インドの植民地"@ja;
-    rdfs:label     "East Indies colonial"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "East Indies colonial"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Police>
+    rdf:type    kgc:Person;
     rdfs:label     "警察"@ja;
-    rdfs:label     "Police"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Police"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/England>
+    rdf:type    kgc:Place;
     rdfs:label     "イングランド"@ja;
-    rdfs:label     "England"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "England"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotPredict>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -5068,9 +5102,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hard-line disease"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/stolen>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "盗まれたもの"@ja;
-    rdfs:label     "stolen"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "stolen"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Find>
     rdfs:label     "Find"@en;
     rdf:type    kgc:Object.
@@ -5112,17 +5146,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Life>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/patient>
+    rdf:type    kgc:Person;
     rdfs:label     "患者"@ja;
-    rdfs:label     "patient"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "patient"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Bank>
+    rdf:type    kgc:Place;
     rdfs:label     "銀行"@ja;
-    rdfs:label     "Bank"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bank"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Morning_7_o_clock>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "朝７時頃"@ja;
-    rdfs:label     "Morning 7 o'clock"@en.
+    rdfs:label     "Morning 7 o'clock"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/handOver>
     rdf:type    kgc:Action;
     rdfs:label     "渡す"@ja;
@@ -5132,9 +5166,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fact"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/One_morning>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "ある朝"@ja;
-    rdfs:label     "One morning"@en.
+    rdfs:label     "One morning"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/feel>
     rdf:type    kgc:Action;
     rdfs:label     "感じる"@ja;
@@ -5156,9 +5190,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the gold"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Upper_floor>
+    rdf:type    kgc:Place;
     rdfs:label     "階上"@ja;
-    rdfs:label     "Upper floor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Upper floor"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/walk_of_Blessington>
     rdfs:label     "walk of Blessington"@en;
     rdf:type    kgc:OFobj;
@@ -5168,18 +5202,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "the proposed street"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/2_days_ago>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "2日前"@ja;
-    rdfs:label     "2 days ago"@en.
+    rdfs:label     "2 days ago"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/prevent>
     rdf:type    kgc:Action;
-    rdfs:label     "妨げる"@ja;
+    rdfs:label     "防ぐ"@ja;
     rdfs:label     "prevent"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sneak>
     rdf:type    kgc:Action;
     rdfs:label     "侵入する"@ja;
     rdfs:label     "sneak"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/two_butts_of_Cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "2つの吸い殻"@ja;
     rdfs:label     "two butts of Cigar"@en;
     rdf:type    kgc:OFobj;
@@ -5192,9 +5227,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_contents>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_letter>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Five_shillings_and_three_pence_to_one_Ginyi>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "一ギニィに五シリングと三ペンス"@ja;
-    rdfs:label     "Five shillings and three pence to one Ginyi"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Five shillings and three pence to one Ginyi"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/around_five_minutes>
     rdfs:label     "around five minutes"@en;
     rdf:type    kgc:Object.
@@ -5206,29 +5241,31 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notSeem"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Have>
     rdfs:label     "Have"@en;
-    rdfs:label     "持つ"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/High-pitched_trembling_voice>
     rdfs:label     "甲高い震えた声"@ja;
     rdfs:label     "High-pitched trembling voice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Cigar_Pipes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "葉巻パイプ"@ja;
-    rdfs:label     "Cigar Pipes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Cigar Pipes"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Wheel_of_a_large_rope>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "大きな綱の輪"@ja;
     rdfs:label     "Wheel of a large rope"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Wheel>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/a_large_rope>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/carpet_of_Blessington_room>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブレッシントンの部屋の絨毯"@ja;
     rdfs:label     "carpet of Blessington room"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/carpet>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington_room>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Several_years_worth_of_living_expenses>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "数年分の生活費"@ja;
     rdfs:label     "Several years worth of living expenses"@en;
     rdf:type    kgc:OFobj;
@@ -5243,15 +5280,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Disgust"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Criminal>
+    rdf:type    kgc:Person;
     rdfs:label     "犯人"@ja;
-    rdfs:label     "Criminal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Criminal"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_heart>
     rdfs:label     "The heart"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上る"@ja;
+    rdfs:label     "上がる"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/irregular>
     rdf:type    kgc:Property;
@@ -5284,9 +5321,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "正面の平坦な家である"@ja;
     rdfs:label     "flat house front"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/someone>
+    rdf:type    kgc:Person;
     rdfs:label     "誰か"@ja;
-    rdfs:label     "someone"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "someone"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Suspicious_incidents>
     rdfs:label     "事件の疑わしい点"@ja;
     rdfs:label     "Suspicious incidents"@en;
@@ -5347,6 +5384,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ようである"@ja;
     rdfs:label     "seem"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Kind_of_butts_of_Cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "吸い殻の葉巻の種類"@ja;
     rdfs:label     "Kind of butts of Cigar"@en;
     rdf:type    kgc:OFobj;
@@ -5359,6 +5397,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "近寄る"@ja;
     rdfs:label     "approach"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Kind_of_Cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "残っていた葉巻の種類"@ja;
     rdfs:label     "Kind of Cigar"@en;
     rdf:type    kgc:OFobj;
@@ -5380,13 +5419,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Strange habit"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/maid>
+    rdf:type    kgc:Person;
     rdfs:label     "女中"@ja;
-    rdfs:label     "maid"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "maid"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Several_thousand_investment_gold>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "数千の投資金"@ja;
-    rdfs:label     "Several thousand investment gold"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Several thousand investment gold"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Facts>
     rdfs:label     "事実関係"@ja;
     rdfs:label     "Facts"@en;
@@ -5405,11 +5444,11 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Percy_Trevelyan>.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "立ち会う"@ja;
+    rdfs:label     "参加する"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/comeTrue>
     rdf:type    kgc:Property;
-    rdfs:label     "当たる"@ja;
+    rdfs:label     "的中する"@ja;
     rdfs:label     "comeTrue"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Conditions>
     rdfs:label     "Conditions"@en;
@@ -5430,6 +5469,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Morbidly"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Man_entered_the_room_of_Blessington>
+    rdf:type    kgc:Person;
     rdfs:label     "ブレッシントンの部屋に入った人間"@ja;
     rdfs:label     "Man entered the room of Blessington"@en;
     rdf:type    kgc:OFobj;
@@ -5444,17 +5484,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "立つ"@ja;
     rdfs:label     "stand"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Certain_large_rent>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "某大な賃料"@ja;
-    rdfs:label     "Certain large rent"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Certain large rent"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_heart_of_Blessington>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブレッシントンの心臓"@ja;
     rdfs:label     "The heart of Blessington"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/The_heart>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/After_the_daily_routine_of_a_walk>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "日課の散歩の後"@ja;
     rdfs:label     "After the daily routine of a walk"@en;
     rdf:type    kgc:OFobj;
@@ -5466,19 +5506,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "escape"@en;
     rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Own_room>
+    rdf:type    kgc:Place;
     rdfs:label     "自身の部屋"@ja;
-    rdfs:label     "Own room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Own room"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Another_two_butts_of_Cigar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "別の2つの吸い殻"@ja;
     rdfs:label     "Another two butts of Cigar"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Another_two_butts>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Cigar>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/third_time>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "三回目"@ja;
-    rdfs:label     "third time"@en.
+    rdfs:label     "third time"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/mustOpen>
     rdf:type    kgc:Property;
     rdfs:label     "開業しなければならない"@ja;
@@ -5500,12 +5541,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "suck"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/insist>
     rdf:type    kgc:Action;
-    rdfs:label     "言い張る"@ja;
+    rdfs:label     "主張する"@ja;
     rdfs:label     "insist"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
     rdfs:label     "開く"@ja;
-    rdfs:label     "open"@en.
+    rdfs:label     "open"@en;
+    rdfs:label     "開業する"@ja;
+    rdfs:label     "開ける"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/pretend>
     rdf:type    kgc:Action;
     rdfs:label     "振りをする"@ja;
@@ -5519,9 +5562,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "硬化症"@ja;
     rdfs:label     "sclerosis"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/that_day>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "その日"@ja;
-    rdfs:label     "that day"@en.
+    rdfs:label     "that day"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/clever_way>
     rdfs:label     "巧妙に仕組まれた方法で"@ja;
     rdfs:label     "clever way"@en;
@@ -5547,9 +5590,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Several years worth"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Watson>
+    rdf:type    kgc:Person;
     rdfs:label     "ワトソン"@ja;
-    rdfs:label     "Watson"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watson"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_rope>
     rdfs:label     "the rope"@en;
     rdf:type    kgc:Object.
@@ -5591,12 +5634,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "feelFear"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Footprint>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "足跡"@ja;
-    rdfs:label     "Footprint"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Footprint"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/desperate>
     rdf:type    kgc:Property;
-    rdfs:label     "切羽詰まっていた"@ja;
+    rdfs:label     "切羽詰まっている"@ja;
     rdfs:label     "desperate"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Pulse_of_Elderly_man>
     rdfs:label     "初老の男の脈拍"@ja;
@@ -5613,16 +5656,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ResidentPatient/the_major_events>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Worthingdon_bank>.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/During_the_week_from_the_incident>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "事件から一週間の間"@ja;
-    rdfs:label     "During the week from the incident"@en.
+    rdfs:label     "During the week from the incident"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/fix>
     rdf:type    kgc:Action;
     rdfs:label     "固定する"@ja;
     rdfs:label     "fix"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Property;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en;
     rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/prospect>
@@ -5630,9 +5673,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "見通しがつく"@ja;
     rdfs:label     "prospect"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/fireplace>
+    rdf:type    kgc:Place;
     rdfs:label     "暖炉"@ja;
-    rdfs:label     "fireplace"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "fireplace"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Wall>
     rdfs:label     "Wall"@en;
     rdf:type    kgc:Object.
@@ -5658,8 +5701,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Obex>
     rdfs:label     "閂"@ja;
     rdfs:label     "Obex"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
-    rdfs:label     "Holmes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Holmes"@en.

--- a/SilverBlaze.ttl
+++ b/SilverBlaze.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -3237,7 +3237,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/338>
     rdf:type    kgc:Situation ;
     kgc:source  "白銀号の名前は競走加入者表に書かれていた"@ja ;
-    kgc:source  "The name 'Silver Blaze' was written in race subscriber table"@en ;
+    kgc:source  "The name Silver Blaze was written in race subscriber table"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_name_of_the_Silver_Blaze> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Competition_subscriber_table> ;
@@ -3807,9 +3807,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "言う"@ja;
     rdfs:label     "say"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Inspector_Gregory>
+    rdf:type    kgc:Person;
     rdfs:label     "グレゴリ警部"@ja;
-    rdfs:label     "Inspector Gregory"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Inspector Gregory"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Spirit_of_the_duplicate_key_possession>
     rdfs:label     "合鍵所持の真意"@ja;
     rdfs:label     "Spirit of the duplicate key possession"@en;
@@ -3832,7 +3832,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Ned_Hunter_and_two_young_men>
     rdfs:label     "ネッド・ハンターと２人の若者"@ja;
     rdfs:label     "Ned Hunter and two young men"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/predicate/notWork>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -3862,7 +3862,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/bring>
     rdf:type    kgc:Action;
     rdfs:label     "持っていく"@ja;
-    rdfs:label     "bring"@en.
+    rdfs:label     "bring"@en;
+    rdfs:label     "持ってくる"@ja;
+    rdfs:label     "運ぶ"@ja.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Disappearance>
     rdfs:label     "Disappearance"@en;
     rdf:type    kgc:Object.
@@ -3930,9 +3932,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/independent>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/the_incident>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Owner>
+    rdf:type    kgc:Person;
     rdfs:label     "馬主筋"@ja;
-    rdfs:label     "Owner"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Owner"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Include>
     rdfs:label     "Include"@en;
     rdf:type    kgc:Object.
@@ -3942,17 +3944,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notOrdinary"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "徘徊する"@ja;
+    rdfs:label     "歩き回る"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Fitzroy_Simpson>
+    rdf:type    kgc:Person;
     rdfs:label     "フィッロイ・シムソン"@ja;
     rdfs:label     "Fitzroy Simpson"@en;
-    rdfs:label     "フィツロイ・シムソン"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "フィツロイ・シムソン"@ja.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Thick_stick>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "太いステッキ"@ja;
-    rdfs:label     "Thick stick"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Thick stick"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Using_something_heavy_Kyoki>
     rdfs:label     "何か重い兇器を使って"@ja;
     rdfs:label     "Using something heavy Kyoki"@en;
@@ -4006,9 +4008,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "wager"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Lame>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "跛"@ja;
-    rdfs:label     "Lame"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Lame"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Injured>
     rdfs:label     "Injured"@en;
     rdf:type    kgc:Object.
@@ -4069,9 +4071,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Plug the water comes out"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/murderer>
+    rdf:type    kgc:Person;
     rdfs:label     "殺害者"@ja;
-    rdfs:label     "murderer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "murderer"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Where_is_the_slope_of_the_land>
     rdfs:label     "土地の傾斜しているところ"@ja;
     rdfs:label     "Where is the slope of the land"@en;
@@ -4108,6 +4110,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ロス大佐の騎手"@ja;
     rdfs:label     "Jockey of Colonel Ross"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:Person;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Jockey>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Colonel_Ross>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Stables>
@@ -4125,7 +4128,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/brown_color>.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "殴る"@ja;
+    rdfs:label     "打つ"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wet>
     rdf:type    kgc:Property;
@@ -4161,6 +4164,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Participate"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Wife_of_John_Straker>
+    rdf:type    kgc:Person;
     rdfs:label     "ジョン・ストレーカーの妻"@ja;
     rdfs:label     "Wife of John Straker"@en;
     rdf:type    kgc:OFobj;
@@ -4178,17 +4182,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Traces"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Two_horses>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "二頭の馬"@ja;
-    rdfs:label     "Two horses"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Two horses"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/practice>
     rdf:type    kgc:Action;
     rdfs:label     "練習する"@ja;
     rdfs:label     "practice"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/silver_watch>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "銀時計"@ja;
-    rdfs:label     "silver watch"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "silver watch"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Depression_in_the_bush_of_the_previous_beam_broom>
     rdfs:label     "はりえにしだの藪の先の窪み"@ja;
     rdfs:label     "Depression in the bush of the previous beam broom"@en;
@@ -4196,14 +4200,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Depression_in_the_bush>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_previous_beam_broom>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Dartmoor>
+    rdf:type    kgc:Place;
     rdfs:label     "ダートムア"@ja;
-    rdfs:label     "Dartmoor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Dartmoor"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Expensive_clothes>
     rdfs:label     "高い服"@ja;
     rdfs:label     "Expensive clothes"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Hunting_of_woolen_cloth>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "羅紗のハンチング"@ja;
     rdfs:label     "Hunting of woolen cloth"@en;
     rdf:type    kgc:OFobj;
@@ -4242,9 +4247,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "興奮する"@ja;
     rdfs:label     "excite"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Youth_stables_number>
+    rdf:type    kgc:Person;
     rdfs:label     "厩舎番の若者"@ja;
-    rdfs:label     "Youth stables number"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Youth stables number"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Ground>
     rdfs:label     "Ground"@en;
     rdf:type    kgc:Object.
@@ -4301,9 +4306,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Night>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_incident>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown_shoes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サイラス・ブラウンの靴"@ja;
-    rdfs:label     "Cyrus Brown shoes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Cyrus Brown shoes"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/thigh>
     rdfs:label     "thigh"@en;
     rdf:type    kgc:Object.
@@ -4352,7 +4357,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Horseshoe_marks>
     rdfs:label     "馬蹄の跡"@ja;
     rdfs:label     "Horseshoe marks"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_duplicate_key_possession>
     rdfs:label     "the duplicate key possession"@en;
     rdf:type    kgc:Object.
@@ -4361,9 +4366,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "食べる"@ja;
     rdfs:label     "eat"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Tavistock>
+    rdf:type    kgc:Place;
     rdfs:label     "タヴィストック"@ja;
-    rdfs:label     "Tavistock"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Tavistock"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/At_thirty_yards_from_the_stables>
     rdfs:label     "厩舎から三十ヤードのところ"@ja;
     rdfs:label     "At thirty yards from the stables"@en;
@@ -4425,9 +4430,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "断言する"@ja;
     rdfs:label     "declare"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Two_young_men>
+    rdf:type    kgc:Person;
     rdfs:label     "二人の若者"@ja;
-    rdfs:label     "Two young men"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Two young men"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/One_of_the_shoes_of_Fitzroy_Simpson>
     rdfs:label     "フィツロイ・シムソンの片方の靴"@ja;
     rdfs:label     "One of the shoes of Fitzroy Simpson"@en;
@@ -4460,13 +4465,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受け取る"@ja;
+    rdfs:label     "受ける"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/House_near_the_stables>
     rdfs:label     "厩舎付近の家"@ja;
     rdfs:label     "House near the stables"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/legs_of_Silver_Blaze>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "白銀の脚"@ja;
     rdfs:label     "legs of Silver Blaze"@en;
     rdf:type    kgc:OFobj;
@@ -4520,9 +4526,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "得する"@ja;
     rdfs:label     "benefit"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/camp>
+    rdf:type    kgc:Place;
     rdfs:label     "キャンプ"@ja;
-    rdfs:label     "camp"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "camp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/put>
     rdf:type    kgc:Action;
     rdfs:label     "置く"@ja;
@@ -4562,10 +4568,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Reasoning Detective"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/two_young_men>
+    rdf:type    kgc:Person;
     rdfs:label     "２人の若者"@ja;
     rdfs:label     "two young men"@en;
-    rdfs:label     "２人の若者の帰り"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "２人の若者の帰り"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotDrink>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -4587,12 +4593,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考える"@ja;
+    rdfs:label     "考慮する"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Crime>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "悪事"@ja;
-    rdfs:label     "Crime"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Crime"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/small_gambling>
     rdfs:label     "small gambling"@en;
     rdf:type    kgc:Object.
@@ -4632,7 +4638,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/crush>
     rdf:type    kgc:Action;
-    rdfs:label     "粉砕する"@ja;
+    rdfs:label     "砕く"@ja;
     rdfs:label     "crush"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Wide_space>
     rdfs:label     "広いスペース"@ja;
@@ -4678,9 +4684,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fat"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/pencil_case>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鉛筆さし"@ja;
-    rdfs:label     "pencil case"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "pencil case"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/chaseAway>
     rdf:type    kgc:Action;
     rdfs:label     "追い払う"@ja;
@@ -4691,7 +4697,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "noContact"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/move>
     rdf:type    kgc:Action;
-    rdfs:label     "動く"@ja;
+    rdfs:label     "移動する"@ja;
     rdfs:label     "move"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mantle>
     rdfs:label     "Mantle"@en;
@@ -4734,18 +4740,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/stable>
     rdfs:label     "厩舎"@ja;
     rdfs:label     "stable"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/knife>
     rdfs:label     "ナイフ"@ja;
     rdfs:label     "knife"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/predicate/Predict>
     rdfs:label     "Predict"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/King_s_Pyland>
+    rdf:type    kgc:Place;
     rdfs:label     "キングス・パイランド"@ja;
-    rdfs:label     "King's Pyland"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "King's Pyland"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Forecast_of_horse_racing>
     rdfs:label     "競馬の予想"@ja;
     rdfs:label     "Forecast of horse racing"@en;
@@ -4771,7 +4777,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Wessex_Cup_game>
     rdfs:label     "ウェセクス賞杯戦"@ja;
     rdfs:label     "Wessex Cup game"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/interest>
     rdfs:label     "利害関係"@ja;
     rdfs:label     "interest"@en;
@@ -4802,21 +4808,22 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Idea"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/London>
+    rdf:type    kgc:Place;
     rdfs:label     "ロンドン"@ja;
-    rdfs:label     "London"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "London"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Knife_that_can_not_hide>
     rdfs:label     "隠すことのできないナイフ"@ja;
     rdfs:label     "Knife that can not hide"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown>
+    rdf:type    kgc:Person;
     rdfs:label     "サイラス・ブラウン"@ja;
     rdfs:label     "Cyrus Brown"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Long_vividly>
     rdfs:label     "長く鮮やかに"@ja;
     rdfs:label     "Long vividly"@en;
@@ -4923,13 +4930,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "brown color"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/horse_trainer>
+    rdf:type    kgc:Person;
     rdfs:label     "調馬師"@ja;
-    rdfs:label     "horse trainer"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "horse trainer"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/children>
+    rdf:type    kgc:Person;
     rdfs:label     "子供"@ja;
-    rdfs:label     "children"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "children"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/One_of_the_shoes_of_John_Straker>
     rdfs:label     "ジョン・ストレーカーの片方の靴"@ja;
     rdfs:label     "One of the shoes of John Straker"@en;
@@ -4939,9 +4946,10 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_shoes>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/John_Straker>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Wasteland>
+    rdf:type    kgc:Person;
     rdfs:label     "荒地"@ja;
     rdfs:label     "Wasteland"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place.
 <http://kgc.knowledge-graph.jp/data/predicate/dead>
     rdf:type    kgc:Property;
     rdfs:label     "死んでいる"@ja;
@@ -4958,16 +4966,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "要求する"@ja;
+    rdfs:label     "依頼する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/deal>
     rdf:type    kgc:Action;
     rdfs:label     "扱う"@ja;
     rdfs:label     "deal"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/lantern>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "提灯"@ja;
-    rdfs:label     "lantern"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "lantern"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smash>
     rdf:type    kgc:Action;
     rdfs:label     "強打する"@ja;
@@ -5052,7 +5060,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
     rdfs:label     "会う"@ja;
-    rdfs:label     "meet"@en.
+    rdfs:label     "meet"@en;
+    rdfs:label     "出会う"@ja.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Figure_of_the_people>
     rdfs:label     "人の姿"@ja;
     rdfs:label     "Figure of the people"@en;
@@ -5060,6 +5069,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Figure>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_people>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Disappearance_of_Silver_Blaze>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "白銀号の失踪"@ja;
     rdfs:label     "Disappearance of Silver Blaze"@en;
     rdf:type    kgc:OFobj;
@@ -5084,9 +5094,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "追跡する"@ja;
     rdfs:label     "trace"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mapleton>
+    rdf:type    kgc:Place;
     rdfs:label     "メープルトン"@ja;
-    rdfs:label     "Mapleton"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Mapleton"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Accompany>
     rdfs:label     "Accompany"@en;
     rdf:type    kgc:Object.
@@ -5094,6 +5104,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "disappearance"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Subordinates_of_Cyrus_Brown>
+    rdf:type    kgc:Person;
     rdfs:label     "サイラス・ブラウンの部下"@ja;
     rdfs:label     "Subordinates of Cyrus Brown"@en;
     rdf:type    kgc:OFobj;
@@ -5107,9 +5118,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "運動する"@ja;
     rdfs:label     "exercise"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/John_Straker>
+    rdf:type    kgc:Person;
     rdfs:label     "ジョン・ストレーカー"@ja;
     rdfs:label     "John Straker"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/most>
     rdfs:label     "もっとも"@ja;
     rdfs:label     "most"@en;
@@ -5119,9 +5131,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "outdoor"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Desborough>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "デスボロ"@ja;
-    rdfs:label     "Desborough"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Desborough"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Hurt>
     rdfs:label     "Hurt"@en;
     rdf:type    kgc:Object.
@@ -5133,9 +5145,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "receipt already in liquidation certificate"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Jockey>
+    rdf:type    kgc:Person;
     rdfs:label     "騎手"@ja;
-    rdfs:label     "Jockey"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Jockey"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Taste>
     rdfs:label     "Taste"@en;
     rdf:type    kgc:Object.
@@ -5153,7 +5165,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/ice>;
-    rdfs:label     "気づく"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "notice"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/State>
     rdfs:label     "State"@en;
@@ -5173,9 +5185,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "The reason for visit"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Small_parcel>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "小さな紙包"@ja;
-    rdfs:label     "Small parcel"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Small parcel"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Accident_of_sheep>
     rdfs:label     "羊の異変"@ja;
     rdfs:label     "Accident of sheep"@en;
@@ -5229,7 +5241,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notExist"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪れる"@ja;
+    rdfs:label     "訪ねる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wonder>
     rdf:type    kgc:Action;
@@ -5262,7 +5274,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つからない"@ja;
+    rdfs:label     "見つけられない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hire>
     rdf:type    kgc:Action;
@@ -5285,9 +5297,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Head>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/John_Straker>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Lord_Backwater>
+    rdf:type    kgc:Person;
     rdfs:label     "バックウォータ卿"@ja;
-    rdfs:label     "Lord Backwater"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Lord Backwater"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/marry>
     rdf:type    kgc:Property;
     rdfs:label     "結婚する"@ja;
@@ -5306,7 +5318,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/police>
     rdfs:label     "警察"@ja;
     rdfs:label     "police"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/predicate/kidnap>
     rdf:type    kgc:Action;
     rdfs:label     "誘拐する"@ja;
@@ -5320,7 +5332,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Horseracing>
     rdfs:label     "競馬"@ja;
     rdfs:label     "Horseracing"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_total_amount>
     rdfs:label     "The total amount"@en;
     rdf:type    kgc:Object.
@@ -5349,23 +5361,24 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "添えない"@ja;
     rdfs:label     "notAccompany"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Curry_dish>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "カレー料理"@ja;
-    rdfs:label     "Curry dish"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Curry dish"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze_of_racehorses>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "白銀号の競走馬"@ja;
     rdfs:label     "Silver Blaze of racehorses"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/racehorses>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown_stables>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "サイラス・ブラウンの厩舎"@ja;
-    rdfs:label     "Cyrus Brown stables"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Cyrus Brown stables"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/cork>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "コルク"@ja;
-    rdfs:label     "cork"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cork"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Murder_scene>
     rdfs:label     "殺害現場"@ja;
     rdfs:label     "Murder scene"@en;
@@ -5386,9 +5399,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "信頼できない"@ja;
     rdfs:label     "notReliable"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Brown_Umanoashi_of>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "栗毛の馬の脚"@ja;
-    rdfs:label     "Brown Umanoashi of"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Brown Umanoashi of"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/growUp>
     rdf:type    kgc:Action;
     rdfs:label     "育つ"@ja;
@@ -5409,6 +5422,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "7 cases"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Dog_of_the_stables>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "厩舎の犬"@ja;
     rdfs:label     "Dog of the stables"@en;
     rdf:type    kgc:OFobj;
@@ -5432,7 +5446,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "not持つ"@ja;
+    rdfs:label     "持たない"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/retire>
     rdf:type    kgc:Action;
@@ -5453,9 +5467,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "しようとする"@ja;
+    rdfs:label     "試みる"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Stables_of_Mapleton>
+    rdf:type    kgc:Place;
     rdfs:label     "メープルトンの厩舎"@ja;
     rdfs:label     "Stables of Mapleton"@en;
     rdf:type    kgc:OFobj;
@@ -5478,7 +5493,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/wind>
     rdfs:label     "風"@ja;
     rdfs:label     "wind"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/predicate/promise>
     rdf:type    kgc:Action;
     rdfs:label     "約束する"@ja;
@@ -5486,7 +5501,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Criminal>
     rdfs:label     "犯人"@ja;
     rdfs:label     "Criminal"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Corpse_of_John_Straker>
     rdfs:label     "ジョン・ストレーカーの死体"@ja;
     rdfs:label     "Corpse of John Straker"@en;
@@ -5506,10 +5521,11 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/disappearance>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Evening_meal>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "夕飯"@ja;
-    rdfs:label     "Evening meal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Evening meal"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Depression_in_the_direction_of_Mapleton>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "メープルトンの方向の窪み"@ja;
     rdfs:label     "Depression in the direction of Mapleton"@en;
     rdf:type    kgc:OFobj;
@@ -5536,9 +5552,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Three_pieces>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/receipt_already_in_liquidation_certificate>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Colonel_Ross>
+    rdf:type    kgc:Person;
     rdfs:label     "ロス大佐"@ja;
-    rdfs:label     "Colonel Ross"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Colonel Ross"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/chase>
     rdf:type    kgc:Action;
     rdfs:label     "追いかける"@ja;
@@ -5548,14 +5564,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "五歳である"@ja;
     rdfs:label     "five years old"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/William_Derbyshire>
+    rdf:type    kgc:Person;
     rdfs:label     "ウィリアム・ダービシャ"@ja;
     rdfs:label     "William Derbyshire"@en;
-    rdfs:label     "ウィリアム・ダービシャ夫人"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ウィリアム・ダービシャ夫人"@ja.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_murder_scene>
     rdfs:label     "the murder scene"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_left_side_of_the_recess>
+    rdf:type    kgc:Place;
     rdfs:label     "窪みの左側"@ja;
     rdfs:label     "The left side of the recess"@en;
     rdf:type    kgc:OFobj;
@@ -5567,9 +5584,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "知る"@ja;
     rdfs:label     "know"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Horse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "馬"@ja;
-    rdfs:label     "Horse"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Horse"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_previous_beam_broom>
     rdfs:label     "the previous beam broom"@en;
     rdf:type    kgc:Object.
@@ -5589,16 +5606,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "見張る"@ja;
     rdfs:label     "watch"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Plymouth>
+    rdf:type    kgc:Place;
     rdfs:label     "プリマス"@ja;
-    rdfs:label     "Plymouth"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Plymouth"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/dark>
     rdf:type    kgc:Property;
     rdfs:label     "暗い"@ja;
     rdfs:label     "dark"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着る"@ja;
+    rdfs:label     "着ている"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/small_knife>
     rdfs:label     "小さなナイフ"@ja;
@@ -5631,15 +5648,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Strong chemicals"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Gray_Scotch_of_clothes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鼠色のスコッチの服"@ja;
     rdfs:label     "Gray Scotch of clothes"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Gray_Scotch>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/clothes>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cigarette_case>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "煙草入れ"@ja;
-    rdfs:label     "Cigarette case"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Cigarette case"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Complexion>
     rdfs:label     "Complexion"@en;
     rdf:type    kgc:Object.
@@ -5655,6 +5673,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Notice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/legs_of_brown_horse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "栗毛の馬の脚"@ja;
     rdfs:label     "legs of brown horse"@en;
     rdf:type    kgc:OFobj;
@@ -5664,16 +5683,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Spirit"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Stable>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "厩舎"@ja;
-    rdfs:label     "Stable"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Stable"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Where_is_the_slope>
     rdfs:label     "Where is the slope"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Bill>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "勘定書"@ja;
-    rdfs:label     "Bill"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Bill"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/white>
     rdf:type    kgc:Property;
     rdfs:label     "白い"@ja;
@@ -5695,6 +5714,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "殺す"@ja;
     rdfs:label     "kill"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Window_of_Stables>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "厩舎の窓"@ja;
     rdfs:label     "Window of Stables"@en;
     rdf:type    kgc:OFobj;
@@ -5704,9 +5724,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "All"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Injured_horse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "傷つけられた馬"@ja;
-    rdfs:label     "Injured horse"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Injured horse"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_depression>
     rdfs:label     "the depression"@en;
     rdf:type    kgc:Object.
@@ -5723,6 +5743,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Dinner>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Ned_Hunter>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_right_side_of_the_recess>
+    rdf:type    kgc:Place;
     rdfs:label     "窪みの右側"@ja;
     rdfs:label     "The right side of the recess"@en;
     rdf:type    kgc:OFobj;
@@ -5745,13 +5766,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "3 sheep"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Gypsy>
+    rdf:type    kgc:Person;
     rdfs:label     "ジプシー"@ja;
-    rdfs:label     "Gypsy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Gypsy"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Gregory_Inspector>
+    rdf:type    kgc:Person;
     rdfs:label     "グレゴリ警部"@ja;
-    rdfs:label     "Gregory Inspector"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Gregory Inspector"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Bring>
     rdfs:label     "Bring"@en;
     rdf:type    kgc:Object.
@@ -5763,13 +5784,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "開放する"@ja;
     rdfs:label     "release"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Gold_coin>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "金貨"@ja;
-    rdfs:label     "Gold coin"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Gold coin"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Various_people>
+    rdf:type    kgc:Person;
     rdfs:label     "いろんな人"@ja;
-    rdfs:label     "Various people"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Various people"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/John_Straker>
     rdfs:label     "John Straker"@en;
     rdf:type    kgc:Object.
@@ -5808,9 +5829,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "brown horse"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Isonomy>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "アイソノミ"@ja;
-    rdfs:label     "Isonomy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Isonomy"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Idea_of_Holmes>
     rdfs:label     "ホームズの考え"@ja;
     rdfs:label     "Idea of Holmes"@en;
@@ -5826,20 +5847,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "dog"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Man>
+    rdf:type    kgc:Person;
     rdfs:label     "人"@ja;
-    rdfs:label     "Man"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Man"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Sport_Club_of_London>
+    rdf:type    kgc:Place;
     rdfs:label     "ロンドンのスポート倶楽部"@ja;
     rdfs:label     "Sport Club of London"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Sport_Club>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/London>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Brown_horse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "栗毛の馬"@ja;
     rdfs:label     "Brown horse"@en;
-    rdfs:label     "栗毛の馬は"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "栗毛の馬は"@ja.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/tendon>
     rdfs:label     "tendon"@en;
     rdf:type    kgc:Object.
@@ -5847,6 +5869,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "メープルトンの方の窪み"@ja;
     rdfs:label     "Depression in the person of Mapleton"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Depression_in_the_person>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mapleton>.
 <http://kgc.knowledge-graph.jp/data/predicate/greet>
@@ -5862,6 +5885,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "仕事中"@ja;
     rdfs:label     "Working"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Stables_of_King_s_Pyland>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "キングス・パイランドの厩舎"@ja;
     rdfs:label     "Stables of King's Pyland"@en;
     rdf:type    kgc:OFobj;
@@ -5896,9 +5920,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "失敗する"@ja;
     rdfs:label     "fail"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/John_Straker_house>
+    rdf:type    kgc:Place;
     rdfs:label     "ジョン・ストレーカーの家"@ja;
-    rdfs:label     "John Straker house"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "John Straker house"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/come>
     rdf:type    kgc:Action;
     rdfs:label     "来る"@ja;
@@ -5921,7 +5945,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/work>
     rdf:type    kgc:Action;
-    rdfs:label     "働く"@ja;
+    rdfs:label     "仕事をする"@ja;
     rdfs:label     "work"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Direction>
     rdfs:label     "Direction"@en;
@@ -5943,8 +5967,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "teach"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/give>
     rdf:type    kgc:Action;
-    rdfs:label     "与える"@ja;
-    rdfs:label     "give"@en.
+    rdfs:label     "渡す"@ja;
+    rdfs:label     "give"@en;
+    rdfs:label     "与える"@ja.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/amount>
     rdfs:label     "額"@ja;
     rdfs:label     "amount"@en;
@@ -6003,21 +6028,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ひどい"@ja;
     rdfs:label     "heavy"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/jockey>
+    rdf:type    kgc:Person;
     rdfs:label     "騎手"@ja;
-    rdfs:label     "jockey"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "jockey"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
     rdfs:label     "聞く"@ja;
     rdfs:label     "hear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "集中している"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Watson>
+    rdf:type    kgc:Person;
     rdfs:label     "ワトソン"@ja;
-    rdfs:label     "Watson"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Watson"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notWander>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -6025,14 +6050,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "徘徊しない"@ja;
     rdfs:label     "notWander"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Ned_Hunter>
+    rdf:type    kgc:Person;
     rdfs:label     "ネッド・ハンター"@ja;
-    rdfs:label     "Ned Hunter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Ned Hunter"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/candle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "蝋燭"@ja;
-    rdfs:label     "candle"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "candle"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Gypsy_of_Dartmoor>
+    rdf:type    kgc:Person;
     rdfs:label     "ダートムアのジプシー"@ja;
     rdfs:label     "Gypsy of Dartmoor"@en;
     rdf:type    kgc:OFobj;
@@ -6108,9 +6134,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Find"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mapleton_riding_ground_stables>
+    rdf:type    kgc:Place;
     rdfs:label     "メープルトン調馬場の厩舎"@ja;
-    rdfs:label     "Mapleton riding ground stables"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Mapleton riding ground stables"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/A_group>
     rdfs:label     "A group"@en;
     rdf:type    kgc:Object.
@@ -6178,9 +6204,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "渡す"@ja;
     rdfs:label     "handOver"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/People>
+    rdf:type    kgc:Person;
     rdfs:label     "人々"@ja;
-    rdfs:label     "People"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "People"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Half-length>
     rdfs:label     "半身"@ja;
     rdfs:label     "Half-length"@en;
@@ -6192,9 +6218,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Enter"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Police>
+    rdf:type    kgc:Person;
     rdfs:label     "警察"@ja;
-    rdfs:label     "Police"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Police"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/feel>
     rdf:type    kgc:Action;
     rdfs:label     "感じる"@ja;
@@ -6221,6 +6247,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Corpse"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mantle_of_John_Straker>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジョン・ストレーカーの外套"@ja;
     rdfs:label     "Mantle of John Straker"@en;
     rdf:type    kgc:OFobj;
@@ -6236,18 +6263,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "famous"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Have>
     rdfs:label     "Have"@en;
-    rdfs:label     "持つ"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Bookmaker_of_a_small_gambling>
+    rdf:type    kgc:Person;
     rdfs:label     "小さな賭事の胴元"@ja;
     rdfs:label     "Bookmaker of a small gambling"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Bookmaker>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/a_small_gambling>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/King_s_Pyland_riding_ground>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "キングス・パイランド調馬場"@ja;
-    rdfs:label     "King's Pyland riding ground"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "King's Pyland riding ground"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/O'clock_the_next_morning>
     rdfs:label     "O'clock the next morning"@en;
     rdf:type    kgc:Object.
@@ -6279,9 +6306,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Five thousand lbs"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Stableman>
+    rdf:type    kgc:Person;
     rdfs:label     "馬丁"@ja;
-    rdfs:label     "Stableman"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Stableman"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/sin>
     rdfs:label     "罪"@ja;
     rdfs:label     "sin"@en;
@@ -6303,16 +6330,16 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/side-by-side>
     rdf:type    kgc:Property;
-    rdfs:label     "横に並んでいた"@ja;
+    rdfs:label     "横並びである"@ja;
     rdfs:label     "side-by-side"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/dispose>
     rdf:type    kgc:Action;
     rdfs:label     "捨てる"@ja;
     rdfs:label     "dispose"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/paper>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "書附"@ja;
-    rdfs:label     "paper"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "paper"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/thigh_of_John_Straker>
     rdfs:label     "自分の腿"@ja;
     rdfs:label     "thigh of John Straker"@en;
@@ -6420,9 +6447,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/large_amount>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/opium>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Wax_match>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "蝋マッチ一箱"@ja;
-    rdfs:label     "Wax match"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Wax match"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/advantageous>
     rdf:type    kgc:Property;
     rdfs:label     "有利である"@ja;
@@ -6488,11 +6515,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "開く"@ja;
     rdfs:label     "open"@en;
-    rdf:type    kgc:Action.
+    rdf:type    kgc:Action;
+    rdfs:label     "開ける"@ja.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Footprint_of_Silver_Blaze>
     rdfs:label     "白銀号の足跡"@ja;
     rdfs:label     "Footprint of Silver Blaze"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Footprint>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Fitzroy_Simpson_for_a_piece_of_paper>
@@ -6502,16 +6531,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/paper>.
 <http://kgc.knowledge-graph.jp/data/predicate/whisper>
     rdf:type    kgc:Action;
-    rdfs:label     "囁く"@ja;
+    rdfs:label     "ささやく"@ja;
     rdfs:label     "whisper"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "白銀号"@ja;
     rdfs:label     "Silver Blaze"@en;
-    rdfs:label     "白銀"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person;
+    rdfs:label     "白銀"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/grab>
     rdf:type    kgc:Action;
-    rdfs:label     "つかむ"@ja;
+    rdfs:label     "掴む"@ja;
     rdfs:label     "grab"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/see>
     rdf:type    kgc:Action;
@@ -6560,9 +6590,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Fitzroy_Simpson_for_a_piece>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/paper>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/alcohol>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "アルコール"@ja;
-    rdfs:label     "alcohol"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "alcohol"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/every_night>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "毎晩"@ja;
@@ -6598,9 +6628,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Age>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Fitzroy_Simpson>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Vest_pocket>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "チョッキのポケット"@ja;
-    rdfs:label     "Vest pocket"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Vest pocket"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/horse_racing_information>
     rdfs:label     "競馬の情報"@ja;
     rdfs:label     "horse racing information"@en;
@@ -6610,9 +6640,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "園遊会"@ja;
     rdfs:label     "garden party"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
-    rdfs:label     "Holmes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Holmes"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_shoes_of_Fitzroy_Simpson>
     rdfs:label     "the shoes of Fitzroy Simpson"@en;
     rdf:type    kgc:OFobj;
@@ -6622,11 +6652,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "紙切れ"@ja;
     rdfs:label     "A scrap of paper"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/A_scrap>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/paper>.
 <http://kgc.knowledge-graph.jp/data/predicate/fight>
     rdf:type    kgc:Action;
-    rdfs:label     "格闘する"@ja;
+    rdfs:label     "戦う"@ja;
     rdfs:label     "fight"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Betting_horse_racing>
     rdfs:label     "競馬の賭け"@ja;
@@ -6640,16 +6671,18 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Place>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Edith_Baxter>
+    rdf:type    kgc:Person;
     rdfs:label     "エディス・バクスタ"@ja;
-    rdfs:label     "Edith Baxter"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Edith Baxter"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/horse_trainer_of_Colonel_Ross>
+    rdf:type    kgc:Person;
     rdfs:label     "ロス大佐の調馬師"@ja;
     rdfs:label     "horse trainer of Colonel Ross"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/horse_trainer>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Colonel_Ross>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Face_of_brown_horse>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "栗毛の馬の顔"@ja;
     rdfs:label     "Face of brown horse"@en;
     rdf:type    kgc:OFobj;
@@ -6711,6 +6744,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Hear"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/A_group_of_Gypsy>
+    rdf:type    kgc:Person;
     rdfs:label     "ジプシーの一群"@ja;
     rdfs:label     "A group of Gypsy"@en;
     rdf:type    kgc:OFobj;
@@ -6730,6 +6764,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "厩舎の戸"@ja;
     rdfs:label     "Door of the stables"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Door>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_stables>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Good_record>
@@ -6745,7 +6780,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Dent_of_wasteland>
     rdfs:label     "荒地の窪み"@ja;
@@ -6769,7 +6804,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/hear>;
-    rdfs:label     "聞こえない"@ja;
+    rdfs:label     "聞かない"@ja;
     rdfs:label     "notHear"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_pattern_of_horseshoe_of_Silver_Blaze>
     rdfs:label     "白銀号の蹄鉄の型"@ja;
@@ -6781,7 +6816,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>.
 <http://kgc.knowledge-graph.jp/data/predicate/comeOut>
     rdf:type    kgc:Action;
-    rdfs:label     "あらわにする"@ja;
+    rdfs:label     "出てくる"@ja;
     rdfs:label     "comeOut"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_name>
     rdfs:label     "The name"@en;

--- a/SpeckledBand.ttl
+++ b/SpeckledBand.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/metadata>
-    rdfs:comment  "作成日（2022-10-17） "@ja ;
+    rdfs:comment  "作成日（2022-11-05） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -1003,7 +1003,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/087>
     rdf:type    kgc:Situation ;
     kgc:source  "事件当夜，ジュリアは寝間着を着ていた。"@ja ;
-    kgc:source  "Julia was wearing a sleepwear on the day Julia died."@en ;
+    kgc:source  "Julia was wearing a sleepwear on the day Julia died."@en .
+<http://kgc.knowledge-graph.jp/data/SpeckledBand/087>
+    rdf:type    kgc:Situation ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wear> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/SpeckledBand/the_day_Julia_died> ;
@@ -4040,13 +4042,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "left building"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bedroom>
+    rdf:type    kgc:Place;
     rdfs:label     "寝室"@ja;
-    rdfs:label     "bedroom"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bedroom"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/baboon>
+    rdf:type    kgc:Animal;
     rdfs:label     "ヒヒ"@ja;
-    rdfs:label     "baboon"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "baboon"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/mother_of_Helen>
     rdfs:label     "mother of Helen"@en;
     rdf:type    kgc:OFobj;
@@ -4060,15 +4062,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "しばしば"@ja;
     rdfs:label     "occasionally"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen’s_bedroom>
+    rdf:type    kgc:Place;
     rdfs:label     "ヘレンの寝室"@ja;
     rdfs:label     "Helen’s bedroom"@en;
     rdfs:label     "ヘレンの寝室の窓"@ja;
-    rdfs:label     "ジュリアの寝室"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ジュリアの寝室"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/window>
     rdfs:label     "窓"@ja;
     rdfs:label     "window"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/predicate/bite>
     rdf:type    kgc:Action;
     rdfs:label     "噛む"@ja;
@@ -4086,10 +4088,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "reward"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/private_documents>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "個人的な書類"@ja;
-    rdfs:label     "private documents"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "private documents"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/voice_of_Julia>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの声"@ja;
     rdfs:label     "voice of Julia"@en;
     rdf:type    kgc:OFobj;
@@ -4108,13 +4111,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ready"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/light>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "光"@ja;
-    rdfs:label     "light"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "light"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/coach>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "馬車"@ja;
-    rdfs:label     "coach"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "coach"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/jaw>
     rdfs:label     "jaw"@en;
     rdf:type    kgc:Object.
@@ -4129,6 +4132,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/smell>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Indian_cigarettes>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/mother_of_Helen>
+    rdf:type    kgc:Person;
     rdfs:label     "ヘレンの母"@ja;
     rdfs:label     "mother of Helen"@en;
     rdf:type    kgc:OFobj;
@@ -4139,14 +4143,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "橋渡しする"@ja;
     rdfs:label     "bridge"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott’s_bedroom>
+    rdf:type    kgc:Place;
     rdfs:label     "ロイロットの寝室"@ja;
     rdfs:label     "Roylott’s bedroom"@en;
     rdfs:label     "ロイロットの寝室の隣"@ja;
     rdfs:label     "ロイロット博士の寝室"@ja;
     rdfs:label     "ロイロット博士の寝室の窓"@ja;
-    rdfs:label     "ヘレンの寝室とロイロット博士の寝室"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ヘレンの寝室とロイロット博士の寝室"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/floor_of_Helen’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの寝室の床"@ja;
     rdfs:label     "floor of Helen’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -4156,9 +4161,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/move>;
-    rdfs:label     "動けない"@ja;
+    rdfs:label     "動かせない"@ja;
     rdfs:label     "cannotMove"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/hinges_of_shutter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鎧戸の蝶番"@ja;
     rdfs:label     "hinges of shutter"@en;
     rdf:type    kgc:OFobj;
@@ -4174,13 +4180,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "危険である"@ja;
     rdfs:label     "danger"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/eye>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "目"@ja;
-    rdfs:label     "eye"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "eye"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/corner>
     rdfs:label     "corner"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/villager_of_Stoke_Moran>
+    rdf:type    kgc:Person;
     rdfs:label     "ストークモランの村人"@ja;
     rdfs:label     "villager of Stoke Moran"@en;
     rdf:type    kgc:OFobj;
@@ -4190,6 +4197,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "price"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/door_of_Julia’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの寝室のドア"@ja;
     rdfs:label     "door of Julia’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -4198,41 +4206,42 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia’s_bedroom>.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "徘徊する"@ja;
+    rdfs:label     "歩き回る"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/dog_whip>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "小さな犬鞭"@ja;
     rdfs:label     "dog whip"@en;
     rdfs:label     "小さな犬鞭の先"@ja;
     rdfs:label     "鞭"@ja;
-    rdfs:label     "鞭を使って"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "鞭を使って"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/two-wheeled_coach>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "二輪馬車"@ja;
-    rdfs:label     "two-wheeled coach"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "two-wheeled coach"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/lamp>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ランプ"@ja;
     rdfs:label     "lamp"@en;
-    rdfs:label     "明かり"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "明かり"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/Listen>
     rdfs:label     "Listen"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/doctor_of_Stoke_Moran>
+    rdf:type    kgc:Person;
     rdfs:label     "ストークモランの医師"@ja;
     rdfs:label     "doctor of Stoke Moran"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/doctor>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Stoke_Moran>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Crown_Inn>
+    rdf:type    kgc:Place;
     rdfs:label     "クラウン・イン"@ja;
-    rdfs:label     "Crown Inn"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Crown Inn"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/wall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "壁に寄せて"@ja;
-    rdfs:label     "wall"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "wall"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Asleep>
     rdfs:label     "Asleep"@en;
     rdf:type    kgc:Object.
@@ -4273,34 +4282,33 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "一ヶ月前"@ja;
     rdfs:label     "one month ago"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Crewe>
+    rdf:type    kgc:Place;
     rdfs:label     "クルー"@ja;
-    rdfs:label     "Crewe"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Crewe"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/west_building>
     rdfs:label     "west building"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/two_small_chairs>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "２つの小さな籐椅子"@ja;
-    rdfs:label     "two small chairs"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "two small chairs"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/inspect>
     rdf:type    kgc:Action;
     rdfs:label     "取り調べる"@ja;
     rdfs:label     "inspect"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/leopard>
+    rdf:type    kgc:Animal;
     rdfs:label     "豹"@ja;
-    rdfs:label     "leopard"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "leopard"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "殴る"@ja;
+    rdfs:label     "打つ"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/scare>
     rdf:type    kgc:Action;
     rdfs:label     "怯える"@ja;
     rdfs:label     "scare"@en;
-    rdf:type    kgc:Property;
-    rdfs:label     "恐れた"@ja.
+    rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/deeply>
     rdfs:label     "ぐっすりと"@ja;
     rdfs:label     "deeply"@en;
@@ -4310,6 +4318,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "壊れている"@ja;
     rdfs:label     "broken"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/floor_of_Julia’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの寝室の床"@ja;
     rdfs:label     "floor of Julia’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -4329,12 +4338,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/sound>
     rdfs:label     "音"@ja;
     rdfs:label     "sound"@en;
-    rdfs:label     "かすかな音"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "かすかな音"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/money>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "お金"@ja;
-    rdfs:label     "money"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "money"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/every_year>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "毎年"@ja;
@@ -4349,9 +4358,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "上向き"@ja;
     rdfs:label     "upward"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/something>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "何か"@ja;
-    rdfs:label     "something"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "something"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/have>
     rdf:type    kgc:Action;
     rdfs:label     "持つ"@ja;
@@ -4368,6 +4377,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia_suffered_from_the_smell>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Indian_cigarettes>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/rope_of_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "呼び鈴の引き綱"@ja;
     rdfs:label     "rope of bell"@en;
     rdf:type    kgc:OFobj;
@@ -4382,7 +4392,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "confirm"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/turnOn>
     rdf:type    kgc:Action;
-    rdfs:label     "灯す"@ja;
+    rdfs:label     "点灯する"@ja;
     rdfs:label     "turnOn"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/like_steam_gushing_out_of_a_medicine_can>
     rdf:type    kgc:Property;
@@ -4396,19 +4406,20 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "結婚式の2週間前"@ja;
     rdfs:label     "two weeks before the wedding ceremony"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/VentilationHole>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "通風孔"@ja;
-    rdfs:label     "VentilationHole"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "VentilationHole"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/simple_chair>
     rdfs:label     "粗末な椅子が一つ"@ja;
     rdfs:label     "simple chair"@en;
     rdfs:label     "粗末な椅子"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/with_a_thick_iron_rod>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "太い鉄の棒をはめて"@ja;
-    rdfs:label     "with a thick iron rod"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "with a thick iron rod"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/reward_of_request>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "依頼の報酬"@ja;
     rdfs:label     "reward of request"@en;
     rdf:type    kgc:OFobj;
@@ -4426,16 +4437,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Satisfied"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Indian_animal>
+    rdf:type    kgc:Animal;
     rdfs:label     "インドの動物"@ja;
-    rdfs:label     "Indian animal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Indian animal"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bell>
     rdfs:label     "bell"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/church_bell>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "教会の鐘"@ja;
-    rdfs:label     "church bell"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "church bell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Roylott>
     rdfs:label     "Roylott"@en;
     rdf:type    kgc:Object.
@@ -4443,6 +4454,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "rope"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia’s_bedroom>
+    rdf:type    kgc:Place;
     rdfs:label     "ジュリアの寝室"@ja;
     rdfs:label     "Julia’s bedroom"@en;
     rdfs:label     "ジュリアの寝室の隣"@ja;
@@ -4451,20 +4463,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ジュリアの寝室の窓"@ja;
     rdfs:label     "部屋"@ja;
     rdfs:label     "ヘレンの寝室とロイロット博士の寝室"@ja;
-    rdfs:label     "隣の寝室"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "隣の寝室"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/white_overhard>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "白い上掛け"@ja;
-    rdfs:label     "white overhard"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "white overhard"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/small_hole_for_ventilation>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "通風孔"@ja;
-    rdfs:label     "small hole for ventilation"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "small hole for ventilation"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bookshelf>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "医学書ばかり詰まった木製の本棚"@ja;
-    rdfs:label     "bookshelf"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bookshelf"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/gently>
     rdfs:label     "静かに"@ja;
     rdfs:label     "gently"@en;
@@ -4474,6 +4485,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "起きる"@ja;
     rdfs:label     "wakeUp"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/question_of_Roylott>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "質問"@ja;
     rdfs:label     "question of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -4495,6 +4507,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "oil"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/mother_of_sister>
+    rdf:type    kgc:Person;
     rdfs:label     "姉妹の母"@ja;
     rdfs:label     "mother of sister"@en;
     rdf:type    kgc:OFobj;
@@ -4506,12 +4519,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "angry"@en;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/lanthanum>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ランタン"@ja;
-    rdfs:label     "lanthanum"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "lanthanum"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受け取る"@ja;
+    rdfs:label     "受ける"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/canView>
     rdf:type    kgc:Action;
@@ -4541,15 +4554,18 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "穏やかな"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/mansion_of_Roylott>
+    rdf:type    kgc:Place;
     rdfs:label     "ロイロットの屋敷"@ja;
     rdfs:label     "mansion of Roylott"@en;
     rdf:type    kgc:OFobj;
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "家"@ja;
     rdfs:label     "屋敷"@ja;
     rdfs:label     "屋敷の地"@ja;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/mansion>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/window_of_Julia’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの寝室の窓"@ja;
     rdfs:label     "window of Julia’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -4557,20 +4573,20 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/window>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia’s_bedroom>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/cry>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鳴き声"@ja;
-    rdfs:label     "cry"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "cry"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/knee>
     rdfs:label     "knee"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/storm>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "嵐"@ja;
-    rdfs:label     "storm"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "storm"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/intense_fear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "激しい恐怖"@ja;
-    rdfs:label     "intense fear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "intense fear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fat>
     rdf:type    kgc:Property;
     rdfs:label     "太い"@ja;
@@ -4596,15 +4612,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "反対しない"@ja;
     rdfs:label     "notOppose"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/small_dish>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "牛乳の入った小皿"@ja;
     rdfs:label     "small dish"@en;
     rdfs:label     "小皿"@ja;
-    rdfs:label     "小皿の牛乳"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "小皿の牛乳"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/stop>
     rdf:type    kgc:Action;
-    rdfs:label     "止める"@ja;
-    rdfs:label     "stop"@en.
+    rdfs:label     "止まる"@ja;
+    rdfs:label     "stop"@en;
+    rdfs:label     "止める"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/Move>
     rdfs:label     "Move"@en;
     rdf:type    kgc:Object.
@@ -4616,41 +4633,44 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "old-fashioned"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/these_days>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "今"@ja;
-    rdfs:label     "these days"@en.
+    rdfs:label     "these days"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考える"@ja;
+    rdfs:label     "考慮する"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/house_of_Holmes>
+    rdf:type    kgc:Place;
     rdfs:label     "ホームズの家"@ja;
     rdfs:label     "house of Holmes"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/house>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Holmes>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/250_GBP>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "250ポンド"@ja;
-    rdfs:label     "250 GBP"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "250 GBP"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/craftsman>
+    rdf:type    kgc:Person;
     rdfs:label     "職人"@ja;
-    rdfs:label     "craftsman"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "craftsman"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/for_a_moment>
+    rdf:type    kgc:AbstractTime;
     rdfs:label     "一瞬だけ"@ja;
-    rdfs:label     "for a moment"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "for a moment"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/garden_of_Roylott>
     rdfs:label     "garden of Roylott"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/window_of_left_building>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "左側の棟の窓"@ja;
     rdfs:label     "window of left building"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/window>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/left_building>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/will_of_mother_of_Helen>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘレンの母の遺言状"@ja;
     rdfs:label     "will of mother of Helen"@en;
     rdf:type    kgc:OFobj;
@@ -4688,14 +4708,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "agricultural products"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/sleepwear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "寝間着"@ja;
-    rdfs:label     "sleepwear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "sleepwear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/move>
     rdf:type    kgc:Action;
-    rdfs:label     "動く"@ja;
+    rdfs:label     "移動する"@ja;
     rdfs:label     "move"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/smell_of_oil>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "続いて油が燃え、金属が熱せられるきつい匂い"@ja;
     rdfs:label     "smell of oil"@en;
     rdf:type    kgc:OFobj;
@@ -4721,6 +4742,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "吹く"@ja;
     rdfs:label     "blow"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/by_falling_price_of_agricultural_products>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "農産物の価格下落"@ja;
     rdfs:label     "by falling price of agricultural products"@en;
     rdf:type    kgc:OFobj;
@@ -4739,6 +4761,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "口実を作る"@ja;
     rdfs:label     "motivate"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/reason_of_sound>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "音の正体"@ja;
     rdfs:label     "reason of sound"@en;
     rdf:type    kgc:OFobj;
@@ -4760,9 +4783,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "first floor"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/premium_wilton_carpet>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "高級なウィルトン絨毯"@ja;
-    rdfs:label     "premium wilton carpet"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "premium wilton carpet"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/roof>
     rdfs:label     "roof"@en;
     rdf:type    kgc:Object.
@@ -4783,9 +4806,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "昼間"@ja;
     rdfs:label     "daytime"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/lieutenant_commander>
+    rdf:type    kgc:Person;
     rdfs:label     "海軍少佐"@ja;
-    rdfs:label     "lieutenant commander"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "lieutenant commander"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/kind>
     rdf:type    kgc:Property;
     rdfs:label     "種類"@ja;
@@ -4794,6 +4817,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "dog whip"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/back_part_of_chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "木の椅子の背の部分"@ja;
     rdfs:label     "back part of chair"@en;
     rdf:type    kgc:OFobj;
@@ -4803,22 +4827,24 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen>
+    rdf:type    kgc:Person;
     rdfs:label     "ヘレン"@ja;
     rdfs:label     "Helen"@en;
     rdfs:label     "何も"@ja;
-    rdfs:label     "ヘレン，ジュリア，ロイロット"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ヘレン，ジュリア，ロイロット"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/like>
     rdf:type    kgc:Action;
     rdfs:label     "好む"@ja;
     rdfs:label     "like"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/wall_of_right_building>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "右側の棟の石の壁"@ja;
     rdfs:label     "wall of right building"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/wall>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/right_building>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/walll_of_Julia’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの寝室の壁"@ja;
     rdfs:label     "walll of Julia’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -4828,9 +4854,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "central building"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roma>
+    rdf:type    kgc:Person;
     rdfs:label     "ロマ"@ja;
-    rdfs:label     "Roma"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Roma"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/enter>
     rdf:type    kgc:Action;
     rdfs:label     "入る"@ja;
@@ -4840,7 +4866,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "帰る"@ja;
+    rdfs:label     "戻る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/narrow>
     rdf:type    kgc:Property;
@@ -4855,16 +4881,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "small"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/keep>
     rdf:type    kgc:Action;
-    rdfs:label     "飼っている"@ja;
+    rdfs:label     "維持する"@ja;
     rdfs:label     "keep"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/send>
     rdf:type    kgc:Action;
     rdfs:label     "送る"@ja;
     rdfs:label     "send"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/hole>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "穴"@ja;
-    rdfs:label     "hole"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "hole"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/asset_of_mother_of_Helen>
     rdfs:label     "asset of mother of Helen"@en;
     rdf:type    kgc:OFobj;
@@ -4873,11 +4899,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/mother_of_Helen>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Holmes>
+    rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
     rdfs:label     "Holmes"@en;
-    rdfs:label     "ホームズのもと"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ホームズのもと"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/central_building_of_mansion_of_Roylott>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "中央部"@ja;
     rdfs:label     "central building of mansion of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -4886,9 +4913,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/mansion>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/milk>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "牛乳"@ja;
-    rdfs:label     "milk"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "milk"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/gradually>
     rdfs:label     "徐々に"@ja;
     rdfs:label     "gradually"@en;
@@ -4933,6 +4960,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "尋ねる"@ja;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bruise_of_fingers_of_Roylott>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "青痣"@ja;
     rdfs:label     "bruise of fingers of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -4941,6 +4969,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/fingers>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/than_bedroom_of_sister>
+    rdf:type    kgc:Place;
     rdfs:label     "娘たちの寝室より"@ja;
     rdfs:label     "than bedroom of sister"@en;
     rdf:type    kgc:OFobj;
@@ -4951,24 +4980,25 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "堅い"@ja;
     rdfs:label     "tight"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Watson>
+    rdf:type    kgc:Person;
     rdfs:label     "ワトソン"@ja;
     rdfs:label     "Watson"@en;
     rdfs:label     "ホームズ"@ja;
-    rdfs:label     "ワトソンン"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ワトソンン"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/suspect>
     rdf:type    kgc:Action;
     rdfs:label     "疑う"@ja;
-    rdfs:label     "suspect"@en.
+    rdfs:label     "suspect"@en;
+    rdfs:label     "知る"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/tremble>
     rdf:type    kgc:Action;
     rdfs:label     "震える"@ja;
     rdfs:label     "tremble"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/shutter>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "鎧戸"@ja;
     rdfs:label     "shutter"@en;
-    rdfs:label     "閂"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "閂"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
     rdfs:label     "会う"@ja;
@@ -4985,18 +5015,18 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "夜明け"@ja;
     rdfs:label     "early morning"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Leatherhead_station>
+    rdf:type    kgc:Place;
     rdfs:label     "レザヘッド駅"@ja;
     rdfs:label     "Leatherhead station"@en;
-    rdfs:label     "レザヘッド"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "レザヘッド"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/quiet>
     rdfs:label     "静かである"@ja;
     rdfs:label     "quiet"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/chest>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "茶色の箪笥"@ja;
-    rdfs:label     "chest"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "chest"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/examine>
     rdf:type    kgc:Action;
     rdfs:label     "調べる"@ja;
@@ -5028,9 +5058,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "neck"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/low_celling>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "低い天井"@ja;
-    rdfs:label     "low celling"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "low celling"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notEnter>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5045,6 +5075,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "like steam gushing out"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/chimney_of_Julia’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの寝室の煙突"@ja;
     rdfs:label     "chimney of Julia’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -5071,14 +5102,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "気づく"@ja;
     rdfs:label     "notice"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/poison>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "毒"@ja;
-    rdfs:label     "poison"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "poison"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/recently>
     rdfs:label     "最近"@ja;
     rdfs:label     "recently"@en;
     rdf:type    kgc:AbstractTime.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/west_building_of_mansion_of_Roylott>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "西棟"@ja;
     rdfs:label     "west building of mansion of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -5091,9 +5123,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "今"@ja;
     rdfs:label     "now"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/1000_GBP>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "1000ポンド"@ja;
-    rdfs:label     "1000 GBP"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "1000 GBP"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notMove>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5105,9 +5137,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "half"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/2_years_ago>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "2年前"@ja;
-    rdfs:label     "2 years ago"@en.
+    rdfs:label     "2 years ago"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/unobservable>
     rdf:type    kgc:Property;
     rdfs:label     "目立たない"@ja;
@@ -5120,7 +5152,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notExist"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪れる"@ja;
+    rdfs:label     "訪ねる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/result>
     rdfs:label     "結果"@ja;
@@ -5141,32 +5173,33 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "suddenly"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "椅子"@ja;
-    rdfs:label     "chair"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "chair"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/crooked_voice>
     rdf:type    kgc:Property;
     rdfs:label     "しゃがれ声"@ja;
     rdfs:label     "crooked voice"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Stoke_Moran>
+    rdf:type    kgc:Place;
     rdfs:label     "ストークモラン"@ja;
     rdfs:label     "Stoke Moran"@en;
-    rdfs:label     "ストーク・モラン"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ストーク・モラン"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/strange_points>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "奇妙な点がいくつか"@ja;
-    rdfs:label     "strange points"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "strange points"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/sister>
+    rdf:type    kgc:Person;
     rdfs:label     "姉妹"@ja;
     rdfs:label     "sister"@en;
-    rdfs:label     "娘"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "娘"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotFind>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つからない"@ja;
+    rdfs:label     "見つけられない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/wrist>
     rdfs:label     "wrist"@en;
@@ -5175,6 +5208,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "engagement"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/price_of_asset_of_mother_of_Helen>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "関係する投下資本の現在価格"@ja;
     rdfs:label     "price of asset of mother of Helen"@en;
     rdf:type    kgc:OFobj;
@@ -5184,9 +5218,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/mother>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/garden>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "芝地"@ja;
-    rdfs:label     "garden"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "garden"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/marry>
     rdf:type    kgc:Action;
     rdfs:label     "結婚する"@ja;
@@ -5202,9 +5236,9 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/pull>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/the_doorbell>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/marriage>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "結婚"@ja;
-    rdfs:label     "marriage"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "marriage"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notSleep>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5223,19 +5257,19 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "半時間のあいだ"@ja;
     rdfs:label     "for half an hour"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/clothes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "衣服"@ja;
-    rdfs:label     "clothes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "clothes"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/jumpUp>
     rdf:type    kgc:Action;
-    rdfs:label     "飛び上がる"@ja;
+    rdfs:label     "跳び上がる"@ja;
     rdfs:label     "jumpUp"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/safe>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "大きい金庫"@ja;
     rdfs:label     "safe"@en;
     rdfs:label     "金庫"@ja;
-    rdfs:label     "金庫の上"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "金庫の上"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/notAsleep>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5292,9 +5326,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ふらふら"@ja;
     rdfs:label     "beDizzy"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/metal_fittings>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "金具"@ja;
-    rdfs:label     "metal fittings"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "metal fittings"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/brown_specled_yellow_band>
     rdf:type    kgc:Property;
     rdfs:label     "褐色の斑がついた黄色い紐"@ja;
@@ -5304,13 +5338,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "750ポンド"@ja;
     rdfs:label     "750 GBP"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/scaffold>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "足場"@ja;
-    rdfs:label     "scaffold"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "scaffold"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Danger>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "危険"@ja;
-    rdfs:label     "Danger"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Danger"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/father-in-law_of_Helen>
     rdf:type    kgc:Property;
     rdfs:label     "ヘレンの義理の父"@ja;
@@ -5319,6 +5353,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/father-in-law>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/Helen>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/body_of_Julia>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの体"@ja;
     rdfs:label     "body of Julia"@en;
     rdf:type    kgc:OFobj;
@@ -5328,20 +5363,21 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "at the same time as rope"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/roof_of_left_building>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "左側の棟の屋根"@ja;
     rdfs:label     "roof of left building"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/roof>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/left_building>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/living_room>
+    rdf:type    kgc:Place;
     rdfs:label     "居間の隣"@ja;
-    rdfs:label     "living room"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "living room"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notHave>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "not持つ"@ja;
+    rdfs:label     "持たない"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/question>
     rdfs:label     "question"@en;
@@ -5351,10 +5387,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "新しい"@ja;
     rdfs:label     "new"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/round_table>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "円卓が一つ"@ja;
     rdfs:label     "round table"@en;
-    rdfs:label     "円卓"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "円卓"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/callBack>
     rdf:type    kgc:Action;
     rdfs:label     "呼び戻す"@ja;
@@ -5377,34 +5413,34 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "強い"@ja;
     rdfs:label     "strong"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/limbs>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "手足"@ja;
-    rdfs:label     "limbs"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "limbs"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/goDown>
     rdf:type    kgc:Action;
-    rdfs:label     "降りる"@ja;
+    rdfs:label     "下りる"@ja;
     rdfs:label     "goDown"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/use>
     rdf:type    kgc:Action;
     rdfs:label     "使う"@ja;
     rdfs:label     "use"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/culprit>
+    rdf:type    kgc:Person;
     rdfs:label     "犯人"@ja;
-    rdfs:label     "culprit"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "culprit"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/door>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ドア"@ja;
-    rdfs:label     "door"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "door"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/whistle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "口笛"@ja;
     rdfs:label     "whistle"@en;
-    rdfs:label     "低い口笛"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "低い口笛"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/fireplace>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "大きい暖炉"@ja;
-    rdfs:label     "fireplace"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "fireplace"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/whip>
     rdfs:label     "鞭"@ja;
     rdfs:label     "whip"@en;
@@ -5420,10 +5456,10 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/sound>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/snake>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/today>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "今日"@ja;
     rdfs:label     "today"@en;
-    rdfs:label     "今日の日中"@ja.
+    rdfs:label     "今日の日中"@ja;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/corner_of_ceiling>
     rdfs:label     "天井の隅"@ja;
     rdfs:label     "corner of ceiling"@en;
@@ -5435,6 +5471,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Safe"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/story_of_Helen>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘレンの話した内容"@ja;
     rdfs:label     "story of Helen"@en;
     rdf:type    kgc:OFobj;
@@ -5442,29 +5479,30 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen>.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "嗅ぐ"@ja;
+    rdfs:label     "匂う"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/handgun>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "拳銃"@ja;
-    rdfs:label     "handgun"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "handgun"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Percy_Armitage>
+    rdf:type    kgc:Person;
     rdfs:label     "パーシィ・アーミティッジ"@ja;
-    rdfs:label     "Percy Armitage"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Percy Armitage"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/alone>
     rdfs:label     "ひとり"@ja;
     rdfs:label     "alone"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/signal>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "合図"@ja;
-    rdfs:label     "signal"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "signal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着る"@ja;
+    rdfs:label     "着ている"@ja;
     rdfs:label     "wear"@en;
-    rdf:type    kgc:Action.
+    rdf:type    kgc:Action;
+    rdfs:label     "着る"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/dark>
     rdf:type    kgc:Property;
     rdfs:label     "暗い"@ja;
@@ -5479,7 +5517,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fall"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/gain>
     rdf:type    kgc:Action;
-    rdfs:label     "獲得する"@ja;
+    rdfs:label     "得る"@ja;
     rdfs:label     "gain"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/putInto>
     rdf:type    kgc:Action;
@@ -5502,9 +5540,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Notice"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/interesting_features>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "非常に興味深い特徴"@ja;
-    rdfs:label     "interesting features"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "interesting features"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/request>
     rdfs:label     "request"@en;
     rdf:type    kgc:Object.
@@ -5512,14 +5550,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Stoke Moran"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/poisonous_snake>
+    rdf:type    kgc:Animal;
     rdfs:label     "毒沼蛇"@ja;
-    rdfs:label     "poisonous snake"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "poisonous snake"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/speckled_band>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "まだらの紐"@ja;
     rdfs:label     "speckled band"@en;
-    rdfs:label     "まだらのひも"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "まだらのひも"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/simple>
     rdf:type    kgc:Property;
     rdfs:label     "質素"@ja;
@@ -5533,9 +5571,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "30歳"@ja;
     rdfs:label     "30 years old"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/in_ten_seconds>
+    rdf:type    kgc:AbstractTime;
     rdfs:label     "十秒で"@ja;
-    rdfs:label     "in ten seconds"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "in ten seconds"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/forecast>
     rdf:type    kgc:Action;
     rdfs:label     "予想する"@ja;
@@ -5545,6 +5583,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "叫ぶ"@ja;
     rdfs:label     "shout"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/garden_of_Roylott>
+    rdf:type    kgc:Place;
     rdfs:label     "ロイロットの庭"@ja;
     rdfs:label     "garden of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -5557,17 +5596,17 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "殺す"@ja;
     rdfs:label     "kill"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/candle>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "燃えさしの蝋燭"@ja;
-    rdfs:label     "candle"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "candle"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/leak>
     rdf:type    kgc:Action;
     rdfs:label     "漏れる"@ja;
     rdfs:label     "leak"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Harrow>
+    rdf:type    kgc:Place;
     rdfs:label     "ハロウ"@ja;
-    rdfs:label     "Harrow"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Harrow"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/one_building>
     rdfs:label     "one building"@en;
     rdf:type    kgc:Object.
@@ -5592,7 +5631,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "contain"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/getOff>
     rdf:type    kgc:Action;
-    rdfs:label     "飛び降りる"@ja;
+    rdfs:label     "下車する"@ja;
     rdfs:label     "getOff"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fixed>
     rdf:type    kgc:Property;
@@ -5605,20 +5644,20 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/using_rope>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/bell>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/decorative_wear>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "化粧着"@ja;
-    rdfs:label     "decorative wear"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "decorative wear"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/OutsideAir>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "外気"@ja;
-    rdfs:label     "OutsideAir"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "OutsideAir"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/the_invested_capital>
     rdfs:label     "the invested capital"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/headache>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "頭痛"@ja;
-    rdfs:label     "headache"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "headache"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/engage>
     rdf:type    kgc:Action;
     rdfs:label     "婚約する"@ja;
@@ -5633,6 +5672,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "specifically"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/window_of_mansion_of_Roylott>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "屋敷の窓"@ja;
     rdfs:label     "window of mansion of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -5645,10 +5685,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "真っ青である"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/India>
+    rdf:type    kgc:Place;
     rdfs:label     "インド"@ja;
-    rdfs:label     "India"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "India"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/sister_of_mother_of_Helen>
+    rdf:type    kgc:Person;
     rdfs:label     "姉妹の母の妹"@ja;
     rdfs:label     "sister of mother of Helen"@en;
     rdf:type    kgc:OFobj;
@@ -5674,25 +5715,25 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/jaw>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/brandy>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ブランデー"@ja;
-    rdfs:label     "brandy"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "brandy"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/cat>
     rdfs:label     "猫"@ja;
     rdfs:label     "cat"@en;
-    rdfs:label     "大きな猫"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Animal;
+    rdfs:label     "大きな猫"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/one_match_cinders>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "マッチの燃えさし"@ja;
-    rdfs:label     "one match cinders"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "one match cinders"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia>
+    rdf:type    kgc:Person;
     rdfs:label     "ジュリア"@ja;
     rdfs:label     "Julia"@en;
     rdfs:label     "ヘレン"@ja;
     rdfs:label     "ヘレン，ジュリア，ロイロット"@ja;
-    rdfs:label     "ご婦人（ヘレンの姉）"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "ご婦人（ヘレンの姉）"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/some_years_ago>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "何年か前"@ja;
@@ -5707,9 +5748,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "夜11時"@ja;
     rdfs:label     "事件当夜"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/match_box>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "マッチの箱"@ja;
-    rdfs:label     "match box"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "match box"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/lose>
     rdf:type    kgc:Action;
     rdfs:label     "失う"@ja;
@@ -5731,11 +5772,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/coroner>
     rdfs:label     "検視官"@ja;
     rdfs:label     "coroner"@en;
-    rdfs:label     "毒物"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:PhysicalObject;
+    rdf:type    kgc:Person;
+    rdfs:label     "毒物"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/work>
     rdf:type    kgc:Action;
-    rdfs:label     "働く"@ja;
+    rdfs:label     "仕事をする"@ja;
     rdfs:label     "work"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/by_falling_price>
     rdfs:label     "by falling price"@en;
@@ -5745,10 +5787,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Case"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/plan>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "計画"@ja;
-    rdfs:label     "plan"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "plan"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/neck_of_Roylott>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロイロット博士の首"@ja;
     rdfs:label     "neck of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -5768,11 +5811,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/sit>
     rdf:type    kgc:Action;
     rdfs:label     "座る"@ja;
-    rdfs:label     "sit"@en.
+    rdfs:label     "sit"@en;
+    rdfs:label     "存在する"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/central_building>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "中央部"@ja;
-    rdfs:label     "central building"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "central building"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/villager>
     rdfs:label     "villager"@en;
     rdf:type    kgc:Object.
@@ -5793,15 +5837,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "集中している"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/desk>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "机の隅"@ja;
     rdfs:label     "desk"@en;
     rdfs:label     "細く長い杖のそば"@ja;
-    rdfs:label     "卓上"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "卓上"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/four_walls_of_Julia’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの寝室の四方の壁"@ja;
     rdfs:label     "four walls of Julia’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -5815,13 +5860,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott’s_bedroom>.
 <http://kgc.knowledge-graph.jp/data/predicate/lookAround>
     rdf:type    kgc:Action;
-    rdfs:label     "ながめ回す"@ja;
+    rdfs:label     "見まわす"@ja;
     rdfs:label     "lookAround"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/cane>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "細く長い杖"@ja;
     rdfs:label     "cane"@en;
-    rdfs:label     "杖で"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "杖で"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/make>
     rdf:type    kgc:Action;
     rdfs:label     "作る"@ja;
@@ -5832,15 +5877,15 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/beReleased>
     rdf:type    kgc:Action;
-    rdfs:label     "存在する"@ja;
+    rdfs:label     "放たれる"@ja;
     rdfs:label     "beReleased"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/back_part>
     rdfs:label     "back part"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/simple_furniture>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "質素な家具"@ja;
-    rdfs:label     "simple furniture"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "simple furniture"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/tightly>
     rdfs:label     "しっかり"@ja;
     rdfs:label     "tightly"@en;
@@ -5851,16 +5896,16 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "this morning"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/arrive>
     rdf:type    kgc:Action;
-    rdfs:label     "到着する"@ja;
+    rdfs:label     "来る"@ja;
     rdfs:label     "arrive"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/scar>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "傷跡"@ja;
-    rdfs:label     "scar"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "scar"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/vanity>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "化粧台"@ja;
-    rdfs:label     "vanity"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "vanity"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/one_building_of_mansion_of_Roylott>
     rdfs:label     "one building of mansion of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -5898,8 +5943,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/gothrough>;
-    rdfs:label     "通れない"@ja;
-    rdfs:label     "cannotGoThrough"@en.
+    rdfs:label     "通り抜けできない"@ja;
+    rdfs:label     "cannotGoThrough"@en;
+    rdfs:label     "通れない"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/by_hitting>
     rdfs:label     "叩いて"@ja;
     rdfs:label     "by hitting"@en;
@@ -5923,6 +5969,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/animal>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/India>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/first_floor_of_one_building_of_mansion_of_Roylott>
+    rdf:type    kgc:Place;
     rdfs:label     "ロイロットの屋敷の一棟の一階"@ja;
     rdfs:label     "first floor of one building of mansion of Roylott"@en;
     rdf:type    kgc:OFobj;
@@ -5938,9 +5985,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Enter"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bad_act>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "悪行"@ja;
-    rdfs:label     "bad act"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "bad act"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/explain>
     rdf:type    kgc:Action;
     rdfs:label     "説明する"@ja;
@@ -5950,6 +5997,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "昨日から"@ja;
     rdfs:label     "since yesterday"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/The_current_price_of_the_invested_capital>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "関係する投下資本の現在価格"@ja;
     rdfs:label     "The current price of the invested capital"@en;
     rdf:type    kgc:OFobj;
@@ -5965,6 +6013,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "animal"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/handkerchief_of_Roma>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ハンカチーフ"@ja;
     rdfs:label     "handkerchief of Roma"@en;
     rdf:type    kgc:OFobj;
@@ -5974,47 +6023,48 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "The current price"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/man>
+    rdf:type    kgc:Person;
     rdfs:label     "人"@ja;
     rdfs:label     "man"@en;
-    rdfs:label     "誰も"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "誰も"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/fingers_of_Roylott>
     rdfs:label     "fingers of Roylott"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/fingers>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/mouse>
+    rdf:type    kgc:Animal;
     rdfs:label     "ネズミ"@ja;
-    rdfs:label     "mouse"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "mouse"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/door_of_safe>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "金庫の戸"@ja;
     rdfs:label     "door of safe"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/door>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/safe>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/elbow_chair>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "肘掛椅子が一つ"@ja;
     rdfs:label     "elbow chair"@en;
-    rdfs:label     "肘掛け椅子"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "肘掛け椅子"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/read>
     rdf:type    kgc:Action;
     rdfs:label     "読む"@ja;
     rdfs:label     "read"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Leopard>
+    rdf:type    kgc:Animal;
     rdfs:label     "豹"@ja;
-    rdfs:label     "Leopard"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Leopard"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Have>
     rdfs:label     "Have"@en;
-    rdfs:label     "持つ"@ja;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/scream>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "悲鳴"@ja;
-    rdfs:label     "scream"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "scream"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/engagement_of_Julia>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの婚約"@ja;
     rdfs:label     "engagement of Julia"@en;
     rdf:type    kgc:OFobj;
@@ -6022,7 +6072,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia>.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上る"@ja;
+    rdfs:label     "上がる"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/die>
     rdf:type    kgc:Action;
@@ -6036,12 +6086,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/respond>;
-    rdfs:label     "反応しない"@ja;
+    rdfs:label     "答えない"@ja;
     rdfs:label     "notRespond"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Sleeping_Woman>
     rdfs:label     "寝台に寝ていた女性"@ja;
     rdfs:label     "Sleeping Woman"@en;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/floor>
     rdfs:label     "床"@ja;
     rdfs:label     "floor"@en;
@@ -6057,9 +6107,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "わからない"@ja;
     rdfs:label     "notUnderstand"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/metallic_sound>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "金属音"@ja;
-    rdfs:label     "metallic sound"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "metallic sound"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/tie>
     rdf:type    kgc:Property;
     rdfs:label     "結ばれている"@ja;
@@ -6068,38 +6118,40 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Open"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/stone_wall>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "堅い石壁"@ja;
-    rdfs:label     "stone wall"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "stone wall"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/approach>
     rdf:type    kgc:Action;
     rdfs:label     "近寄る"@ja;
     rdfs:label     "approach"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/knee_of_Roylott>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロイロット博士の膝の上"@ja;
     rdfs:label     "knee of Roylott"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/knee>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/four_nails>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "四本の釘"@ja;
-    rdfs:label     "four nails"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "four nails"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/right_building>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "右の棟"@ja;
     rdfs:label     "right building"@en;
     rdfs:label     "右側の棟"@ja;
-    rdfs:label     "右側の棟の反対側"@ja;
-    rdf:type    kgc:Object.
+    rdf:type    kgc:Place;
+    rdfs:label     "右側の棟の反対側"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bed>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "寝台"@ja;
     rdfs:label     "bed"@en;
     rdfs:label     "寝台のそば"@ja;
     rdfs:label     "枕"@ja;
     rdfs:label     "寝台のわきに"@ja;
     rdfs:label     "普通の寝台"@ja;
-    rdfs:label     "寝台のへり"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "寝台のへり"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/the_time>
     rdfs:label     "the time"@en;
     rdf:type    kgc:Object.
@@ -6139,7 +6191,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "滞在する"@ja;
+    rdfs:label     "留まる"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/friend_of_Roylott>
     rdf:type    kgc:Property;
@@ -6162,13 +6214,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "立つ"@ja;
     rdfs:label     "stand"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/housekeeper>
+    rdf:type    kgc:Person;
     rdfs:label     "召使い"@ja;
-    rdfs:label     "housekeeper"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "housekeeper"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Crane_Water>
+    rdf:type    kgc:Place;
     rdfs:label     "クレイン・ウォータ"@ja;
-    rdfs:label     "Crane Water"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Crane Water"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/escape>
     rdf:type    kgc:Action;
     rdfs:label     "逃げる"@ja;
@@ -6178,14 +6230,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "面している"@ja;
     rdfs:label     "face"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/folding_bed>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "折りたたみ寝台"@ja;
-    rdfs:label     "folding bed"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "folding bed"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/instruct>
     rdf:type    kgc:Action;
     rdfs:label     "指示する"@ja;
     rdfs:label     "instruct"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/wedding_ceremony_of_Julia>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ジュリアの結婚式"@ja;
     rdfs:label     "wedding ceremony of Julia"@en;
     rdf:type    kgc:OFobj;
@@ -6200,25 +6253,26 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "修理されている"@ja;
     rdfs:label     "repaired"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Indian_cigarettes>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ロイロット博士の煙草"@ja;
-    rdfs:label     "Indian cigarettes"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "Indian cigarettes"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/gray>
     rdf:type    kgc:Property;
     rdfs:label     "灰色"@ja;
     rdfs:label     "gray"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/corridor>
+    rdf:type    kgc:Place;
     rdfs:label     "廊下"@ja;
-    rdfs:label     "corridor"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "corridor"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/prepare>
     rdf:type    kgc:Action;
     rdfs:label     "準備する"@ja;
     rdfs:label     "prepare"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
-    rdfs:label     "開く"@ja;
+    rdfs:label     "開ける"@ja;
     rdfs:label     "open"@en;
+    rdfs:label     "開く"@ja;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/same_place>
     rdfs:label     "同じ位置"@ja;
@@ -6235,12 +6289,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "引く"@ja;
     rdfs:label     "pull"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>
+    rdf:type    kgc:Person;
     rdfs:label     "ロイロット"@ja;
     rdfs:label     "Roylott"@en;
     rdfs:label     "ロイロット博士"@ja;
     rdfs:label     "ヘレン，ジュリア，ロイロット"@ja;
-    rdfs:label     "博士"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "博士"@ja.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/within_2_months>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "２ヶ月以内"@ja;
@@ -6266,14 +6320,15 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "燃やす"@ja;
     rdfs:label     "fire"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/8_years_ago>
-    rdf:type    kgc:AbstractTime;
     rdfs:label     "8年前"@ja;
-    rdfs:label     "8 years ago"@en.
+    rdfs:label     "8 years ago"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/night>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "夜"@ja;
     rdfs:label     "night"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/wall_of_Helen’s_bedroom>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "ヘレンの寝室の壁"@ja;
     rdfs:label     "wall of Helen’s bedroom"@en;
     rdf:type    kgc:OFobj;
@@ -6295,16 +6350,16 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/fight>
     rdf:type    kgc:Action;
-    rdfs:label     "格闘する"@ja;
+    rdfs:label     "戦う"@ja;
     rdfs:label     "fight"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/VentilationHole>
     rdf:type    kgc:Property;
     rdfs:label     "通風孔"@ja;
     rdfs:label     "VentilationHole"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/London>
+    rdf:type    kgc:Place;
     rdfs:label     "ロンドン"@ja;
-    rdfs:label     "London"@en;
-    rdf:type    kgc:Object.
+    rdfs:label     "London"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/See>
     rdfs:label     "See"@en;
     rdf:type    kgc:Object.
@@ -6313,10 +6368,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "楽団"@ja;
     rdfs:label     "band"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/left_building>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "左の棟"@ja;
     rdfs:label     "left building"@en;
-    rdfs:label     "左側の棟"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "左側の棟"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/friend>
     rdfs:label     "friend"@en;
     rdf:type    kgc:Object.
@@ -6341,16 +6396,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen’s_mothers_death>.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "したい"@ja;
+    rdfs:label     "望む"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bedroom_of_housekeeper>
+    rdf:type    kgc:Place;
     rdfs:label     "家政婦の寝室"@ja;
     rdfs:label     "bedroom of housekeeper"@en;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SpeckledBand/bedroom>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/housekeeper>.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/band>
+    rdf:type    kgc:PhysicalObject;
     rdfs:label     "褐色の斑《ぶち》がついた黄色い紐"@ja;
     rdfs:label     "band"@en;
-    rdfs:label     "紐"@ja;
-    rdf:type    kgc:Object.
+    rdfs:label     "紐"@ja.


### PR DESCRIPTION
Typeの修正
- 人物のtypeがすべてObjectになっていたのでPersonに修正

その他 
- AbbeyGrange
  - caseがPersonになっていたのでObjectに修正
  - Lady BrackenstallがPlaceになっていたのでPersonに修正
  - Mouth of Lady BrackenstallがPersonになっていたのでObjectに修正
- CrookedMan
  - シンプソンのURIが日本語になっていたので英語に修正
- ACaseOfIdentity
  - Sutherlandの日本語ラベルにホームズが混入していたことの修正
