### PR TITLE
EtoJの適用とキャラクター名修正

### DIFF
--- a/ACaseOfIdentity.ttl
+++ b/ACaseOfIdentity.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -699,11 +699,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/060>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズがホズマを見つける"@ja ;
-    kgc:source  "Holmes find Hozma"@en ;
+    kgc:source  "Holmes find Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/062>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは稼ぎをホームズに渡す"@ja ;
@@ -732,47 +732,47 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/065>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは呑気である"@ja ;
-    kgc:source  "Windybank is naive"@en ;
+    kgc:source  "Windibank is naive"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/careless> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/066>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは警察に行きたくない"@ja ;
-    kgc:source  "Windybank does not want to go to the police"@en ;
+    kgc:source  "Windibank does not want to go to the police"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/unwillingToGo> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/police> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/067>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはホームズを訪ねたくない"@ja ;
-    kgc:source  "Windybank does not want to visit Holmes"@en ;
+    kgc:source  "Windibank does not want to visit Holmes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/67a> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/67a>
     rdf:type    kgc:Statement ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/visit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/068>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの義理の父である"@ja ;
-    kgc:source  "Windybank is Sutherland's father-in-law"@en ;
+    kgc:source  "Windibank is Sutherland's father-in-law"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/father-in-law_of_Sutherland> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/069>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドより5年2ヶ月年上である"@ja ;
-    kgc:source  "Windybank is 5 years and 2 months older than Sutherland"@en ;
+    kgc:source  "Windibank is 5 years and 2 months older than Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/older> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/5_years_2_months> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/070>
     rdf:type    kgc:Statement ;
@@ -839,18 +839,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/077>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの父の店を売らせた"@ja ;
-    kgc:source  "Windybank sold her father's shop in Sutherland"@en ;
+    kgc:source  "Windibank sold her father's shop in Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sell> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/shop_of_father_of_Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/078>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはワインの外商である"@ja ;
-    kgc:source  "Windybank is a wine commerce"@en ;
+    kgc:source  "Windibank is a wine commerce"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/foreign_trade_of_wine> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/079>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの父の店は4700ポンドで売れた"@ja ;
@@ -1081,19 +1081,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/105>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは利回りから四分の一を引き出す"@ja ;
-    kgc:source  "Windybank draws a quarter from the yield"@en ;
+    kgc:source  "Windibank draws a quarter from the yield"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pullOut> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/yield> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/one_quarter> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/106>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの母に渡す"@ja ;
-    kgc:source  "Windybank passes to mother of Sutherland"@en ;
+    kgc:source  "Windibank passes to mother of Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/handOver> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/107>
     rdf:type    kgc:Statement ;
@@ -1170,14 +1170,14 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/114>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはガス工組合の舞踏会でホズマと出会う"@ja ;
-    kgc:source  "Sutherland Meets Hozma at the Gas Industry Association Ball"@en ;
+    kgc:source  "Sutherland Meets Hosmer at the Gas Industry Association Ball"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance_of_Gas_Industry> ;
     kgc:time  "1890-09-01T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1890-09-01> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/115>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの父はガス工組合の舞踏会の招待状をサザランドに送っていた"@ja ;
@@ -1204,10 +1204,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/117>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下を承知しない"@ja ;
-    kgc:source  "Windybank does not know"@en ;
+    kgc:source  "Windibank does not know"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notAccept> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/118> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/119> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/120> .
@@ -1231,10 +1231,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/120>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下で狂う"@ja ;
-    kgc:source  "Windybank goes mad below"@en ;
+    kgc:source  "Windibank goes mad below"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/angry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/121> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/122> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/121>
@@ -1266,26 +1266,26 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/123>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドを止められない"@ja ;
-    kgc:source  "Windybank can not stop Sutherland"@en ;
+    kgc:source  "Windibank can not stop Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotStop> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/122a> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/124> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/124>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下を言う"@ja ;
-    kgc:source  "Windybank says"@en ;
+    kgc:source  "Windibank says"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/125> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/127> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/125>
     rdf:type    kgc:Statement ;
     kgc:source  "舞踏会の人は価値を持たない"@ja ;
     kgc:source  "People in the ball have no value"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/people_of_Dance_party> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/value> .
@@ -1300,16 +1300,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/127>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/128> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/131> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/128>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは着る服を持たない"@ja ;
     kgc:source  "Sutherland has no clothes to wear"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Clothes_to_wear> .
@@ -1336,10 +1336,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/132>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは所用のためフランスへ行った"@ja ;
-    kgc:source  "Windybank went to France for work."@en ;
+    kgc:source  "Windibank went to France for work."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Required> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/France> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/133> .
@@ -1357,12 +1357,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/134>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは舞踏会でホズマに会った"@ja ;
-    kgc:source  "Sutherland met Hozma at the ball"@en ;
+    kgc:source  "Sutherland met Hosmer at the ball"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Dance_party> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/135>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは以下を思った"@ja ;
@@ -1375,10 +1375,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/136>
     rdf:type    kgc:Thought ;
     kgc:source  "ウィンディバンクは以下を不満だった"@ja ;
-    kgc:source  "Windybank complained of"@en ;
+    kgc:source  "Windibank complained of"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/dissatisfied> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/137> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/137>
     rdf:type    kgc:Thought ;
@@ -1399,10 +1399,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/139>
     rdf:type    kgc:Thought ;
     kgc:source  "ウィンディバンクは嬉しい"@ja ;
-    kgc:source  "Windybank is happy"@en ;
+    kgc:source  "Windibank is happy"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland_s_thoughts> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/happy> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/140>
     rdf:type    kgc:Situation ;
     kgc:source  "サザランドは以下を言った"@ja ;
@@ -1414,22 +1414,22 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/141>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは笑った"@ja ;
-    kgc:source  "Windybank laughed"@en ;
+    kgc:source  "Windibank laughed"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/laugh> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/142>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/143> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/143>
     rdf:type    kgc:Statement ;
     kgc:source  "女は自由である"@ja ;
     kgc:source  "Woman is free"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/free> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/woman> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/144>
@@ -1450,68 +1450,68 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/145>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは舞踏会でホズマに出会った"@ja ;
-    kgc:source  "Sutherland met Hozma at a ball"@en ;
+    kgc:source  "Sutherland met Hosmer at a ball"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/146> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/146>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは舞踏会の翌日にサザランドの家を訪ねる"@ja ;
-    kgc:source  "Hozma visits Sutherland's house the day after the ball"@en ;
+    kgc:source  "Hosmer visits Sutherland's house the day after the ball"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/visit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland_House> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/day_after_dance> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/147> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/147>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは舞踏会の後もホズマに会う"@ja ;
-    kgc:source  "Sutherland meets Hozma after the ball"@en ;
+    kgc:source  "Sutherland meets Hosmer after the ball"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/after_dance> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/148> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/148>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマと二度会っている"@ja ;
-    kgc:source  "Sutherland has met Hozma twice"@en ;
+    kgc:source  "Sutherland has met Hosmer twice"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meeting> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/twice> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/149> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/149>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは家に戻った"@ja ;
-    kgc:source  "Windybank returned home"@en ;
+    kgc:source  "Windibank returned home"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Windibank> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/150> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/150>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは家に来られない"@ja ;
-    kgc:source  "Hozma can not come home"@en ;
+    kgc:source  "Hosmer can not come home"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotCome> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Sutherland> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/151> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/151>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下が嫌いである"@ja ;
-    kgc:source  "Windybank dislikes"@en ;
+    kgc:source  "Windibank dislikes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notLike> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/152> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/152>
     rdf:type    kgc:Statement ;
@@ -1524,15 +1524,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/153>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を思った"@ja ;
-    kgc:source  "Windybank thought that"@en ;
+    kgc:source  "Windibank thought that"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/154> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/154>
     rdf:type    kgc:Thought ;
     kgc:source  "家庭内で女性は幸せである"@ja ;
     kgc:source  "Women are happy at home"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank_s_Thoughts> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank_s_Thoughts> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/happy> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Woman> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/home> .
@@ -1575,35 +1575,35 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/159>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは一週間後にフランスへ行く"@ja ;
-    kgc:source  "Windybank goes to France a week later"@en ;
+    kgc:source  "Windibank goes to France a week later"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/France> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/After_a_week> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/160>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは以下を言った"@ja ;
-    kgc:source  "Hozma said the following"@en ;
+    kgc:source  "Hosmer said the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/161> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/161>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはウィンディバンクがいる間にサザランドと会わない"@ja ;
-    kgc:source  "Hozma does not meet Sutherland while Windybank is"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> .
+    kgc:source  "Hosmer does not meet Sutherland while Windibank is"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/162>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notMeet> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/161>
     rdf:type    kgc:Situation ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/162>
     rdf:type    kgc:Situation ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/existence_of_Windybank> .
+    kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/existence_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/163>
     rdf:type    kgc:Situation ;
     kgc:source  "サザランドは以下を言った"@ja ;
@@ -1632,11 +1632,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/164>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドとホズマは毎日、手紙を書いた"@ja ;
-    kgc:source  "Sutherland and Hozma wrote a letter every day"@en ;
+    kgc:source  "Sutherland and Hosmer wrote a letter every day"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/write> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/every_day> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/165> .
@@ -1653,45 +1653,45 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/166>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは手紙を知らない"@ja ;
-    kgc:source  "Windybank does not know the letter"@en ;
+    kgc:source  "Windibank does not know the letter"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/167> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/167>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは初散歩の時にホズマと婚約した"@ja ;
-    kgc:source  "Sutherland was engaged to Hozma at the first walk"@en ;
+    kgc:source  "Sutherland was engaged to Hosmer at the first walk"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/engage> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/First_walk> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/169> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/168>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはレドンホール街の事務所の出納係である"@ja ;
-    kgc:source  "Hozma is the teller of Redon Hall Street office"@en ;
+    kgc:source  "Hosmer is the teller of Redon Hall Street office"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/teller_of_Redon_Hall_Street_office> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/169>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマの業種を知らない"@ja ;
-    kgc:source  "Sutherland does not know the industry of Hozma"@en ;
+    kgc:source  "Sutherland does not know the industry of Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Industries_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Industries_of_Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/170> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/170>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはレドンホール街の事務所に住んでいる"@ja ;
-    kgc:source  "Hozma lives in the office of Redon Hall Street"@en ;
+    kgc:source  "Hosmer lives in the office of Redon Hall Street"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Office_of_Redon_Hall_Street> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/171> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/171>
@@ -1707,10 +1707,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/172>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの住所はレドンホール街にある"@ja ;
-    kgc:source  "Hozma's address is on Redon Hall Street"@en ;
+    kgc:source  "Hosmer's address is on Redon Hall Street"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Redon_Hall_Street> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/173>
     rdf:type    kgc:Statement ;
@@ -1724,9 +1724,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/174>
     rdf:type    kgc:Situation ;
     kgc:source  "ホズマは以下を言った"@ja ;
-    kgc:source  "Hozma said the following"@en ;
+    kgc:source  "Hosmer said the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/176> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/177> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/178> ;
@@ -1737,40 +1737,40 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの手紙が事務所に届く"@ja ;
     kgc:source  "Sutherland's letter arrives at the office"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/reach> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Sutherland> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Office> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/178>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは同僚にからかわれる"@ja ;
-    kgc:source  "Hozma is teased by colleagues"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> ;
+    kgc:source  "Hosmer is teased by colleagues"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beTeased> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Coworker> ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/176> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/179> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/179>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはタイプ打ちの手紙を受け取りたくない"@ja ;
-    kgc:source  "Hozma does not want to receive typing letters"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> ;
+    kgc:source  "Hosmer does not want to receive typing letters"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/179a> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/180> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/179a>
     rdf:type    kgc:Statement ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_type> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/180>
     rdf:type    kgc:Statement ;
     kgc:source  "手書きの手紙はサザランドを感じる"@ja ;
     kgc:source  "Handwritten letter feels Sutherland"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/feel> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Handwritten_letter> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
@@ -1779,7 +1779,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "タイプ打ちの手紙は機械を感じる"@ja ;
     kgc:source  "Typing letter feels machine"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/feel> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_type> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/machine> .
@@ -1795,19 +1795,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/183>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはサザランドを愛している"@ja ;
-    kgc:source  "Hozma loves Sutherland"@en ;
+    kgc:source  "Hosmer loves Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/184> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/184>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは気を配る"@ja ;
-    kgc:source  "Hozma pays attention"@en ;
+    kgc:source  "Hosmer pays attention"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/payAttention> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/185>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは座右（以下）の銘を言った"@ja ;
@@ -1890,38 +1890,38 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/188>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは恥ずかしがり屋である"@ja ;
-    kgc:source  "Hozma is shy"@en ;
+    kgc:source  "Hosmer is shy"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/shy> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/192>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは内気である"@ja ;
-    kgc:source  "Hozma is shy"@en ;
+    kgc:source  "Hosmer is shy"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/shy> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/193>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは紳士らしい"@ja ;
-    kgc:source  "Hozma is a gentleman"@en ;
+    kgc:source  "Hosmer is a gentleman"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/gentle> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/194>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの声が細い"@ja ;
-    kgc:source  "Hozma's voice is thin"@en ;
+    kgc:source  "Hosmer's voice is thin"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/thin> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/195>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは若いときに扁桃炎を患った"@ja ;
-    kgc:source  "Hozma suffered tonsillitis when he was young"@en ;
+    kgc:source  "Hosmer suffered tonsillitis when he was young"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sufferFrom> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/young> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Tonsillitis> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/196>
@@ -1930,77 +1930,77 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/197>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは弱い喉を持つ"@ja ;
-    kgc:source  "Hozma has a weak throat"@en ;
+    kgc:source  "Hosmer has a weak throat"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Weak_throat> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/198>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはささやくように話す"@ja ;
-    kgc:source  "Hozma speaks whisperly"@en ;
+    kgc:source  "Hosmer speaks whisperly"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/talk> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/whisper> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/199>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの身だしなみはよい"@ja ;
-    kgc:source  "The appearance of Hozma is good"@en ;
+    kgc:source  "The appearance of Hosmer is good"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/good> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/200>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの目は悪い"@ja ;
-    kgc:source  "Hozma's eyes are bad"@en ;
+    kgc:source  "Hosmer's eyes are bad"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bad> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Eyes_of_hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Eyes_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/201>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは色眼鏡を持つ"@ja ;
-    kgc:source  "Hozma has colored glasses"@en ;
+    kgc:source  "Hosmer has colored glasses"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Color_glasses> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/202>
     rdf:type    kgc:Situation ;
     kgc:source  "ホズマは以下を言った"@ja ;
-    kgc:source  "Hozma said the following"@en ;
+    kgc:source  "Hosmer said the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/203> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/203>
     rdf:type    kgc:Thought ;
     kgc:source  "ホズマはサザランドの父の帰国前にサザランドと結婚したい"@ja ;
-    kgc:source  "Hozma wants to marry Sutherland before his father's return home"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_thoughts> ;
+    kgc:source  "Hosmer wants to marry Sutherland before his father's return home"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_thoughts> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/203a> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/203a>
     rdf:type    kgc:Thought ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_thoughts> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_thoughts> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_return_of_father_of_Sutherland> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/204>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは熱心だった"@ja ;
-    kgc:source  "Hozma was keen"@en ;
+    kgc:source  "Hosmer was keen"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/enthusiastic> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/205>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはサザランドに聖書を持たせた"@ja ;
-    kgc:source  "Hozma gave the Bible to Sutherland"@en ;
+    kgc:source  "Hosmer gave the Bible to Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/let> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/205a> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/206> .
@@ -2008,24 +2008,24 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hold> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Bible> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/206>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは以下をサザランドに誓わせた"@ja ;
-    kgc:source  "Hozma has made Sutherland vow:"@en ;
+    kgc:source  "Hosmer has made Sutherland vow:"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/swear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/207> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/207>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマを信じる"@ja ;
-    kgc:source  "Sutherland believes in Hozma"@en ;
+    kgc:source  "Sutherland believes in Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/208>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの母は上記に賛成だった"@ja ;
@@ -2037,26 +2037,26 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/209>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの母はホズマをサザランドより愛していた"@ja ;
-    kgc:source  "mother of Sutherland loved Hozma more than Sutherland"@en ;
+    kgc:source  "mother of Sutherland loved Hosmer more than Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/more_than_Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/210>
     rdf:type    kgc:Situation ;
     kgc:source  "ホズマは以下を言った"@ja ;
-    kgc:source  "Hozma said the following"@en ;
+    kgc:source  "Hosmer said the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/211> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/211>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは今週、サザランドと結婚する"@ja ;
-    kgc:source  "Hozma will marry Sutherland this week"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement> ;
+    kgc:source  "Hosmer will marry Sutherland this week"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/this_week> ;
     kgc:time  "1891-08-14T14:00:00"^^xsd:dateTime ;
@@ -2065,40 +2065,40 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/212>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはウィンディバンクを心配した"@ja ;
-    kgc:source  "Sutherland worried about Windybank"@en ;
+    kgc:source  "Sutherland worried about Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/worry> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/213>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの母とホズマは以下を言った"@ja ;
-    kgc:source  "mother of Sutherland and Hozma said"@en ;
+    kgc:source  "mother of Sutherland and Hosmer said"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Less_than> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/214>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはウィンディバンクを心配しない"@ja ;
-    kgc:source  "Sutherland Worries About Windybank"@en ;
+    kgc:source  "Sutherland Worries About Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWorry> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/215>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの母はウィンディバンクに対応する"@ja ;
-    kgc:source  "mother of Sutherland corresponds to Windybank"@en ;
+    kgc:source  "mother of Sutherland corresponds to Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/correspond> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/216>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは結婚式前にウィンディバンクに報告したい"@ja ;
-    kgc:source  "Sutherland wants to report to Windybank before the wedding"@en ;
+    kgc:source  "Sutherland wants to report to Windibank before the wedding"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
@@ -2109,23 +2109,23 @@ kgc:Thought rdf:type owl:Class ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/report> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_the_wedding> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/217>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはボルドーの会社のフランス事務所で働いている"@ja ;
-    kgc:source  "Windybank works at the French office of the Bordeaux company"@en ;
+    kgc:source  "Windibank works at the French office of the Bordeaux company"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/working> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/France_office_of_company_of_Bordeaux> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/218>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはウィンディバンクに手紙を送った"@ja ;
-    kgc:source  "Sutherland sent a letter to Windybank"@en ;
+    kgc:source  "Sutherland sent a letter to Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/219> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/219>
@@ -2143,19 +2143,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/220>
     rdf:type    kgc:Statement ;
     kgc:source  "手紙はウィンディバンクに届かなかった"@ja ;
-    kgc:source  "The letter did not reach Windybank"@en ;
+    kgc:source  "The letter did not reach Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notReach> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/221> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/221>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは手紙が着く直前にイングランドへ発った"@ja ;
-    kgc:source  "Windybank left for England just before the letter arrived"@en ;
+    kgc:source  "Windibank left for England just before the letter arrived"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Just_before_the_letter_arrives> ;
     kgc:time  "1891-08-27T08:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-08-27T08> ;
@@ -2182,11 +2182,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/226>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドとホズマは聖セントパンクラス・ホテルで朝食を食べる"@ja ;
-    kgc:source  "Sutherland and Hozma eat breakfast at Saint St Pancras Hotel"@en ;
+    kgc:source  "Sutherland and Hosmer eat breakfast at Saint St Pancras Hotel"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/eat> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/breakfast> ;
     kgc:time  "1891-08-14T09:30:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-08-14T09:30> ;
@@ -2199,7 +2199,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-08-14> ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hansom_carriage> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Last_Friday> ;
     kgc:time  "1891-08-14T09:00:00"^^xsd:dateTime ;
@@ -2208,10 +2208,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/228>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはサザランドとサザランドの母をハンソム馬車に乗せた"@ja ;
-    kgc:source  "Hozma put mother of Sutherland and Sutherland&#39;s mother on a Hansom carriage"@en ;
+    kgc:source  "Hosmer put mother of Sutherland and Sutherland&#39;s mother on a Hansom carriage"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/putOn> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hansom_carriage> ;
@@ -2225,10 +2225,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/229>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは辻馬車に乗った"@ja ;
-    kgc:source  "Hozma got on a carriage"@en ;
+    kgc:source  "Hosmer got on a carriage"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/getOn> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hansom_carriage> ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/230> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/230>
@@ -2243,21 +2243,21 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/231>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドとサザランドの母はホズマより先に教会に着いた"@ja ;
-    kgc:source  "Sutherland and mother of Sutherland arrived at the church before Hozma"@en ;
+    kgc:source  "Sutherland and mother of Sutherland arrived at the church before Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrive> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
-    kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_Hozma> ;
+    kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Church> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/232> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/232>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは辻馬車にいなかった"@ja ;
-    kgc:source  "Hozma wasn't in a cart"@en ;
+    kgc:source  "Hosmer wasn't in a cart"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExist> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hansom_carriage> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/233> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/233>
@@ -2281,11 +2281,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/235>
     rdf:type    kgc:Statement ;
     kgc:source  "御者はホズマの居場所が分からない"@ja ;
-    kgc:source  "He does not know where Hozma is"@en ;
+    kgc:source  "He does not know where Hosmer is"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notUnderstand> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/The_Horseman> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location_of_Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/236> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/236>
     rdf:type    kgc:Statement ;
@@ -2299,46 +2299,46 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/237>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマが辻馬車に入る"@ja ;
-    kgc:source  "Hozma gets into the cart"@en ;
+    kgc:source  "Hosmer gets into the cart"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/The_speaker_s_statement> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enter> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hansom_carriage> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/239> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/239>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは手紙を送らない"@ja ;
-    kgc:source  "Hozma does not send letters"@en ;
+    kgc:source  "Hosmer does not send letters"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSend> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/240> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/240>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは姿を見せない"@ja ;
-    kgc:source  "Hozma does not show up"@en ;
+    kgc:source  "Hosmer does not show up"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notShow> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appearance> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/241> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/241>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマの行方をわからない"@ja ;
-    kgc:source  "Sutherland does not know where Hozma is"@en ;
+    kgc:source  "Sutherland does not know where Hosmer is"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location_of_Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/242> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/242>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはサザランドを捨てない"@ja ;
-    kgc:source  "Hozma does not throw away Sutherland"@en ;
+    kgc:source  "Hosmer does not throw away Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notThrow> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/243>
     rdf:type    kgc:Statement ;
@@ -2346,7 +2346,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Last Friday morning"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/244> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Last_Friday> ;
@@ -2355,11 +2355,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/244>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマを信じる"@ja ;
-    kgc:source  "Sutherland believes in Hozma"@en ;
+    kgc:source  "Sutherland believes in Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/247> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/245>
     rdf:type    kgc:Statement ;
@@ -2372,15 +2372,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/247>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドがホズマと離れる"@ja ;
-    kgc:source  "Sutherland leaves with Hozma"@en ;
+    kgc:source  "Sutherland leaves with Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/248>
     rdf:type    kgc:Statement ;
     kgc:source  "現在、サザランドはホズマの言葉を理解した"@ja ;
-    kgc:source  "Sutherland now understands the language of Hozma"@en ;
+    kgc:source  "Sutherland now understands the language of Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/understand> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
@@ -2400,19 +2400,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/250>
     rdf:type    kgc:Thought ;
     kgc:source  "ホズマは危険を知っていた"@ja ;
-    kgc:source  "Hozma knew about the danger"@en ;
+    kgc:source  "Hosmer knew about the danger"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland_s_thoughts> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Danger> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/252> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/252>
     rdf:type    kgc:Thought ;
     kgc:source  "ホズマは上記を言った"@ja ;
-    kgc:source  "Hozma said above"@en ;
+    kgc:source  "Hosmer said above"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland_s_thoughts> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/244> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/253>
     rdf:type    kgc:Situation ;
@@ -2427,30 +2427,30 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/254>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマの危険を知らない"@ja ;
-    kgc:source  "Sutherland does not know the danger of Hozma"@en ;
+    kgc:source  "Sutherland does not know the danger of Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger_of_hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/255>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはサザランドの母とウィンディバンクにホズマ失踪を伝えた"@ja ;
-    kgc:source  "Sutherland reported Hozma's disappearance to Sutherland&#39;s mother and Windybank"@en ;
+    kgc:source  "Sutherland reported Hosmer's disappearance to Sutherland&#39;s mother and Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/256> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/256>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの母はホズマ失踪に怒った"@ja ;
-    kgc:source  "mother of Sutherland got mad at Hozma&#39;s disappearance"@en ;
+    kgc:source  "mother of Sutherland got mad at Hosmer&#39;s disappearance"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/angry> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/257> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/257>
     rdf:type    kgc:Situation ;
@@ -2464,25 +2464,25 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/258>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマ失踪を話さない"@ja ;
-    kgc:source  "Sutherland does not speak Hozma's disappearance"@en ;
+    kgc:source  "Sutherland does not speak Hosmer's disappearance"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland&#39_s_remark> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/259>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/260> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/260>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはサザランドに連絡する"@ja ;
-    kgc:source  "Hozma will contact Sutherland"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Hosmer will contact Sutherland"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/contact> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/261>
     rdf:type    kgc:Situation ;
@@ -2498,19 +2498,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/262>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは自分の財産を持っている"@ja ;
-    kgc:source  "Hozma owns his property"@en ;
+    kgc:source  "Hosmer owns his property"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property_of_Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property_of_Hosmer> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/263> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/263>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはサザランドのお金を欲してない"@ja ;
-    kgc:source  "Hozma does not want Sutherland's money"@en ;
+    kgc:source  "Hosmer does not want Sutherland's money"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money_of_Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/264>
     rdf:type    kgc:Statement ;
@@ -2543,50 +2543,50 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/267>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはホズマ失踪を調べる"@ja ;
-    kgc:source  "Holmes examines Hozma's disappearance"@en ;
+    kgc:source  "Holmes examines Hosmer's disappearance"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/268> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/268>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはホズマ失踪を解決できる"@ja ;
-    kgc:source  "Holmes can solve Hozma's disappearance"@en ;
+    kgc:source  "Holmes can solve Hosmer's disappearance"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/canSolve> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/269> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/269>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマを忘れる"@ja ;
-    kgc:source  "Sutherland forgets Hozma"@en ;
+    kgc:source  "Sutherland forgets Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/forget> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/270> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/270>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマに会えない"@ja ;
-    kgc:source  "Sutherland can not see Hozma"@en ;
+    kgc:source  "Sutherland can not see Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotMeet> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/271>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはホズマの人相書きを欲しい"@ja ;
-    kgc:source  "Holmes wants Hozma's personalities"@en ;
+    kgc:source  "Holmes wants Hosmer's personalities"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/272>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはホズマの手紙を欲しい"@ja ;
-    kgc:source  "Holmes wants a letter from Hozma"@en ;
+    kgc:source  "Holmes wants a letter from Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
@@ -2623,7 +2623,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/276>
     rdf:type    kgc:Situation ;
     kgc:source  "サザランドはホームズにホズマの手紙を渡した"@ja ;
-    kgc:source  "Sutherland gave Hozma a letter to Holmes"@en ;
+    kgc:source  "Sutherland gave Hosmer a letter to Holmes"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/handOver> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
@@ -2650,18 +2650,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/279>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマの住所を知らない"@ja ;
-    kgc:source  "Sutherland does not know Hozma's address"@en ;
+    kgc:source  "Sutherland does not know Hosmer's address"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/280>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはウェストハウス＆マーバンクの外商である"@ja ;
-    kgc:source  "Hozma is a foreign company in West House &amp; Marbank"@en ;
+    kgc:source  "Hosmer is a foreign company in West House &amp; Marbank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/foreign_business_of_West_House&Marbank> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/281>
     rdf:type    kgc:Statement ;
     kgc:source  "フェンチャーチ街で、ウェストハウス＆マーバンクは最大のクラレット輸入業者である"@ja ;
@@ -2690,11 +2690,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/284>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマ失踪を忘れる"@ja ;
-    kgc:source  "Sutherland forgets Hozma's disappearance"@en ;
+    kgc:source  "Sutherland forgets Hosmer's disappearance"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/forget> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/285>
     rdf:type    kgc:Situation ;
     kgc:source  "サザランドは以下を言った"@ja ;
@@ -2707,19 +2707,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/286>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマを忘れられない"@ja ;
-    kgc:source  "Sutherland can not forget Hozma"@en ;
+    kgc:source  "Sutherland can not forget Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/unforgettable> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/287>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマを信じている"@ja ;
-    kgc:source  "Sutherland believes in Hozma"@en ;
+    kgc:source  "Sutherland believes in Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/288>
     rdf:type    kgc:Situation ;
     kgc:source  "ワトソンはサザランドに気品と敬意を感じた"@ja ;
@@ -3296,81 +3296,81 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/355>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは14日朝失踪した"@ja ;
-    kgc:source  "Hozma disappeared on the morning of the 14th"@en ;
+    kgc:source  "Hosmer disappeared on the morning of the 14th"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/disappear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/14th_Monday> ;
     kgc:time  "1891-08-14T09:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-08-14T09> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/356>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの身長は5フィート7インチである"@ja ;
-    kgc:source  "Hozma's height is 5 feet 7 inches"@en ;
+    kgc:source  "Hosmer's height is 5 feet 7 inches"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/equalTo> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/5_feet_7_inches> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height_of_Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/357>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの体格はよい"@ja ;
-    kgc:source  "Hozma's physique is good"@en ;
+    kgc:source  "Hosmer's physique is good"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/good> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/358>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの顔色は悪い"@ja ;
-    kgc:source  "The color of hozma is bad"@en ;
+    kgc:source  "The color of Hosmer is bad"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bad> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/359>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの髪は黒である"@ja ;
-    kgc:source  "Hozma's hair is black"@en ;
+    kgc:source  "Hosmer's hair is black"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/black> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/360>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの頭頂には小禿がある"@ja ;
-    kgc:source  "There is a small boat on the top of Hozma's head"@en ;
+    kgc:source  "There is a small boat on the top of Hosmer's head"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/gavel> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/head_of_Hozma> .
+    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/head_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/361>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは黒い頬髯口髭を持つ"@ja ;
-    kgc:source  "Hozma has a black cheek and mouth"@en ;
+    kgc:source  "Hosmer has a black cheek and mouth"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/black_whisker> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/black_mustache> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/362>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマは色眼鏡を持つ"@ja ;
-    kgc:source  "Hozma has colored glasses"@en ;
+    kgc:source  "Hosmer has colored glasses"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Color_glasses> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/363>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの話し方は訥々である"@ja ;
-    kgc:source  "Hozma's way of speaking is jealous"@en ;
+    kgc:source  "Hosmer's way of speaking is jealous"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/hesitating> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak_of_hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/364>
     rdf:type    kgc:Statement ;
     kgc:source  "失踪時の服装は黒のフロックコートである"@ja ;
     kgc:source  "At the time of disappearance is a black frock coat"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/black_frock_coat> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing> ;
     kgc:time  "1891-08-14T08:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-08-14T08> .
@@ -3380,7 +3380,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "At the time of disappearance is a black vest"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/black_best> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing> ;
     kgc:time  "1891-08-14T08:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-08-14T08> .
@@ -3390,7 +3390,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Dress at the time of disappearance is the Albert chain of gold"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/albert_chain_of_gold> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hosmer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing> ;
     kgc:time  "1891-08-14T08:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-08-14T08> .
@@ -3400,17 +3400,17 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "In the past"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/working> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Office_of_Redon_Hall_Street> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/past> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/368>
     rdf:type    kgc:Statement ;
     kgc:source  "手紙はホズマの手がかりを持たない"@ja ;
-    kgc:source  "Letters have no clues to Hozma"@en ;
+    kgc:source  "Letters have no clues to Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clue_of_Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clue_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/369>
     rdf:type    kgc:Statement ;
     kgc:source  "手紙には、バルザックからの引用がある"@ja ;
@@ -3450,9 +3450,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/373>
     rdf:type    kgc:Statement ;
     kgc:source  "署名はホズマ・エインジェルである"@ja ;
-    kgc:source  "Signature is Hozma Aingel"@en ;
+    kgc:source  "Signature is Hosmer Aingel"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Hozma_Aingel> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Hosmer_Aingel> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/signature> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/374>
     rdf:type    kgc:Statement ;
@@ -3500,7 +3500,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Hosma received an appeal against breach of covenants"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appeal_of_breach_of_pledge> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/381>
     rdf:type    kgc:Situation ;
@@ -3528,10 +3528,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/383>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマ失踪は解決する"@ja ;
-    kgc:source  "Hozma's disappearance resolves"@en ;
+    kgc:source  "Hosmer's disappearance resolves"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/solve> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer> ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/385> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/385>
     rdf:type    kgc:Statement ;
@@ -3553,11 +3553,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/387>
     rdf:type    kgc:Statement ;
     kgc:source  "手紙2はウィンディバンクへ送る"@ja ;
-    kgc:source  "Letter 2 sent to Windybank"@en ;
+    kgc:source  "Letter 2 sent to Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Letter_2> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/388>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズは手紙2に以下を書く"@ja ;
@@ -3570,7 +3570,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/389>
     rdf:type    kgc:Statement ;
     kgc:source  "明晩六時に、ホームズがウィンディバンクに会いたい"@ja ;
-    kgc:source  "Holmes wants to see Windybank at 6 o'clock in the evening"@en ;
+    kgc:source  "Holmes wants to see Windibank at 6 o'clock in the evening"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
@@ -3580,7 +3580,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Tommorw_evening_6_o_clock> ;
     kgc:time  "1891-09-02T18:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1891-09-02T18> .
@@ -3673,87 +3673,87 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/400>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクが来た"@ja ;
-    kgc:source  "Windybank came"@en ;
+    kgc:source  "Windibank came"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/408> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/401>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの体格はいい"@ja ;
-    kgc:source  "Windybank's physique is good"@en ;
+    kgc:source  "Windibank's physique is good"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/good> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/402>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは中背である"@ja ;
-    kgc:source  "Windybank is medium-sized"@en ;
+    kgc:source  "Windibank is medium-sized"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/ｍedium_height> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/403>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの年は30歳前後である"@ja ;
-    kgc:source  "The age of Windybank is around 30 years old"@en ;
+    kgc:source  "The age of Windibank is around 30 years old"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/around_30_years_old> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/age_of_Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/age_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/404>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは髯を持たない"@ja ;
-    kgc:source  "Windybank has no bribe"@en ;
+    kgc:source  "Windibank has no bribe"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mustache> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/405>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの顔色は悪い"@ja ;
-    kgc:source  "The color of Windybank is bad"@en ;
+    kgc:source  "The color of Windibank is bad"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bad> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/406>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの物腰は穏やかである"@ja ;
-    kgc:source  "Windybank's behavior is calm"@en ;
+    kgc:source  "Windibank's behavior is calm"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/calm> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/407>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの灰色の瞳は鋭い"@ja ;
-    kgc:source  "Windybank's gray eyes are sharp"@en ;
+    kgc:source  "Windibank's gray eyes are sharp"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sharp> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/eyes_of_Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/eyes_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/408>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクはホームズとワトソンを見た"@ja ;
-    kgc:source  "Windybank saw Holmes and Watson"@en ;
+    kgc:source  "Windibank saw Holmes and Watson"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/409> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/409>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは山高帽を横棚に置いた"@ja ;
-    kgc:source  "Windybank put a bowler hat on the side shelf"@en ;
+    kgc:source  "Windibank put a bowler hat on the side shelf"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/put> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Bowler_hat> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Horizontal_shelf> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/410> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/410>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクはホームズに挨拶した"@ja ;
-    kgc:source  "Windybank greets Holmes"@en ;
+    kgc:source  "Windibank greets Holmes"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/greet> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/411> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/411>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは椅子に座った"@ja ;
-    kgc:source  "Windybank sat in a chair"@en ;
+    kgc:source  "Windibank sat in a chair"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/chair> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/412> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/412>
@@ -3767,16 +3767,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/413>
     rdf:type    kgc:Statement ;
     kgc:source  "タイプの手紙はウィンディバンクの手紙である"@ja ;
-    kgc:source  "The type letter is a Windybank letter"@en ;
+    kgc:source  "The type letter is a Windibank letter"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/letter_of_Windybank> ;
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/letter_of_Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_type> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/414>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/415> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/416> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/417> ;
@@ -3792,47 +3792,47 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/415>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは遅刻を心配した"@ja ;
-    kgc:source  "Windybank worried about being late"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank worried about being late"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/worry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Late> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/416>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは忙しい"@ja ;
-    kgc:source  "Windybank is busy"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank is busy"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/busy> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/417>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下を謝る"@ja ;
-    kgc:source  "Windybank apologizes for"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank apologizes for"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/apologize> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/418> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/418>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドがホームズを煩わせる"@ja ;
     kgc:source  "Sutherland bothers Holmes"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bother> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/419>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下を望まない"@ja ;
-    kgc:source  "Windybank does not want"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank does not want"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/420> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/420>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドがホームズに来る"@ja ;
     kgc:source  "Sutherland comes to Holmes"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> .
@@ -3840,7 +3840,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドが家庭の災難を話す"@ja ;
     kgc:source  "Sutherland talks about family misfortune"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Family_calamity> .
@@ -3848,55 +3848,55 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはすぐに動く"@ja ;
     kgc:source  "Sutherland moves quickly"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/move> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Immediately> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/423>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下に喜ぶ"@ja ;
-    kgc:source  "Windybank is pleased to"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank is pleased to"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bePleased> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/424> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/424>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズは警察官憲ではない"@ja ;
     kgc:source  "Holmes is not a police officer"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notEqualTo> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/police_officer> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/425>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは無用の出費を避けたい"@ja ;
-    kgc:source  "Windybank wants to avoid unnecessary expenses"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank wants to avoid unnecessary expenses"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/425a> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/425a>
     rdf:type    kgc:Statement ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/waste> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/426>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を思う"@ja ;
-    kgc:source  "Windybank thinks the following"@en ;
+    kgc:source  "Windibank thinks the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/427> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/428> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/427>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはホズマを見つけられない"@ja ;
-    kgc:source  "Holmes can not find Hozma"@en ;
+    kgc:source  "Holmes can not find Hosmer"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotFind> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/428>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは以下を言った"@ja ;
@@ -3908,39 +3908,39 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/429>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはホズマを見つける"@ja ;
-    kgc:source  "Holmes find Hozma"@en ;
+    kgc:source  "Holmes find Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/430>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは驚いて手袋を落とした"@ja ;
-    kgc:source  "Windybank dropped her gloves in surprise"@en .
+    kgc:source  "Windibank dropped her gloves in surprise"@en .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/431>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drop> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/430>
     rdf:type    kgc:Situation ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/gloves> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Surprised> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/432> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/432>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を喜んだ"@ja ;
-    kgc:source  "Windybank was pleased with"@en ;
+    kgc:source  "Windibank was pleased with"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bePleased> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/433> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/434> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/433>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズがホズマを見つける"@ja ;
-    kgc:source  "Holmes find Hozma"@en ;
+    kgc:source  "Holmes find Hosmer"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/434>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズが以下を言った"@ja ;
@@ -3964,51 +3964,51 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/436>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクの手紙では、eが不鮮明である"@ja ;
-    kgc:source  "In the Windybank letter"@en ;
+    kgc:source  "In the Windibank letter"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/blurred> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/e> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windybank> ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windibank> ;
     kgc:and   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/438> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/438>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクの手紙では、rが欠けている"@ja ;
-    kgc:source  "In the Windybank letter"@en ;
+    kgc:source  "In the Windibank letter"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/miss> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/r> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windybank> .
+    kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/439>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクの手紙は14の特徴を持つ"@ja ;
-    kgc:source  "Windybank's letter has 14 features"@en ;
+    kgc:source  "Windibank's letter has 14 features"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windybank> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/14_features> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/440>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/441> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/443> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/444> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/441>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクの職場は１つの機械を持つ"@ja ;
-    kgc:source  "Windybank's workplace has one machine"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank's workplace has one machine"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace_of_Windybank> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace_of_Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/One_Typewriter> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/443> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/443>
     rdf:type    kgc:Statement ;
     kgc:source  "文字が摩滅する"@ja ;
     kgc:source  "Letters wear out"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wearOut> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/character_of_typewriter> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/444>
@@ -4060,7 +4060,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/449>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの手紙では、rが欠けている"@ja ;
-    kgc:source  "In the letter of hozma r is missing"@en ;
+    kgc:source  "In the letter of Hosmer r is missing"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/miss> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/r> ;
@@ -4076,59 +4076,59 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/451>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは椅子から跳び上がった"@ja ;
-    kgc:source  "Windybank jumped out of the chair"@en ;
+    kgc:source  "Windibank jumped out of the chair"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/jumpUp> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Chair> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/452> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/452>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは帽子をつかんだ"@ja ;
-    kgc:source  "Windybank grabbed a hat"@en ;
+    kgc:source  "Windibank grabbed a hat"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/grab> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hat> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/453> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/453>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/454> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/455> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/454>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは無駄な時間を持たない"@ja ;
-    kgc:source  "Windybank has no wasted time"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank has no wasted time"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Time_wasted> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/455>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下をホームズに頼む"@ja ;
-    kgc:source  "Windybank asks Holmes:"@en ;
+    kgc:source  "Windibank asks Holmes:"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/request> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/456> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/459> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/456>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズがウィンディバンクに知らせる"@ja ;
-    kgc:source  "Holmes Tells Windybank"@en ;
+    kgc:source  "Holmes Tells Windibank"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/458> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/458>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズがホズマを捕まえる"@ja ;
-    kgc:source  "Holmes catches Hozma"@en ;
+    kgc:source  "Holmes catches Hosmer"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/catch> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/459>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは扉をロックした"@ja ;
@@ -4148,33 +4148,33 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/461>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはホズマを捕まえた"@ja ;
-    kgc:source  "Holmes caught Hozma"@en ;
+    kgc:source  "Holmes caught Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/catch> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/462>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクはホズマの居場所をホームズに尋ねた"@ja ;
-    kgc:source  "Windybank asked Holmes where Hozma was"@en ;
+    kgc:source  "Windibank asked Holmes where Hosmer was"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ask> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Place> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/463> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/463>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの唇は真っ青だった"@ja ;
-    kgc:source  "Windybank's lips were deep blue"@en ;
+    kgc:source  "Windibank's lips were deep blue"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/pale> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip_of_Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip_of_Windibank> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/464> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/464>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは回りを見まわした"@ja ;
-    kgc:source  "Windybank looked around"@en ;
+    kgc:source  "Windibank looked around"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/lookAround> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Around> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/465> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/465>
@@ -4188,51 +4188,51 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/466>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはホームズから逃げられない"@ja ;
-    kgc:source  "Windybank can not escape from Holmes"@en ;
+    kgc:source  "Windibank can not escape from Holmes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotEscape> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/467>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは椅子に座った"@ja ;
-    kgc:source  "Windybank sat in a chair"@en ;
+    kgc:source  "Windibank sat in a chair"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Chair> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/468> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/468>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの顔は死んだようだった"@ja ;
-    kgc:source  "Windybank's face seemed dead"@en ;
+    kgc:source  "Windibank's face seemed dead"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/seem> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dead> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/469> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/469>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクの額は冷や汗を持つ"@ja ;
-    kgc:source  "Windybank's forehead has cold sweat"@en ;
+    kgc:source  "Windibank's forehead has cold sweat"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windybank> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/cold_sweat> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/470> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/470>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/471> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/472> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/471>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはウィンディバンクを訴えない"@ja ;
-    kgc:source  "Holmes does not sue Windybank"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Holmes does not sue Windibank"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notComplain> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/472>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは以下を言った"@ja ;
@@ -4295,28 +4295,28 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/475>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの母とお金のために結婚した"@ja ;
-    kgc:source  "Windybank married for money with mother of Sutherland"@en ;
+    kgc:source  "Windibank married for money with mother of Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mother_of_Sutherland> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/476>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの金が使える"@ja ;
-    kgc:source  "Windybank can use Sutherland gold"@en ;
+    kgc:source  "Windibank can use Sutherland gold"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/canBeUsed> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money_of_Sutherland> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/478> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/478>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクがサザランドと住んでいる"@ja ;
-    kgc:source  "Windybank lives with Sutherland"@en ;
+    kgc:source  "Windibank lives with Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/479>
     rdf:type    kgc:Statement ;
@@ -4329,10 +4329,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/480>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの金が欲しい"@ja ;
-    kgc:source  "Windybank Wants Sutherland Gold"@en ;
+    kgc:source  "Windibank Wants Sutherland Gold"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money_of_Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/481>
     rdf:type    kgc:Statement ;
@@ -4377,29 +4377,29 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/488>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは1年で100ポンドを失う"@ja ;
-    kgc:source  "Windybank loses 100 pounds in a year"@en ;
+    kgc:source  "Windibank loses 100 pounds in a year"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/lose> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/100_GBP> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/1_year> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/490> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/490>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドを家から出さない"@ja ;
-    kgc:source  "Windybank will not leave Sutherland from home"@en ;
+    kgc:source  "Windibank will not leave Sutherland from home"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notIssue> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Windybank> .
+    kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/491>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドに同年代の人間との交際を禁じる"@ja ;
-    kgc:source  "Windybank prohibits Sutherland from dating with people of the same age"@en ;
+    kgc:source  "Windibank prohibits Sutherland from dating with people of the same age"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/prohibit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/relation_of_same-aged_people> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/492>
@@ -4412,11 +4412,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/493>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはウィンディバンクに反抗する"@ja ;
-    kgc:source  "Sutherland defy Windybank"@en ;
+    kgc:source  "Sutherland defy Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rebel> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/494>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは権利を主張する"@ja ;
@@ -4442,42 +4442,42 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/496>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの母の助けを得る"@ja ;
-    kgc:source  "Windybank gets the help of mother of Sutherland"@en ;
+    kgc:source  "Windibank gets the help of mother of Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/get> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/help_of_mother_of_Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/497>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは変装する"@ja ;
-    kgc:source  "Windybank disguises"@en ;
+    kgc:source  "Windibank disguises"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/disguise> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/498>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは色眼鏡を着けた"@ja ;
-    kgc:source  "Windybank wore colored glasses"@en ;
+    kgc:source  "Windibank wore colored glasses"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Color_glasses> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/499>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは口髭頬髯を着けた"@ja ;
-    kgc:source  "Windybank wore a mustache"@en ;
+    kgc:source  "Windibank wore a mustache"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mustache> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/whiskers> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/500>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはささやいた"@ja ;
-    kgc:source  "Windybank whispered"@en ;
+    kgc:source  "Windibank whispered"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/whisper> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/501>
     rdf:type    kgc:Statement ;
     kgc:source  "変装は安全である"@ja ;
@@ -4496,43 +4496,43 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/504>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはホズマである"@ja ;
-    kgc:source  "Windybank is Hozma"@en ;
+    kgc:source  "Windibank is Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Hozma> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Hosmer> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/505>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドから他人を追い払う"@ja ;
-    kgc:source  "Windybank chases others from Sutherland"@en ;
+    kgc:source  "Windibank chases others from Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/chaseAway> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/others> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/507> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/507>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドがウィンディバンクを愛する"@ja ;
-    kgc:source  "Sutherland loves Windybank"@en ;
+    kgc:source  "Sutherland loves Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/508>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を思わなかった"@ja ;
-    kgc:source  "Windybank did not think of"@en ;
+    kgc:source  "Windibank did not think of"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notThink> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/509> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/510> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/509>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドの心を奪う"@ja ;
-    kgc:source  "Windybank robs Sutherland"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank robs Sutherland"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rob> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heart_of_Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/510>
     rdf:type    kgc:Situation ;
@@ -4571,11 +4571,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/511>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはホズマを愛した"@ja ;
-    kgc:source  "Sutherland loved Hozma"@en ;
+    kgc:source  "Sutherland loved Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/512>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドは以下を思っている"@ja ;
@@ -4587,10 +4587,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/513>
     rdf:type    kgc:Thought ;
     kgc:source  "ウィンディバンクはフランスにいる"@ja ;
-    kgc:source  "Windybank is in France"@en ;
+    kgc:source  "Windibank is in France"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland_s_thoughts> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/France> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/514>
     rdf:type    kgc:Statement ;
@@ -4603,27 +4603,27 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/515>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマはサザランドと何度も会った"@ja ;
-    kgc:source  "Hozma met Sutherland many times"@en ;
+    kgc:source  "Hosmer met Sutherland many times"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Many_times> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/516>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは安心した"@ja ;
-    kgc:source  "Windybank was relieved"@en ;
+    kgc:source  "Windibank was relieved"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/relive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/518> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/518>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドと婚約する"@ja ;
-    kgc:source  "Windybank gets engaged with Sutherland"@en ;
+    kgc:source  "Windibank gets engaged with Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/engage> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/519>
     rdf:type    kgc:Statement ;
@@ -4636,27 +4636,27 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/520>
     rdf:type    kgc:Statement ;
     kgc:source  "永遠に、ウィンディバンクはサザランドを騙せない"@ja ;
-    kgc:source  "Forever, Windybank can't fool Sutherland"@en ;
+    kgc:source  "Forever, Windibank can't fool Sutherland"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotCheat> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Forever> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/521>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下が必要である"@ja ;
-    kgc:source  "Windybank needs:"@en ;
+    kgc:source  "Windibank needs:"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/need> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/522> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/522>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは劇的にサザランドと別れる"@ja ;
-    kgc:source  "Windybank breaks up with Sutherland dramatically"@en ;
+    kgc:source  "Windibank breaks up with Sutherland dramatically"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/breakUp> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Dramatically> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/524> .
@@ -4668,7 +4668,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/engrave> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heart_of_Sutherland> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Forever> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/525>
     rdf:type    kgc:Statement ;
     kgc:source  "当分の間、サザランドは他人を愛さない"@ja ;
@@ -4682,10 +4682,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/527>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはサザランドに聖書で誓わせた"@ja ;
-    kgc:source  "Windybank made Sutherland swear in the Bible"@en ;
+    kgc:source  "Windibank made Sutherland swear in the Bible"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/let> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/527a> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/527a>
@@ -4697,10 +4697,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/528>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下をほのめかした"@ja ;
-    kgc:source  "Windybank hints at"@en ;
+    kgc:source  "Windibank hints at"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/imply> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/529> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/529>
     rdf:type    kgc:Statement ;
@@ -4715,10 +4715,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/530>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは以下を望んだ"@ja ;
-    kgc:source  "Windybank wanted to"@en ;
+    kgc:source  "Windibank wanted to"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/531> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/531>
     rdf:type    kgc:Statement ;
@@ -4727,7 +4727,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bind> ;
     kgc:whoｍ   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/532>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドが他人を愛さない"@ja ;
@@ -4740,57 +4740,57 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/534>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの生死が不明である"@ja ;
-    kgc:source  "Life and death of Hozma is unknown"@en ;
+    kgc:source  "Life and death of Hosmer is unknown"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unknown> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life_of_Hozma> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death_of_Hozma> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life_of_Hosmer> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death_of_Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/535>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは教会にサザランドを運んだ"@ja ;
-    kgc:source  "Windybank carried Sutherland to the church"@en ;
+    kgc:source  "Windibank carried Sutherland to the church"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/carry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Church> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/537> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/537>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは消えた"@ja ;
-    kgc:source  "Windybank has disappeared"@en ;
+    kgc:source  "Windibank has disappeared"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/disappear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/538>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは反対の戸から出た"@ja ;
-    kgc:source  "Windybank came out of the opposite door"@en ;
+    kgc:source  "Windibank came out of the opposite door"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goOut> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Opposite_door> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/539>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは椅子から立った"@ja ;
-    kgc:source  "Windybank stood out of the chair"@en ;
+    kgc:source  "Windibank stood out of the chair"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stand> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Chair> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/540> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/540>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは冷笑した"@ja ;
-    kgc:source  "Windybank laughed"@en ;
+    kgc:source  "Windibank laughed"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sneer> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/541> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/541>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは以下を言った"@ja ;
-    kgc:source  "Windybank said"@en ;
+    kgc:source  "Windibank said"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/542> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/543> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/544> ;
@@ -4801,26 +4801,26 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/542>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは事実を知らない"@ja ;
-    kgc:source  "Windybank does not know the facts"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank does not know the facts"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/truth> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/543>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは法律を破っていない"@ja ;
-    kgc:source  "Windybank has not beat the law"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank has not beat the law"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notBreak> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/law> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/544>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクはホームズを暴行の脅迫と不法拘束で訴えることができる"@ja ;
-    kgc:source  "Windybank can sue Holmes for beating threat and illegal detention"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:source  "Windibank can sue Holmes for beating threat and illegal detention"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/canSue> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Assault_threat> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Illegally> ;
@@ -4829,7 +4829,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズは扉を閉めている"@ja ;
     kgc:source  "Holmes is closing the door"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/close> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/door> .
@@ -4844,11 +4844,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/549>
     rdf:type    kgc:Statement ;
     kgc:source  "法律はウィンディバンクを扱えない"@ja ;
-    kgc:source  "Law can not handle Windybank"@en ;
+    kgc:source  "Law can not handle Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotHandle> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/law> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/550>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは扉を開けた"@ja ;
@@ -4869,20 +4869,20 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/552>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは罪を持つ"@ja ;
-    kgc:source  "Windybank has sins"@en ;
+    kgc:source  "Windibank has sins"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sin> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/553>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドの兄弟親友がウィンディバンクを懲らしめる"@ja ;
-    kgc:source  "Sutherland brothers best friend wins Windybank"@en ;
+    kgc:source  "Sutherland brothers best friend wins Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/punish> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/brother_of_Sutherland> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/friend_of_Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/554>
     rdf:type    kgc:Situation ;
     kgc:source  "ワトソンは以下を言った"@ja ;
@@ -4917,9 +4917,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/557>
     rdf:type    kgc:Situation ;
     kgc:source  "ウィンディバンクは全速力で逃げた"@ja ;
-    kgc:source  "Windybank ran away at full speed"@en ;
+    kgc:source  "Windibank ran away at full speed"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/escape> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/At_full_speed> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/558> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/558>
@@ -4953,10 +4953,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/559>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクは罪を重ねる"@ja ;
-    kgc:source  "Windybank Overlaps Sin"@en ;
+    kgc:source  "Windibank Overlaps Sin"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/repeat> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sin> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/560>
     rdf:type    kgc:Statement ;
@@ -4964,33 +4964,33 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "Finally"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Gallow> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/At_last> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/561>
     rdf:type    kgc:Statement ;
     kgc:source  "ホズマの振る舞いは深い動機を持っていた"@ja ;
-    kgc:source  "The behavior of Hozma had a deep motive"@en ;
+    kgc:source  "The behavior of Hosmer had a deep motive"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior_of_Hozma> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior_of_Hosmer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Deep_motive> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/562>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクがお金を得る"@ja ;
-    kgc:source  "Windybank Gets Money"@en ;
+    kgc:source  "Windibank Gets Money"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/gain> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/563>
     rdf:type    kgc:Statement ;
     kgc:source  "ウィンディバンクとホズマは一緒に現れない"@ja ;
-    kgc:source  "Windybank and Hozma do not appear together"@en ;
+    kgc:source  "Windibank and Hosmer do not appear together"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notAppear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/together> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/564>
     rdf:type    kgc:Statement ;
@@ -5012,28 +5012,28 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/566>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはウィンディバンクの筆跡を知っている"@ja ;
-    kgc:source  "Sutherland knows Windybank handwriting"@en ;
+    kgc:source  "Sutherland knows Windibank handwriting"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting_of_Windybank> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting_of_Windibank> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/568> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/568>
     rdf:type    kgc:Statement ;
     kgc:source  "サザランドはウィンディバンクの筆跡に気づく"@ja ;
-    kgc:source  "Sutherland notices Windybank handwriting"@en ;
+    kgc:source  "Sutherland notices Windibank handwriting"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notice> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting_of_Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/569>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはウィンディバンクの会社を知っている"@ja ;
-    kgc:source  "Holmes knows the company of Windybank"@en ;
+    kgc:source  "Holmes knows the company of Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company_of_Windybank> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company_of_Windibank> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/570>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズは人相書から髯、眼鏡、声を取り除いた"@ja ;
@@ -5065,11 +5065,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/573>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはウィンディバンクに手紙を送った"@ja ;
-    kgc:source  "Holmes sent a letter to Windybank"@en ;
+    kgc:source  "Holmes sent a letter to Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/574>
     rdf:type    kgc:Statement ;
@@ -5081,11 +5081,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/575>
     rdf:type    kgc:Statement ;
     kgc:source  "タイプの特徴がホズマと一致した"@ja ;
-    kgc:source  "The characteristics of the type matched Hozma"@en ;
+    kgc:source  "The characteristics of the type matched Hosmer"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/match> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/feature_of_type> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/576>
     rdf:type    kgc:Statement ;
     kgc:source  "会社は以下を言った"@ja ;
@@ -5097,10 +5097,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/577>
     rdf:type    kgc:Statement ;
     kgc:source  "人相書はウィンディバンクである"@ja ;
-    kgc:source  "The document is Windybank"@en ;
+    kgc:source  "The document is Windibank"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/someone_of_Company> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/is> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Personal_statement> .
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/578>
     rdf:type    kgc:Statement ;
@@ -5216,6 +5216,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Bordeaux>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの手紙"@ja;
+    rdfs:label     "letter of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/simply>
     rdfs:label     "簡単に"@ja;
     rdfs:label     "simply"@en;
@@ -5247,6 +5254,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Post_Office>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Redon_Hall_Street>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの職場"@ja;
+    rdfs:label     "workplace of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/predicate/hold>
     rdf:type    kgc:Action;
     rdfs:label     "握る"@ja;
@@ -5330,13 +5344,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "熱心だ"@ja;
     rdfs:label     "enthusiastic"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの声"@ja;
-    rdfs:label     "voice of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/notLove>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5439,17 +5446,14 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "得る"@ja;
     rdfs:label     "get"@en.
+<http://kgc.knowledge-graph.jp/data/predicate/Hosmer_Aingel>
+    rdf:type    kgc:Property;
+    rdfs:label     "ホズマ・エインジェル"@ja;
+    rdfs:label     "Hosmer Aingel"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/eat>
     rdf:type    kgc:Action;
     rdfs:label     "食べる"@ja;
     rdfs:label     "eat"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの職場"@ja;
-    rdfs:label     "workplace of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/predicate/brown>
     rdf:type    kgc:Property;
     rdfs:label     "茶褐色だ"@ja;
@@ -5503,6 +5507,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "怒る"@ja;
     rdfs:label     "angry"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの話し方"@ja;
+    rdfs:label     "speak of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/footsteps>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "足音"@ja;
@@ -5519,9 +5530,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/morning>
     rdfs:label     "morning"@en;
-    rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_statement>
-    rdfs:label     "Hozma's statement"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sender>
     rdfs:label     "sender"@en;
@@ -5550,13 +5558,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland_s_thoughts>
     rdfs:label     "Sutherland's thoughts"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの振る舞い"@ja;
-    rdfs:label     "behavior of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Purple_plush>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "紫のフラシ天"@ja;
@@ -5624,19 +5625,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "30歳前後である"@ja;
     rdfs:label     "around 30 years old"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma_s_thoughts>
-    rdfs:label     "Hozma's thoughts"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/cuffs>
     rdfs:label     "cuffs"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/pledge>
     rdfs:label     "pledge"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/predicate/Hozma_Aingel>
-    rdf:type    kgc:Property;
-    rdfs:label     "ホズマ・エインジェル"@ja;
-    rdfs:label     "Hozma Aingel"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/father-in-law>
     rdfs:label     "father-in-law"@en;
     rdf:type    kgc:Object.
@@ -5659,6 +5653,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "1877年"@ja;
     rdfs:label     "1877"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの会社"@ja;
+    rdfs:label     "company of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair>
     rdfs:label     "hair"@en;
     rdf:type    kgc:Object.
@@ -5697,13 +5698,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "危険"@ja;
     rdfs:label     "Danger"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの筆跡"@ja;
-    rdfs:label     "handwriting of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heritage>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "遺産"@ja;
@@ -5711,6 +5705,13 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/ice>
     rdfs:label     "ice"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの唇"@ja;
+    rdfs:label     "lip of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/less_than_60_GBP>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "60ポンド以下の収入で"@ja;
@@ -5737,6 +5738,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプライター"@ja;
     rdfs:label     "Typewriter"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの筆跡"@ja;
+    rdfs:label     "handwriting of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/handwriting>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Saint_St._Savior_Church>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "聖セントセイヴィア教会"@ja;
@@ -5777,6 +5785,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "フラシ織"@ja;
     rdfs:label     "Plush weave"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>
+    rdf:type    kgc:Person;
+    rdfs:label     "ホズマ"@ja;
+    rdfs:label     "Hosmer"@en;
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "サザランド"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/notRelyOn>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -5873,13 +5887,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/workplace>
     rdfs:label     "workplace"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/eyes_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの灰色の瞳"@ja;
-    rdfs:label     "eyes of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/eyes>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/predicate/Go>
     rdfs:label     "Go"@en;
     rdf:type    kgc:Object.
@@ -5917,15 +5924,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/love>
     rdfs:label     "love"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの顔色"@ja;
-    rdfs:label     "color of face of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windybank>;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/predicate/bind>
     rdf:type    kgc:Action;
     rdfs:label     "束縛する"@ja;
@@ -5989,13 +5987,20 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "聖書"@ja;
     rdfs:label     "Bible"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/age_of_Windybank>
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death_of_Hosmer>
     rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの年"@ja;
-    rdfs:label     "age of Windybank"@en;
+    rdfs:label     "ホズマの生死"@ja;
+    rdfs:label     "death of Hosmer"@en;
     rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/age>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの声"@ja;
+    rdfs:label     "voice of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/voice>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/predicate/Stop>
     rdfs:label     "Stop"@en;
     rdf:type    kgc:Object.
@@ -6036,13 +6041,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "不鮮明である"@ja;
     rdfs:label     "blurred"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの顔"@ja;
-    rdfs:label     "face of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/predicate/marry>
     rdf:type    kgc:Action;
     rdfs:label     "結婚する"@ja;
@@ -6053,13 +6051,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/Throw>
     rdfs:label     "Throw"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの体格"@ja;
-    rdfs:label     "body of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/paper>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "論文"@ja;
@@ -6070,13 +6061,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities>
     rdfs:label     "personalities"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの唇"@ja;
-    rdfs:label     "lip of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/lip>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Weak_throat>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "弱い喉"@ja;
@@ -6103,13 +6087,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "落とす"@ja;
     rdfs:label     "drop"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの髪"@ja;
-    rdfs:label     "hair of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/good-natured>
     rdf:type    kgc:Property;
     rdfs:label     "お人好しである"@ja;
@@ -6140,21 +6117,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "タイプで"@ja;
     rdfs:label     "typewritter"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの会社"@ja;
-    rdfs:label     "company of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/company>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mark>
     rdfs:label     "mark"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windybank>
-    rdfs:label     "face of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/predicate/mark>
     rdfs:label     "mark"@en;
     rdf:type    kgc:Object.
@@ -6218,6 +6183,14 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "サザランドの金"@ja;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/money>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの居場所"@ja;
+    rdfs:label     "location of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    rdfs:label     "ホズマの行方"@ja;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/At_full_speed>
     rdfs:label     "全速力"@ja;
     rdfs:label     "At full speed"@en;
@@ -6243,14 +6216,17 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "思う"@ja;
     rdfs:label     "think"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_Hozma>
-    rdfs:label     "ホズマより先"@ja;
-    rdfs:label     "Before Hozma"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/know>
     rdf:type    kgc:Action;
     rdfs:label     "知る"@ja;
     rdfs:label     "know"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Industries_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの業種"@ja;
+    rdfs:label     "Industries of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Industries>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/feature_of_type>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプの特徴"@ja;
@@ -6262,13 +6238,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "入ってくる"@ja;
     rdfs:label     "comeIn"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/head_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの頭頂"@ja;
-    rdfs:label     "head of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/head>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/right>
     rdfs:label     "right"@en;
     rdf:type    kgc:Object.
@@ -6286,6 +6255,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appeal>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/breach>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/pledge>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの顔色"@ja;
+    rdfs:label     "color of face of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windibank>;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/gavel>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "小禿"@ja;
@@ -6308,6 +6286,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Place;
     rdfs:label     "向かいの舗道"@ja;
     rdfs:label     "Pavement opposite"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Hosmer>
+    rdfs:label     "face of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/predicate/jumpOut>
     rdf:type    kgc:Action;
     rdfs:label     "飛び出す"@ja;
@@ -6319,6 +6302,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "筆跡のように"@ja;
     rdfs:label     "Like handwriting"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの振る舞い"@ja;
+    rdfs:label     "behavior of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/mark_of_nose_glasses>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "鼻眼鏡の跡"@ja;
@@ -6387,13 +6377,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/heart>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Eyes_of_hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの目"@ja;
-    rdfs:label     "Eyes of hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Eyes>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Immediately>
     rdfs:label     "すぐに"@ja;
     rdfs:label     "Immediately"@en;
@@ -6455,11 +6438,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "すり切れている"@ja;
     rdfs:label     "worn"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_hozma>
-    rdfs:label     "face of hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Red_brick_feather>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "赤煉瓦色の羽根"@ja;
@@ -6493,13 +6471,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "いじる"@ja;
     rdfs:label     "mess"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger_of_hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの危険"@ja;
-    rdfs:label     "danger of hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/coat>
     rdfs:label     "coat"@en;
     rdf:type    kgc:Object.
@@ -6565,6 +6536,20 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "内気である"@ja;
     rdfs:label     "shy"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clue_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの手がかり"@ja;
+    rdfs:label     "clue of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clue>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの住所"@ja;
+    rdfs:label     "Address of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/predicate/notGo>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -6596,6 +6581,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "配管業である"@ja;
     rdfs:label     "plumbing business"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windibank>
+    rdfs:label     "face of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property>
     rdfs:label     "property"@en;
     rdf:type    kgc:Object.
@@ -6603,6 +6593,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "見つける"@ja;
     rdfs:label     "find"@en.
+<http://kgc.knowledge-graph.jp/data/predicate/Windibank>
+    rdfs:label     "Windibank"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/fine>
     rdf:type    kgc:Property;
     rdfs:label     "元気である"@ja;
@@ -6621,6 +6614,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "扁桃炎"@ja;
     rdfs:label     "Tonsillitis"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの体格"@ja;
+    rdfs:label     "body of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/coat_of_Sutherland>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの上着"@ja;
@@ -6648,6 +6648,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:AbstractTime;
     rdfs:label     "当分の間"@ja;
     rdfs:label     "For the time being"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの身だしなみ"@ja;
+    rdfs:label     "appearance of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/thought>
     rdfs:label     "thought"@en;
     rdf:type    kgc:Object.
@@ -6756,12 +6763,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "何度も"@ja;
     rdfs:label     "Many times"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/existence_of_Windybank>
-    rdfs:label     "ウィンディバンクがいる間"@ja;
-    rdfs:label     "existence of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/existence>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/knee>
     rdfs:label     "knee"@en;
     rdf:type    kgc:Object.
@@ -6843,6 +6844,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/breach>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/pledge>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの顔"@ja;
+    rdfs:label     "face of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/predicate/deny>
     rdf:type    kgc:Action;
     rdfs:label     "否定する"@ja;
@@ -6875,10 +6883,23 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "のんきである"@ja;
     rdfs:label     "easygoing"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの危険"@ja;
+    rdfs:label     "danger of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/danger>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/predicate/swear>
     rdf:type    kgc:Action;
     rdfs:label     "誓う"@ja;
     rdfs:label     "swear"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>
+    rdf:type    kgc:Person;
+    rdfs:label     "ウィンディバンク"@ja;
+    rdfs:label     "Windibank"@en;
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの物腰"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/door_of_Room_of_Holmes>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "部屋の扉"@ja;
@@ -6930,20 +6951,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Oversight>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/others>.
-<http://kgc.knowledge-graph.jp/data/predicate/Windybank>
-    rdfs:label     "Windybank"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/careless>
     rdf:type    kgc:Property;
     rdfs:label     "呑気である"@ja;
     rdfs:label     "careless"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clue_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの手がかり"@ja;
-    rdfs:label     "clue of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clue>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/canSue>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanAction;
@@ -6957,6 +6968,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの髪"@ja;
+    rdfs:label     "hair of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hair>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Pledge>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "誓約"@ja;
@@ -6993,24 +7011,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの家"@ja;
     rdfs:label     "Sutherland House"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの体格"@ja;
-    rdfs:label     "body of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/predicate/unwillingToGo>
     rdf:type    kgc:Action;
     rdfs:label     "行きたくない"@ja;
     rdfs:label     "unwillingToGo"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの服装"@ja;
-    rdfs:label     "clothes of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Important_of_minor>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "細事の大事"@ja;
@@ -7147,6 +7151,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "覗く"@ja;
     rdfs:label     "peep"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/existence_of_Windibank>
+    rdfs:label     "ウィンディバンクがいる間"@ja;
+    rdfs:label     "existence of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/existence>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/woman>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "女"@ja;
@@ -7191,6 +7201,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/finger>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/head_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの頭頂"@ja;
+    rdfs:label     "head of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/head>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/After_death_of_father_of_Sutherland>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "サザランドの父の死後"@ja;
@@ -7220,6 +7237,13 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Bordeaux>
     rdfs:label     "Bordeaux"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの身長"@ja;
+    rdfs:label     "height of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/predicate/repeat>
     rdf:type    kgc:Action;
     rdfs:label     "重ねる"@ja;
@@ -7253,6 +7277,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/show>;
     rdfs:label     "見せない"@ja;
     rdfs:label     "notShow"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの顔色"@ja;
+    rdfs:label     "color of face of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_Hosmer>;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak>
     rdfs:label     "speak"@en;
     rdf:type    kgc:Object.
@@ -7270,13 +7303,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "利回り"@ja;
     rdfs:label     "yield"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの生死"@ja;
-    rdfs:label     "Life of Hozma"@en;
+<http://kgc.knowledge-graph.jp/data/predicate/letter_of_Windibank>
+    rdf:type    kgc:Property;
+    rdfs:label     "ウィンディバンクの手紙である"@ja;
+    rdfs:label     "letter of Windibank"@en;
     rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/letter>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/Windibank>.
 <http://kgc.knowledge-graph.jp/data/predicate/put>
     rdf:type    kgc:Action;
     rdfs:label     "置く"@ja;
@@ -7444,12 +7477,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "年上である"@ja;
     rdfs:label     "older"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>
-    rdf:type    kgc:Person;
-    rdfs:label     "ウィンディバンク"@ja;
-    rdfs:label     "Windybank"@en;
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの物腰"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/100_GBP>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "100ポンド"@ja;
@@ -7554,6 +7581,16 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/shop>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/father>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの人相書き"@ja;
+    rdfs:label     "personalities of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank_s_Thoughts>
+    rdfs:label     "Windibank's Thoughts"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/notAppear>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -7659,6 +7696,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "色眼鏡"@ja;
     rdfs:label     "Color glasses"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの服装"@ja;
+    rdfs:label     "clothes of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/clothes>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Left_and_right_separate_shoes>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "左右別の靴"@ja;
@@ -7667,13 +7711,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "タイプである"@ja;
     rdfs:label     "beTypeed"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの身だしなみ"@ja;
-    rdfs:label     "appearance of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/appearance>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/story>
     rdfs:label     "story"@en;
     rdf:type    kgc:Object.
@@ -7707,13 +7744,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Dance_party>
     rdfs:label     "Dance party"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/predicate/letter_of_Windybank>
-    rdf:type    kgc:Property;
-    rdfs:label     "ウィンディバンクの手紙である"@ja;
-    rdfs:label     "letter of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/letter>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Surprised>
     rdfs:label     "驚いて"@ja;
     rdfs:label     "Surprised"@en;
@@ -7722,15 +7752,21 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "回り"@ja;
     rdfs:label     "Around"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color_of_face_of_hozma>
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hosmer>
     rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの顔色"@ja;
-    rdfs:label     "color of face of hozma"@en;
+    rdfs:label     "ホズマ失踪"@ja;
+    rdfs:label     "missing of Hosmer"@en;
     rdf:type    kgc:OFobj;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face_of_hozma>;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/color>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/face>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>.
+    rdfs:label     "ホズマ失踪に"@ja;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Eyes_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの目"@ja;
+    rdfs:label     "Eyes of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Eyes>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Sutherland>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "サザランドの手紙"@ja;
@@ -7753,14 +7789,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "ウィンディバンクである"@ja;
     rdfs:label     "is"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの居場所"@ja;
-    rdfs:label     "location of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    rdfs:label     "ホズマの行方"@ja;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/location>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/wearOut>
     rdf:type    kgc:Action;
     rdfs:label     "摩滅する"@ja;
@@ -7806,13 +7834,17 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "続けている"@ja;
     rdfs:label     "continue"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "自分の財産"@ja;
+    rdfs:label     "property of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/predicate/comeBack>
     rdf:type    kgc:Action;
     rdfs:label     "戻ってくる"@ja;
     rdfs:label     "comeBack"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>
-    rdfs:label     "hozma"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/signature_of_letter>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "手紙の署名"@ja;
@@ -7836,13 +7868,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "消える"@ja;
     rdfs:label     "disappear"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの住所"@ja;
-    rdfs:label     "Address of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Address>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Face_value_of_heritage>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "遺産の額面"@ja;
@@ -7854,9 +7879,20 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "家庭の災難"@ja;
     rdfs:label     "Family calamity"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの体格"@ja;
+    rdfs:label     "body of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before>
     rdfs:label     "以前"@ja;
     rdfs:label     "Before"@en;
+    rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Before_Hosmer>
+    rdfs:label     "ホズマより先"@ja;
+    rdfs:label     "Before Hosmer"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/solve>
     rdf:type    kgc:Action;
@@ -7875,6 +7911,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "連絡する"@ja;
     rdfs:label     "contact"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_statement>
+    rdfs:label     "Hosmer's statement"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/notHave>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -7903,13 +7942,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "置いていく"@ja;
     rdfs:label     "leaveBehind"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Industries_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの業種"@ja;
-    rdfs:label     "Industries of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Industries>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
     rdfs:label     "しようとする"@ja;
@@ -7938,13 +7970,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "気を配る"@ja;
     rdfs:label     "payAttention"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "家"@ja;
-    rdfs:label     "House of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/young>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "若い"@ja;
@@ -7967,13 +7992,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "廊下"@ja;
     rdfs:label     "Corridor"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height_of_Hozma>
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/age_of_Windibank>
     rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの身長"@ja;
-    rdfs:label     "height of Hozma"@en;
+    rdfs:label     "ウィンディバンクの年"@ja;
+    rdfs:label     "age of Windibank"@en;
     rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/height>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/age>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Just_before_the_letter_arrives>
     rdfs:label     "手紙が着く直前"@ja;
     rdfs:label     "Just before the letter arrives"@en;
@@ -8018,13 +8043,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/teller>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/Redon_Hall_Street_office>.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの人相書き"@ja;
-    rdfs:label     "personalities of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/personalities>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Left_wrist_double_wire>
     rdfs:label     "Left wrist double wire"@en;
     rdf:type    kgc:Object.
@@ -8033,13 +8051,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/sender>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter>.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak_of_hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの話し方"@ja;
-    rdfs:label     "speak of hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/speak>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Blackboard_color>
     rdfs:label     "Blackboard color"@en;
     rdf:type    kgc:Object.
@@ -8070,9 +8081,6 @@ kgc:Thought rdf:type owl:Class ;
     kgc:can    <http://kgc.knowledge-graph.jp/data/predicate/beused>;
     rdfs:label     "使える"@ja;
     rdfs:label     "canBeUsed"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank_s_Thoughts>
-    rdfs:label     "Windybank's Thoughts"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Oversight>
     rdfs:label     "Oversight"@en;
     rdf:type    kgc:Object.
@@ -8170,6 +8178,13 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/BeInTime>
     rdfs:label     "BeInTime"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/eyes_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ウィンディバンクの灰色の瞳"@ja;
+    rdfs:label     "eyes of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/eyes>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/On_the_sleeve>
     rdfs:label     "袖"@ja;
     rdfs:label     "On the sleeve"@en;
@@ -8201,6 +8216,10 @@ kgc:Thought rdf:type owl:Class ;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/important>;
     rdfs:label     "はない"@ja;
     rdfs:label     "notImportant"@en.
+<http://kgc.knowledge-graph.jp/data/predicate/Hosmer>
+    rdf:type    kgc:Property;
+    rdfs:label     "ホズマ"@ja;
+    rdfs:label     "Hosmer"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/e>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "e"@ja;
@@ -8209,13 +8228,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "禁じる"@ja;
     rdfs:label     "prohibit"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter_of_Windybank>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ウィンディバンクの手紙"@ja;
-    rdfs:label     "letter of Windybank"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/letter>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windybank>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/body>
     rdfs:label     "body"@en;
     rdf:type    kgc:Object.
@@ -8257,18 +8269,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/address>
     rdfs:label     "address"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/predicate/Hozma>
-    rdf:type    kgc:Property;
-    rdfs:label     "ホズマ"@ja;
-    rdfs:label     "Hozma"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマ失踪"@ja;
-    rdfs:label     "missing of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    rdfs:label     "ホズマ失踪に"@ja;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/missing>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appearance>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "姿"@ja;
@@ -8324,13 +8324,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/Find>
     rdfs:label     "Find"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "自分の財産"@ja;
-    rdfs:label     "property of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/property>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Plush_weave>
     rdfs:label     "Plush weave"@en;
     rdf:type    kgc:Object.
@@ -8349,13 +8342,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "新聞"@ja;
     rdfs:label     "newspaper"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death_of_Hozma>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ホズマの生死"@ja;
-    rdfs:label     "death of Hozma"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/death>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/notBeInTime>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -8406,6 +8392,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/foreign_trade>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/wine>.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House_of_Windibank>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "家"@ja;
+    rdfs:label     "House of Windibank"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/House>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Windibank>.
 <http://kgc.knowledge-graph.jp/data/predicate/write>
     rdf:type    kgc:Action;
     rdfs:label     "書く"@ja;
@@ -8467,6 +8460,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "跡"@ja;
     rdfs:label     "Trace"@en.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer_s_thoughts>
+    rdfs:label     "Hosmer's thoughts"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Dance_party>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "舞踏会"@ja;
@@ -8554,12 +8550,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "囁く"@ja;
     rdfs:label     "whisper"@en.
-<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>
-    rdf:type    kgc:Person;
-    rdfs:label     "ホズマ"@ja;
-    rdfs:label     "Hozma"@en;
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "サザランド"@ja.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Man>
     rdf:type    kgc:Person;
     rdfs:label     "男"@ja;
@@ -8631,6 +8621,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "急いで"@ja;
     rdfs:label     "Quickly"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life_of_Hosmer>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ホズマの生死"@ja;
+    rdfs:label     "Life of Hosmer"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Life>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hosmer>.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "舞踏会"@ja;

--- a/ACaseOfIdentity.ttl
+++ b/ACaseOfIdentity.ttl
@@ -5538,7 +5538,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cannotCome"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/disguise>
     rdf:type    kgc:Action;
-    rdfs:label     "変装する"@ja;
+    rdfs:label     "せいにする"@ja;
     rdfs:label     "disguise"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/behavior>
     rdfs:label     "behavior"@en;
@@ -5747,7 +5747,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Terrible things"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/overlook>
     rdf:type    kgc:Action;
-    rdfs:label     "見落とす"@ja;
+    rdfs:label     "見落としている"@ja;
     rdfs:label     "overlook"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/road>
     rdf:type    kgc:PhysicalObject;
@@ -5787,7 +5787,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/like>;
-    rdfs:label     "嫌いである"@ja;
+    rdfs:label     "嫌がる"@ja;
     rdfs:label     "notLike"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/this_morning>
     rdf:type    kgc:AbstractTime;
@@ -5829,9 +5829,8 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "imply"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
-    rdfs:label     "出会う"@ja;
-    rdfs:label     "meet"@en;
-    rdfs:label     "会う"@ja.
+    rdfs:label     "会う"@ja;
+    rdfs:label     "meet"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/type>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "タイプ"@ja;
@@ -6031,7 +6030,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つけられない"@ja;
+    rdfs:label     "見つからない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/blurred>
     rdf:type    kgc:Property;
@@ -6094,7 +6093,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notThrow"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/jumpUp>
     rdf:type    kgc:Action;
-    rdfs:label     "跳び上がる"@ja;
+    rdfs:label     "飛び上がる"@ja;
     rdfs:label     "jumpUp"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/gloves>
     rdf:type    kgc:PhysicalObject;
@@ -6128,7 +6127,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Church"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/surprise>
     rdf:type    kgc:Action;
-    rdfs:label     "驚かせる"@ja;
+    rdfs:label     "驚く"@ja;
     rdfs:label     "surprise"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/absent>
     rdf:type    kgc:Property;
@@ -6225,7 +6224,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/thin>
     rdf:type    kgc:Property;
-    rdfs:label     "細い"@ja;
+    rdfs:label     "薄い"@ja;
     rdfs:label     "thin"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/canUnderstand>
     rdf:type    kgc:Action;
@@ -6275,10 +6274,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着ている"@ja;
+    rdfs:label     "着る"@ja;
     rdfs:label     "wear"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "着る"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Appeal_of_breach_of_pledge>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "誓約不履行の訴え"@ja;
@@ -6338,7 +6336,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Single women"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/lead>
     rdf:type    kgc:Action;
-    rdfs:label     "導く"@ja;
+    rdfs:label     "率いる"@ja;
     rdfs:label     "lead"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/expensive_cloth>
     rdf:type    kgc:Property;
@@ -6429,8 +6427,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/worry>
     rdf:type    kgc:Action;
     rdfs:label     "悩む"@ja;
-    rdfs:label     "worry"@en;
-    rdfs:label     "心配する"@ja.
+    rdfs:label     "worry"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/one_quarter>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "四分の一"@ja;
@@ -6490,7 +6487,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/predicate/pullOut>
     rdf:type    kgc:Action;
-    rdfs:label     "引き出す"@ja;
+    rdfs:label     "引きだす"@ja;
     rdfs:label     "pullOut"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/mess>
     rdf:type    kgc:Action;
@@ -6531,7 +6528,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Holmes>.
 <http://kgc.knowledge-graph.jp/data/predicate/relate>
     rdf:type    kgc:Property;
-    rdfs:label     "関係している"@ja;
+    rdfs:label     "関係する"@ja;
     rdfs:label     "relate"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
@@ -6543,13 +6540,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "beBeaten"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "集中している"@ja;
     rdfs:label     "focus"@en;
-    rdf:type    kgc:Property;
-    rdfs:label     "目ざとい"@ja.
+    rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/predicate/lookAround>
     rdf:type    kgc:Action;
-    rdfs:label     "見まわす"@ja;
+    rdfs:label     "ながめ回す"@ja;
     rdfs:label     "lookAround"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/After_a_week>
     rdf:type    kgc:AbstractTime;
@@ -6593,10 +6589,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notBreak"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/attached>
     rdf:type    kgc:Property;
-    rdfs:label     "ついている"@ja;
+    rdfs:label     "付いている"@ja;
     rdfs:label     "attached"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "付いている"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/plumbing_business>
     rdf:type    kgc:Property;
     rdfs:label     "配管業である"@ja;
@@ -6740,7 +6735,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Watson>.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
-    rdfs:label     "開ける"@ja;
+    rdfs:label     "開く"@ja;
     rdfs:label     "open"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/father_of_Sutherland>
     rdf:type    kgc:Person;
@@ -6983,10 +6978,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/good>
     rdf:type    kgc:Property;
-    rdfs:label     "よい"@ja;
+    rdfs:label     "良い"@ja;
     rdfs:label     "good"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "良い"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/black_frock_coat>
     rdf:type    kgc:Property;
     rdfs:label     "黒のフロックコートである"@ja;
@@ -7042,8 +7036,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/close>
     rdf:type    kgc:Action;
     rdfs:label     "閉める"@ja;
-    rdfs:label     "close"@en;
-    rdfs:label     "閉じる"@ja.
+    rdfs:label     "close"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/need>
     rdf:type    kgc:Action;
     rdfs:label     "必要とする"@ja;
@@ -7229,7 +7222,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/repeat>
     rdf:type    kgc:Action;
-    rdfs:label     "繰り返す"@ja;
+    rdfs:label     "重ねる"@ja;
     rdfs:label     "repeat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/relive>
     rdf:type    kgc:Action;
@@ -7245,7 +7238,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受ける"@ja;
+    rdfs:label     "受け取る"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/straw_hat_of_Blackboard_color>
     rdf:type    kgc:PhysicalObject;
@@ -7423,8 +7416,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "嬉しい"@ja;
     rdfs:label     "happy"@en;
-    rdf:type    kgc:Property;
-    rdfs:label     "幸福である"@ja.
+    rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Back_and_forth>
     rdfs:label     "前後に"@ja;
     rdfs:label     "Back and forth"@en;
@@ -7471,7 +7463,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "enter"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Horizontal_shelf>
     rdf:type    kgc:PhysicalObject;
@@ -7590,7 +7582,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "依頼する"@ja;
+    rdfs:label     "要求する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dance_of_Gas_Industry>
     rdfs:label     "dance of Gas Industry"@en;
@@ -7748,7 +7740,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪ねる"@ja;
+    rdfs:label     "訪れる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/albert_chain_of_gold>
     rdf:type    kgc:Property;
@@ -7887,7 +7879,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "持たない"@ja;
+    rdfs:label     "not持つ"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Continue>
     rdfs:label     "Continue"@en;
@@ -7920,7 +7912,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "試みる"@ja;
+    rdfs:label     "しようとする"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/string>
     rdfs:label     "string"@en;
@@ -8130,7 +8122,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Sutherland>.
 <http://kgc.knowledge-graph.jp/data/predicate/pale>
     rdf:type    kgc:Property;
-    rdfs:label     "真っ青である"@ja;
+    rdfs:label     "青ざめる"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/greet>
     rdf:type    kgc:Action;
@@ -8301,7 +8293,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "望まない"@ja;
+    rdfs:label     "したくない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/dark_blue>
     rdfs:label     "鼠色だ"@ja;
@@ -8495,7 +8487,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "black"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "参加する"@ja;
+    rdfs:label     "立ち会う"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notHesitate>
     rdf:type    kgc:Action;
@@ -8550,7 +8542,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/insist>
     rdf:type    kgc:Action;
-    rdfs:label     "主張する"@ja;
+    rdfs:label     "言い張る"@ja;
     rdfs:label     "insist"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/edge_of_hem>
     rdfs:label     "裾のふさ縁に"@ja;
@@ -8560,7 +8552,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/hem>.
 <http://kgc.knowledge-graph.jp/data/predicate/whisper>
     rdf:type    kgc:Action;
-    rdfs:label     "ささやく"@ja;
+    rdfs:label     "囁く"@ja;
     rdfs:label     "whisper"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Hozma>
     rdf:type    kgc:Person;
@@ -8574,7 +8566,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Man"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/grab>
     rdf:type    kgc:Action;
-    rdfs:label     "掴む"@ja;
+    rdfs:label     "つかむ"@ja;
     rdfs:label     "grab"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/interesting>
     rdf:type    kgc:Property;
@@ -8673,7 +8665,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "sufferFrom"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/ACaseOfIdentity/Deep_motive>
     rdf:type    kgc:PhysicalObject;

--- a/AbbeyGrange.ttl
+++ b/AbbeyGrange.ttl
@@ -5773,7 +5773,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cannotMove"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pour>
     rdf:type    kgc:Action;
-    rdfs:label     "注ぐ"@ja;
+    rdfs:label     "浴びせる"@ja;
     rdfs:label     "pour"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/bottle_of_wine>
     rdf:type    kgc:PhysicalObject;
@@ -6030,7 +6030,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "amiable"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "打つ"@ja;
+    rdfs:label     "殴る"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notMarry>
     rdf:type    kgc:Action;
@@ -6083,7 +6083,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "believe"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fill>
     rdf:type    kgc:Action;
-    rdfs:label     "満たす"@ja;
+    rdfs:label     "埋めつくす"@ja;
     rdfs:label     "fill"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/15_minutes>
     rdf:type    kgc:PhysicalObject;
@@ -6213,7 +6213,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cigar"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wakeUp>
     rdf:type    kgc:Action;
-    rdfs:label     "起こす"@ja;
+    rdfs:label     "起きる"@ja;
     rdfs:label     "wakeUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hide>
     rdf:type    kgc:Action;
@@ -6232,7 +6232,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/the_Abbey_Grange>.
 <http://kgc.knowledge-graph.jp/data/predicate/repeat>
     rdf:type    kgc:Action;
-    rdfs:label     "繰り返す"@ja;
+    rdfs:label     "重ねる"@ja;
     rdfs:label     "repeat"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hate>
     rdf:type    kgc:Action;
@@ -6272,7 +6272,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受ける"@ja;
+    rdfs:label     "受け取る"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window_of_room_of_Lady_Brackenstall>
     rdf:type    kgc:PhysicalObject;
@@ -6337,8 +6337,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/put>
     rdf:type    kgc:Action;
     rdfs:label     "置く"@ja;
-    rdfs:label     "put"@en;
-    rdfs:label     "乗せる"@ja.
+    rdfs:label     "put"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand>
     rdfs:label     "hand"@en;
     rdf:type    kgc:Object.
@@ -6408,11 +6407,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Small three windows"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/command>
     rdf:type    kgc:Action;
-    rdfs:label     "命令する"@ja;
+    rdfs:label     "指揮を執る"@ja;
     rdfs:label     "command"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考慮する"@ja;
+    rdfs:label     "考える"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/revive>
     rdf:type    kgc:Action;
@@ -6716,7 +6715,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holes_of_pond>
     rdf:type    kgc:PhysicalObject;
@@ -6738,7 +6737,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Book"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/keep>
     rdf:type    kgc:Action;
-    rdfs:label     "維持する"@ja;
+    rdfs:label     "飼っている"@ja;
     rdfs:label     "keep"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/report>
     rdf:type    kgc:Action;
@@ -6889,7 +6888,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "complaint"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "依頼する"@ja;
+    rdfs:label     "要求する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/window>
     rdf:type    kgc:Place;
@@ -7007,8 +7006,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
     rdfs:label     "会う"@ja;
-    rdfs:label     "meet"@en;
-    rdfs:label     "出会う"@ja.
+    rdfs:label     "meet"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smart>
     rdf:type    kgc:Property;
     rdfs:label     "利口である"@ja;
@@ -7130,7 +7128,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes>.
 <http://kgc.knowledge-graph.jp/data/predicate/include>
     rdf:type    kgc:Action;
-    rdfs:label     "である"@ja;
+    rdfs:label     "含んでいる"@ja;
     rdfs:label     "include"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/clean>
     rdf:type    kgc:Property;
@@ -7280,13 +7278,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つけられない"@ja;
+    rdfs:label     "見つからない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExamine>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/examine>;
-    rdfs:label     "調べない"@ja;
+    rdfs:label     "あさらない"@ja;
     rdfs:label     "notExamine"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/putOut>
     rdf:type    kgc:Action;
@@ -7528,7 +7526,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "持たない"@ja;
+    rdfs:label     "not持つ"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/callBack>
     rdf:type    kgc:Action;
@@ -7573,7 +7571,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "6 feet 3 inch"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "試みる"@ja;
+    rdfs:label     "しようとする"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/promise>
     rdf:type    kgc:Action;
@@ -7599,7 +7597,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "レディー・ブラックンストール"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/goDown>
     rdf:type    kgc:Action;
-    rdfs:label     "下りる"@ja;
+    rdfs:label     "降りる"@ja;
     rdfs:label     "goDown"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/newspaper>
     rdf:type    kgc:PhysicalObject;
@@ -7694,7 +7692,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着ている"@ja;
+    rdfs:label     "着る"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/conscience>
     rdf:type    kgc:PhysicalObject;
@@ -7795,7 +7793,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "similarly"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/getOff>
     rdf:type    kgc:Action;
-    rdfs:label     "下車する"@ja;
+    rdfs:label     "飛び降りる"@ja;
     rdfs:label     "getOff"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/［複数行可］下記から種類を選択の上「目的語」を記入>
     rdfs:label     "Holmes approaches the bell string"@ja;
@@ -7953,7 +7951,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "voyage"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/work>
     rdf:type    kgc:Action;
-    rdfs:label     "仕事をする"@ja;
+    rdfs:label     "働く"@ja;
     rdfs:label     "work"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Kitchen>
     rdf:type    kgc:Place;
@@ -7961,7 +7959,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Kitchen"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pullOut>
     rdf:type    kgc:Action;
-    rdfs:label     "引き出す"@ja;
+    rdfs:label     "引きだす"@ja;
     rdfs:label     "pullOut"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/free>
     rdfs:label     "自由である"@ja;
@@ -8055,7 +8053,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/glass>.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "集中している"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
@@ -8078,7 +8076,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "望まない"@ja;
+    rdfs:label     "したくない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Dining_room_of_Abbey_Grange>
     rdf:type    kgc:Place;
@@ -8264,7 +8262,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上がる"@ja;
+    rdfs:label     "上る"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Voice_of_the_people>
     rdf:type    kgc:PhysicalObject;
@@ -8417,7 +8415,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "参加する"@ja;
+    rdfs:label     "立ち会う"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/pajama>
     rdf:type    kgc:PhysicalObject;
@@ -8485,7 +8483,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cache"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "留まる"@ja;
+    rdfs:label     "滞在する"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sprinkle>
     rdf:type    kgc:Action;
@@ -8545,8 +8543,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "開く"@ja;
     rdfs:label     "open"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "開ける"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Brutal_character_of_criminal>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "犯人の残忍な性格"@ja;
@@ -8586,7 +8583,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "swell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/grab>
     rdf:type    kgc:Action;
-    rdfs:label     "掴む"@ja;
+    rdfs:label     "つかむ"@ja;
     rdfs:label     "grab"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Suez_Canal>
     rdf:type    kgc:Place;
@@ -8677,7 +8674,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/case>.
 <http://kgc.knowledge-graph.jp/data/predicate/fight>
     rdf:type    kgc:Action;
-    rdfs:label     "戦う"@ja;
+    rdfs:label     "格闘する"@ja;
     rdfs:label     "fight"@en.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Death_of_Sir_Eustace_brackenstall>
     rdf:type    kgc:PhysicalObject;
@@ -8782,8 +8779,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "ほつれている"@ja;
     rdfs:label     "fray"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "ほつれさせる"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/fix>
     rdf:type    kgc:Action;
     rdfs:label     "固定する"@ja;
@@ -8794,7 +8790,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Voice>
     rdfs:label     "Voice"@en;

--- a/AbbeyGrange.ttl
+++ b/AbbeyGrange.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -3833,10 +3833,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/273>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは一等航海士だった"@ja ;
-    kgc:source  "Jack Crocker was the Chief officer"@en .
+    kgc:source  "Jack Croker was the Chief officer"@en .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/273>
     rdf:type    kgc:Situation ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Chief_officer> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/273>
     rdf:type    kgc:Situation ;
@@ -3846,10 +3846,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/274>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは船長になっている"@ja ;
-    kgc:source  "Jack Crocker has become the captain"@en .
+    kgc:source  "Jack Croker has become the captain"@en .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/274>
     rdf:type    kgc:Situation ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Captain> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/274>
     rdf:type    kgc:Situation ;
@@ -3873,8 +3873,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/276>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーはベイス・ロック号の指揮を執る"@ja ;
-    kgc:source  "Jack Crocker takes command of the Base Rock"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker takes command of the Base Rock"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/command> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/276>
     rdf:type    kgc:Situation ;
@@ -3882,8 +3882,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/277>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーはシドナムに住んでいる"@ja ;
-    kgc:source  "Jack Crocker lives in Sydenham"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker lives in Sydenham"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/277>
     rdf:type    kgc:Situation ;
@@ -3891,8 +3891,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/278>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーの経歴はすばらしかった"@ja ;
-    kgc:source  "The career of Jack Crocker was wonderful"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career_of_Jack_Crocker> ;
+    kgc:source  "The career of Jack Croker was wonderful"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career_of_Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wonderful> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/278>
     rdf:type    kgc:Situation ;
@@ -3900,8 +3900,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/279>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーに匹敵する航海士はどの船にもいなかった"@ja ;
-    kgc:source  "The officer comparable to Jack Crocker was not on any ship"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "The officer comparable to Jack Croker was not on any ship"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notExist> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/279>
     rdf:type    kgc:Situation ;
@@ -3912,8 +3912,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/280>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは船を離れる"@ja ;
-    kgc:source  "Jack Crocker leaves the ship"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker leaves the ship"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/280>
     rdf:type    kgc:Situation ;
@@ -3921,8 +3921,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/281>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーの性格は無鉄砲である"@ja ;
-    kgc:source  "The personality of Jack Crocker is wildly reckless"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality_of_Jack_Crocker> ;
+    kgc:source  "The personality of Jack Croker is wildly reckless"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality_of_Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Reckless> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
     rdf:type    kgc:Situation ;
@@ -3933,8 +3933,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/282>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは短気で興奮しやすい"@ja ;
-    kgc:source  "Jack Crocker easy excited in the short term"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker easy excited in the short term"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/inpatient> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
     rdf:type    kgc:Situation ;
@@ -3942,8 +3942,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/283>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは忠実で正直で優しい"@ja ;
-    kgc:source  "Jack Crocker is friendly, faithful, and honest"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker is friendly, faithful, and honest"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Friendly> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/faithful> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/honest> .
@@ -4242,14 +4242,14 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/308>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは男らしい"@ja ;
-    kgc:source  "Jack Crocker is manly"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker is manly"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/manly> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/309>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーがホームズの部屋に入ってきた"@ja ;
-    kgc:source  "Jack Crocker walked into Holmes' room"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker walked into Holmes' room"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/309>
     rdf:type    kgc:Situation ;
@@ -4257,8 +4257,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/310>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは軽快な足取りをしていた"@ja ;
-    kgc:source  "Jack Crocker had a nimble gait"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker had a nimble gait"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/nimble-footed> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/310>
     rdf:type    kgc:Situation ;
@@ -4266,9 +4266,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/311>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはホームズからの電報を受け取った"@ja ;
-    kgc:source  "Jack Crocker received a telegram from Holmes"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker received a telegram from Holmes"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/311>
     rdf:type    kgc:Situation ;
@@ -4298,8 +4298,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/312a>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは葉巻を吸う"@ja ;
-    kgc:source  "Jack Crocker smoked a cigar"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker smoked a cigar"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/smoke> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/312a>
     rdf:type    kgc:Situation ;
@@ -4321,15 +4321,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/314>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは普通の犯罪者である"@ja ;
-    kgc:source  "Jack Crocker is an ordinary criminal"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker is an ordinary criminal"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Ordinary_criminal> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/315>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはホームズを信じる"@ja ;
-    kgc:source  "Jack Crocker believe Holmes"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker believe Holmes"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/315>
     rdf:type    kgc:Situation ;
@@ -4340,10 +4340,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは以下を誓った"@ja ;
-    kgc:source  "Jack Crocker vowed the following"@en .
+    kgc:source  "Jack Croker vowed the following"@en .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316>
     rdf:type    kgc:Situation ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/swear> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316>
     rdf:type    kgc:Situation ;
@@ -4351,9 +4351,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316a>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは事実を話す"@ja ;
-    kgc:source  "Jack Crocker speaks the truth."@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker speaks the truth."@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/316a>
     rdf:type    kgc:Situation ;
@@ -4362,17 +4362,17 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "サー・ユースタス・ブラックンストールが生き返る"@ja ;
     kgc:source  "Sir Eustace Brackenstall come back to life"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/revive> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは同じことをする"@ja ;
-    kgc:source  "Jack Crocker does the same thing to Sir Eustace Brackenstall"@en .
+    kgc:source  "Jack Croker does the same thing to Sir Eustace Brackenstall"@en .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
     rdf:type    kgc:Statement ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/repeat> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/318>
     rdf:type    kgc:Situation ;
@@ -4386,9 +4386,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/319>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは以下を望まない"@ja ;
-    kgc:source  "Jack Crocker does not want the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker does not want the following"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/319>
     rdf:type    kgc:Situation ;
@@ -4396,11 +4396,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/320>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールを厄介な立場に巻き込む"@ja ;
-    kgc:source  "Jack Crocker puts Lady Blackenstall in an awkward position"@en .
+    kgc:source  "Jack Croker puts Lady Blackenstall in an awkward position"@en .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/319a>
     rdf:type    kgc:Statement ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/involve> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/319a>
     rdf:type    kgc:Situation ;
@@ -4411,9 +4411,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/320>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは命をささげる"@ja ;
-    kgc:source  "Jack Crocker gives his life"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker gives his life"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/dedicate> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/320>
     rdf:type    kgc:Situation ;
@@ -4424,9 +4424,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/321>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーとレディー・ブラックンストールはロック・オブ・ジブラルタルという船で出会った"@ja ;
-    kgc:source  "Jack Crocker and Lady Brackenstall met at the Rock of Gibraltar"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker and Lady Brackenstall met at the Rock of Gibraltar"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/321>
@@ -4435,8 +4435,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/322>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーにとってレディー・ブラックンストールはただ一人の女性となった"@ja ;
-    kgc:source  "Lady Brackenstall just became one of the women for Jack Crocker"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Lady Brackenstall just became one of the women for Jack Croker"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/322>
@@ -4448,9 +4448,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/323>
     rdf:type    kgc:Statement ;
     kgc:source  "恋心はジャック・クロッカーの方ばかりだった"@ja ;
-    kgc:source  "Love was the only person of Jack Crocker"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Love was the only person of Jack Croker"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/323>
     rdf:type    kgc:Situation ;
@@ -4464,8 +4464,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/324>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーが次の航海から帰った"@ja ;
-    kgc:source  "Jack Crocker was back from the next voyage"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker was back from the next voyage"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/324>
     rdf:type    kgc:Situation ;
@@ -4473,9 +4473,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/325>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールの結婚を知った"@ja ;
-    kgc:source  "Jack Crocker was aware of the marriage of Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker was aware of the marriage of Lady Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/325>
     rdf:type    kgc:Situation ;
@@ -4487,7 +4487,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Thought ;
     kgc:source  "レディー・ブラックンストールは好きな男と結婚していない"@ja ;
     kgc:source  "Lady Brackenstall is not married to a favorite man"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notMarry> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/326>
@@ -4497,25 +4497,25 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Thought ;
     kgc:source  "レディー・ブラックンストールは上品なものすべてのために生まれた"@ja ;
     kgc:source  "Lady Brackenstall was born for this classy life"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/classy> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/328>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールがジャック・クロッカーのために不幸にならない"@ja ;
-    kgc:source  "Lady Bracknstall is not unhappy for Jack Crocker."@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Lady Bracknstall is not unhappy for Jack Croker."@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notUnhappy> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/328>
     rdf:type    kgc:Situation ;
-    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
+    kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/329>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは以下を喜んだ"@ja ;
-    kgc:source  "Jack Crocker was pleased with the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker was pleased with the following"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bePleased> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/329>
     rdf:type    kgc:Situation ;
@@ -4523,9 +4523,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/330>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは新しい船のためシドナムで数ヵ月待っていた"@ja ;
-    kgc:source  "Jack Crocker had been waiting in Sydenham for the new ship for several months"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker had been waiting in Sydenham for the new ship for several months"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/330>
     rdf:type    kgc:Situation ;
@@ -4541,9 +4541,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/331>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはテリーサと会った"@ja ;
-    kgc:source  "Jack Crocker met with Theresa"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker met with Theresa"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/331>
@@ -4555,9 +4555,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/332>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはテリーサからサー・ユースタス・ブラックンストールの話を聞いた"@ja ;
-    kgc:source  "Jack Crocker heard the story of Sir Eustace Brackenstall from Theresa"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker heard the story of Sir Eustace Brackenstall from Theresa"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/332>
     rdf:type    kgc:Situation ;
@@ -4568,9 +4568,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/333>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはもう一度テリーサと会った"@ja ;
-    kgc:source  "Jack Crocker met Theresa once again"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker met Theresa once again"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/333>
@@ -4582,17 +4582,17 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/334>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはメアリーに会った"@ja ;
-    kgc:source  "Jack Crocker met Mary"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker met Mary"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Mary> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/335>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは船旅に出る"@ja ;
-    kgc:source  "Jack Crocker go on a voyage"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker go on a voyage"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/335>
     rdf:type    kgc:Situation ;
@@ -4600,9 +4600,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/336>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはもう一度テリーサに会った"@ja ;
-    kgc:source  "Jack Crocker met Teresa once more"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker met Teresa once more"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/336>
     rdf:type    kgc:Situation ;
@@ -4616,8 +4616,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/337>
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサはいつもジャック・クロッカーの味方だった"@ja ;
-    kgc:source  "Theresa was always an ally of Jack Crocker"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Theresa was always an ally of Jack Croker"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/ally> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/337>
@@ -4629,9 +4629,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/338>
     rdf:type    kgc:Situation ;
     kgc:source  "テリーサはジャック・クロッカーと同様にサー・ユースタス・ブラックンストールを憎んでいる"@ja ;
-    kgc:source  "Theresa is hated Sir Eustace Brackenstall in the same way as Jack Crocker"@en ;
+    kgc:source  "Theresa is hated Sir Eustace Brackenstall in the same way as Jack Croker"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hate> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/338>
     rdf:type    kgc:Situation ;
@@ -4642,9 +4642,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/339>
     rdf:type    kgc:Situation ;
     kgc:source  "テリーサはジャック・クロッカーと同様にレディー・ブラックンストールを愛している"@ja ;
-    kgc:source  "Theresa loves Lady Brackenstall in the same way as Jack Crocker"@en ;
+    kgc:source  "Theresa loves Lady Brackenstall in the same way as Jack Croker"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/339>
     rdf:type    kgc:Situation ;
@@ -4655,9 +4655,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/340>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはテリーサから以下のことを聞いた"@ja ;
-    kgc:source  "Jack Crocker heard the following from Theresa"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker heard the following from Theresa"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/340>
     rdf:type    kgc:Situation ;
@@ -4675,7 +4675,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールはいつも階下の小さな部屋で本を読んでいる"@ja ;
     kgc:source  "Lady Brackenstall is always reading a book in a small room downstairs"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/read> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/341>
@@ -4687,9 +4687,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/342>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールの部屋の窓をひっかいた"@ja ;
-    kgc:source  "Jack Crocker scratched the window of the room of Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker scratched the window of the room of Lady Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/scratch> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/342>
     rdf:type    kgc:Situation ;
@@ -4700,26 +4700,26 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/343>
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールはジャック・クロッカーのことを愛している"@ja ;
-    kgc:source  "Lady Brackenstall love Jack Crocker"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Lady Brackenstall love Jack Croker"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/343>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールによりダイニングルームに招き入れられた"@ja ;
-    kgc:source  "Jack Crocker was invited to the dining room by Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker was invited to the dining room by Lady Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inviteIn> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
     rdf:type    kgc:Situation ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dining_room> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/344>
     rdf:type    kgc:Situation ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/343> .
@@ -4729,9 +4729,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/345>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールから事情を聞いた"@ja ;
-    kgc:source  "Jack Crocker heard what happened from Lady Bracknstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker heard what happened from Lady Bracknstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/345>
     rdf:type    kgc:Situation ;
@@ -4745,9 +4745,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/346>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールと共に窓の内側に立っていた"@ja ;
-    kgc:source  "Jack Crocker was standing on the inside of the window along with the Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker was standing on the inside of the window along with the Lady Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stand> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/346>
@@ -4760,7 +4760,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "サー・ユースタス・ブラックンストールが狂ったようにダイニングルームに駆け込んできた"@ja ;
     kgc:source  "Sir Eustace Brackenstall has rushed to the dining room like crazy"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rush> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/347>
@@ -4773,7 +4773,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "サー・ユースタス・ブラックンストールはステッキでレディー・ブラックンストールの顔を横から殴った"@ja ;
     kgc:source  "Sir Eustace Brackenstall hit the face of the Lady Brackenstall from the side with a stick"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/348>
@@ -4788,9 +4788,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/349>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは火かき棒に飛びついた"@ja ;
-    kgc:source  "Jack Crocker jumped at the poker"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker jumped at the poker"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/349>
     rdf:type    kgc:Situation ;
@@ -4801,9 +4801,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/350>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーとサー・ユースタス・ブラックンストールは正々堂々戦った"@ja ;
-    kgc:source  "Jack Crocker and Sir Eustace Brackenstall fought fair and square"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker and Sir Eustace Brackenstall fought fair and square"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fight> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/350>
@@ -4815,8 +4815,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/351>
     rdf:type    kgc:Statement ;
     kgc:source  "サー・ユースタス・ブラックンストールはジャック・クロッカーの腕に一撃加えた"@ja ;
-    kgc:source  "Sir Eustace Brackenstall added a blow to the arm of Jack Crocker"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Sir Eustace Brackenstall added a blow to the arm of Jack Croker"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sir_Eustace_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/351>
@@ -4828,9 +4828,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/352>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはサー・ユースタス・ブラックンストールを腐ったかぼちゃのようにやっつけた"@ja ;
-    kgc:source  "Jack Crocker beat Sir Eustace Blackenstall like a rotten pumpkin"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker beat Sir Eustace Blackenstall like a rotten pumpkin"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/・hasProperty→状態を表す>
     rdf:type    kgc:Situation ;
@@ -4844,9 +4844,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/353>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは以下を後悔していない"@ja ;
-    kgc:source  "Jack Crocker does not regret the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker does not regret the following"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notRegret> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/353>
     rdf:type    kgc:Situation ;
@@ -4854,8 +4854,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/354>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーがサー・ユースタス・ブラックンストールを殺さない"@ja ;
-    kgc:source  "Jack Crocker does not kill Sir Eustace Brackenstall"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker does not kill Sir Eustace Brackenstall"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKill> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/354>
     rdf:type    kgc:Situation ;
@@ -4863,9 +4863,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/355>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーが危なかった"@ja ;
-    kgc:source  "Jack Crocker was dangerous"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker was dangerous"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/dangerous> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/355>
     rdf:type    kgc:Situation ;
@@ -4874,7 +4874,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Thought ;
     kgc:source  "レディー・ブラックンストールが危なかった"@ja ;
     kgc:source  "Lady Brackenstall was dangerous"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/dangerous> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/356>
@@ -4883,9 +4883,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/357>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはサー・ユースタス・ブラックンストールにレディー・ブラックンストールを残せなかった"@ja ;
-    kgc:source  "Jack Crocker could not leave Lady Blackenstall for Sir Eustace Blackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker could not leave Lady Blackenstall for Sir Eustace Blackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notLeave> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/357>
     rdf:type    kgc:Situation ;
@@ -4896,9 +4896,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/358>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはサー・ユースタス・ブラックンストールを殺した"@ja ;
-    kgc:source  "Jack Crocker killed Sir Eustace Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker killed Sir Eustace Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/358>
     rdf:type    kgc:Situation ;
@@ -4913,7 +4913,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールはサー・ユースタス・ブラックンストールに殴られた"@ja ;
     kgc:source  "Lady Brackenstall was beaten by Sir Eustace Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/359>
@@ -4923,7 +4923,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは叫び声をあげた"@ja ;
     kgc:source  "Lady Brackenstall screamed"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/360>
@@ -4939,7 +4939,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサはレディー・ブラックンストールの叫び声を聞いた"@ja ;
     kgc:source  "Theresa heard the screams of Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/361>
@@ -4952,7 +4952,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサは上の部屋から降りてきた"@ja ;
     kgc:source  "Theresa came down from the top of the room"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goDown> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/362>
@@ -4962,7 +4962,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "サイドボードにワインの瓶があった"@ja ;
     kgc:source  "On the sideboard, there was a wine bottle"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Bottle_of_wine> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/363>
@@ -4974,9 +4974,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/364>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはワインの瓶を開けた"@ja ;
-    kgc:source  "Jack Crocker opened the bottle of wine"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker opened the bottle of wine"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/open> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/364>
     rdf:type    kgc:Situation ;
@@ -4985,7 +4985,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールはショックで死んだようになっている"@ja ;
     kgc:source  "Lady Brackenstall is as dead in shock"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/unconscious> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/365>
@@ -4994,9 +4994,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/366>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールの口にワインを少し注いだ"@ja ;
-    kgc:source  "Jack Crocker poured a little wine into the mouth of Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker poured a little wine into the mouth of Lady Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/pour> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/366>
     rdf:type    kgc:Situation ;
@@ -5013,9 +5013,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/367>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーもワインを一杯飲んだ"@ja ;
-    kgc:source  "Jack Crocker also had a glass of wine"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker also had a glass of wine"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drink> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/367>
     rdf:type    kgc:Situation ;
@@ -5026,10 +5026,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/368>
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサとジャック・クロッカーが策略を考えた"@ja ;
-    kgc:source  "Theresa and Jack Crocker thought of the ruse"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Theresa and Jack Croker thought of the ruse"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/consider> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/368>
     rdf:type    kgc:Situation ;
@@ -5040,10 +5040,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/369>
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサとジャック・クロッカーは事件を夜盗の仕業にした"@ja ;
-    kgc:source  "Theresa and Jack Crocker were involved in the work of burglary"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Theresa and Jack Croker were involved in the work of burglary"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/camouflage> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/369>
     rdf:type    kgc:Situation ;
@@ -5061,7 +5061,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサは作り話を繰り返しレディー・ブラックンストールに聞かせた"@ja ;
     kgc:source  "Theresa let Lady Brackenstall repeat the apocryphal"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/370>
@@ -5079,9 +5079,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/371>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはベルの紐を切った"@ja ;
-    kgc:source  "Jack Crocker cut the bell code"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker cut the bell code"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cut> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/371>
     rdf:type    kgc:Situation ;
@@ -5092,9 +5092,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/372>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールを椅子に縛り付けた"@ja ;
-    kgc:source  "Jack Crocker was tied to chair the Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker was tied to chair the Lady Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/tie> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/372>
     rdf:type    kgc:Situation ;
@@ -5105,9 +5105,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/373>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは紐の端をほつれさせた"@ja ;
-    kgc:source  "Jack Crocker frayed the ends of the code"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker frayed the ends of the code"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fray> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/373>
     rdf:type    kgc:Situation ;
@@ -5127,9 +5127,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/375>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは泥棒というアイディアを貫徹したい"@ja ;
-    kgc:source  "Jack Crocker want to penetration of the idea of __thief"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker want to penetration of the idea of __thief"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/keep> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/375>
     rdf:type    kgc:Situation ;
@@ -5137,9 +5137,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/376>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは銀のさらやポットをいくつかかき集めた"@ja ;
-    kgc:source  "Jack Crocker has gathered some of the silver plates and pots"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker has gathered some of the silver plates and pots"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collect> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/376>
     rdf:type    kgc:Situation ;
@@ -5151,7 +5151,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "テリーサとレディー・ブラックンストールは15分したら非常を知らせる"@ja ;
     kgc:source  "Theresa and Lady Brackenstall inform a police after the 15 minutes"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Theresa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/inform> .
@@ -5164,9 +5164,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/378>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは指示した"@ja ;
-    kgc:source  "Jack Crocker instructed"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker instructed"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/instruct> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/378>
     rdf:type    kgc:Situation ;
@@ -5180,9 +5180,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/379>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは池の底に銀製品を落とした"@ja ;
-    kgc:source  "Jack Crocker dropped the silver product to the bottom of the pond"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker dropped the silver product to the bottom of the pond"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/drop> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/379>
     rdf:type    kgc:Situation ;
@@ -5193,9 +5193,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/380>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは本当に良いことをした"@ja ;
-    kgc:source  "Jack Crocker did a really good thing"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker did a really good thing"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/perform> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/380>
     rdf:type    kgc:Situation ;
@@ -5203,9 +5203,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/381>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは以下を思った"@ja ;
-    kgc:source  "Jack Crocker thought the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker thought the following"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/381>
     rdf:type    kgc:Situation ;
@@ -5216,9 +5216,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/382>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはシドナムへ向かった"@ja ;
-    kgc:source  "Jack Crocker went to Sydenham"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker went to Sydenham"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/382>
     rdf:type    kgc:Situation ;
@@ -5226,8 +5226,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/383>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーは真実を話した"@ja ;
-    kgc:source  "Jack Crocker told the truth"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker told the truth"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/383>
     rdf:type    kgc:Situation ;
@@ -5238,22 +5238,22 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/384>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはジャック・クロッカーの手を握った"@ja ;
-    kgc:source  "Holmes was holding the hand of Jack Crocker"@en ;
+    kgc:source  "Holmes was holding the hand of Jack Croker"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hold> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/384>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand_of_Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand_of_Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/385>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはジャック・クロッカーの一言一言が真実であるとわかる"@ja ;
-    kgc:source  "Holmes finds Jack Crocker's story to be true"@en ;
+    kgc:source  "Holmes finds Jack Croker's story to be true"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/385>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/・Opposite（反対側）>
     rdf:type    kgc:Situation ;
     kgc:   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/370> .
@@ -5263,8 +5263,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/386>
     rdf:type    kgc:Situation ;
     kgc:source  "ジャック・クロッカーはホームズの知らないことを言わなかった"@ja ;
-    kgc:source  "Jack Crocker never told Holmes what he didn't know"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker never told Holmes what he didn't know"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/386>
     rdf:type    kgc:Situation ;
@@ -5393,16 +5393,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/395>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーの行動は極めて重大な問題である"@ja ;
-    kgc:source  "Behavior of Jack Crocker is an extremely serious problem"@en ;
+    kgc:source  "Behavior of Jack Croker is an extremely serious problem"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior_of_Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior_of_Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Serious_problems> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/396>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーの行動は正当防衛である"@ja ;
-    kgc:source  "Behavior of Jack Crocker is in self-defense."@en ;
+    kgc:source  "Behavior of Jack Croker is in self-defense."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior_of_Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior_of_Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/self-defense> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/397>
     rdf:type    kgc:Statement ;
@@ -5423,32 +5423,32 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/398>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはジャック・クロッカーにおおいに同情している"@ja ;
-    kgc:source  "Holmes has shown much sympathy for Jack Crocker"@en ;
+    kgc:source  "Holmes has shown much sympathy for Jack Croker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sympathy> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/398>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399>
     rdf:type    kgc:Statement ;
     kgc:source  "誰もジャック・クロッカーを妨げない"@ja ;
-    kgc:source  "No one prevents Jack Crocker"@en ;
+    kgc:source  "No one prevents Jack Croker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/everyone> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notInterfere> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399>
     rdf:type    kgc:Situation ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399a> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399a>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーが二十四時間以内に姿を隠す"@ja ;
-    kgc:source  "Jack Crocker hide the appearance within twenty-four hours"@en ;
+    kgc:source  "Jack Croker hide the appearance within twenty-four hours"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/399a>
     rdf:type    kgc:Situation ;
@@ -5469,9 +5469,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/401>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは隠れる"@ja ;
-    kgc:source  "Jack Crocker is hidden"@en ;
+    kgc:source  "Jack Croker is hidden"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/401>
     rdf:type    kgc:Situation ;
@@ -5493,7 +5493,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "レディー・ブラックンストールは共犯者として非難を受ける"@ja ;
     kgc:source  "Lady Brackenstall receives the accused as an accomplice"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/police> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/concider> .
@@ -5513,9 +5513,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/405>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはレディー・ブラックンストールを置いて逃げない"@ja ;
-    kgc:source  "Jack Crocker will not run away at Lady Brackenstall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:source  "Jack Croker will not run away at Lady Brackenstall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notEscape> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/405>
     rdf:type    kgc:Situation ;
@@ -5523,13 +5523,13 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/406>
     rdf:type    kgc:Statement ;
     kgc:source  "ホームズはジャック・クロッカーを試していた"@ja ;
-    kgc:source  "Holmes only had to try Jack Crocker"@en ;
+    kgc:source  "Holmes only had to try Jack Croker"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/try> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/406>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity_of_Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity_of_Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/406>
     rdf:type    kgc:Situation ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/407> .
@@ -5550,12 +5550,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/408>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはジャック・クロッカーの罪をワトソンに聞いた"@ja ;
-    kgc:source  "Holmes asked Watson about Jack Crocker's crimes"@en ;
+    kgc:source  "Holmes asked Watson about Jack Croker's crimes"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ask> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/408>
     rdf:type    kgc:Situation ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin_of_Jack_Crocker> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin_of_Jack_Croker> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/408>
     rdf:type    kgc:Situation ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> .
@@ -5565,9 +5565,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/409>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは無罪である"@ja ;
-    kgc:source  "Jack Crocker is innocent"@en ;
+    kgc:source  "Jack Croker is innocent"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Watson> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/innocent> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/410>
     rdf:type    kgc:Statement ;
@@ -5582,9 +5582,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/411>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーは無罪放免である"@ja ;
-    kgc:source  "Jack Crocker was acquitted"@en ;
+    kgc:source  "Jack Croker was acquitted"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/411>
     rdf:type    kgc:Situation ;
@@ -5601,9 +5601,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/413>
     rdf:type    kgc:Statement ;
     kgc:source  "ジャック・クロッカーはホームズのことを信じる"@ja ;
-    kgc:source  "Jack Crocker believes Holmes"@en ;
+    kgc:source  "Jack Croker believes Holmes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> .
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/413>
     rdf:type    kgc:Situation ;
@@ -5750,9 +5750,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "招き入れる"@ja;
     rdfs:label     "inviteIn"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>
-    rdfs:label     "Jack Crocker"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/cord>
     rdfs:label     "cord"@en;
     rdf:type    kgc:Object.
@@ -6052,6 +6049,13 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "7月"@ja;
     rdfs:label     "July"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career_of_Jack_Croker>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ジャック・クロッカーの経歴"@ja;
+    rdfs:label     "Career of Jack Croker"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Heavy_curved_poker>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "曲がった重い火かき棒"@ja;
@@ -6200,6 +6204,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "冷やす"@ja;
     rdfs:label     "chill"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity_of_Jack_Croker>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ジャック・クロッカーの誠実さ"@ja;
+    rdfs:label     "Sincerity of Jack Croker"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/dregs>
     rdfs:label     "dregs"@en;
     rdf:type    kgc:Object.
@@ -6455,15 +6466,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "しらふ"@ja;
     rdfs:label     "sober"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior_of_Jack_Crocker>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ジャック・クロッカーの行動は"@ja;
-    rdfs:label     "Behavior of Jack Crocker"@en;
-    rdf:type    kgc:OFobj;
-    rdf:type    kgc:Person;
-    rdfs:label     "ジャック・クロッカーの行動"@ja;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Upper_limbs>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "上肢"@ja;
@@ -6607,13 +6609,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Person;
     rdfs:label     "使い"@ja;
     rdfs:label     "use"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity_of_Jack_Crocker>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ジャック・クロッカーの誠実さ"@ja;
-    rdfs:label     "Sincerity of Jack Crocker"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sincerity>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/predicate/demon>
     rdf:type    kgc:Property;
     rdfs:label     "鬼のようである"@ja;
@@ -6625,13 +6620,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Marriage>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Jack_Crocker>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ジャック・クロッカーの証言"@ja;
-    rdfs:label     "Testimony of Jack Crocker"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/predicate/Friendly>
     rdf:type    kgc:Property;
     rdfs:label     "忠実"@ja;
@@ -6739,6 +6727,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "飼っている"@ja;
     rdfs:label     "keep"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand_of_Jack_Croker>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ジャック・クロッカーの手"@ja;
+    rdfs:label     "hand of Jack Croker"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/predicate/report>
     rdf:type    kgc:Action;
     rdfs:label     "報告する"@ja;
@@ -6996,6 +6991,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "事件"@ja;
     rdfs:label     "case"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin_of_Jack_Croker>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ジャック・クロッカーの罪"@ja;
+    rdfs:label     "Sin of Jack Croker"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Recovery>
     rdfs:label     "Recovery"@en;
     rdf:type    kgc:Object.
@@ -7055,13 +7057,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/a_cup>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/wine>.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin_of_Jack_Crocker>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ジャック・クロッカーの罪"@ja;
-    rdfs:label     "Sin of Jack Crocker"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Sin>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/High_French_windows>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "フランス窓"@ja;
@@ -7302,11 +7297,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "早い時間帯"@ja;
     rdfs:label     "early time"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Crocker>
-    rdfs:label     "Thought of Jack Crocker"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/predicate/wonderful>
     rdf:type    kgc:Property;
     rdfs:label     "すばらしい"@ja;
@@ -7555,6 +7545,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/room>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Blackenstall>.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony_of_Jack_Croker>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ジャック・クロッカーの証言"@ja;
+    rdfs:label     "Testimony of Jack Croker"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Testimony>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/predicate/leaveBehind>
     rdf:type    kgc:Action;
     rdfs:label     "置いていく"@ja;
@@ -7589,12 +7586,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "演ずる"@ja;
     rdfs:label     "perform"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>
-    rdf:type    kgc:Person;
-    rdfs:label     "ジャック・クロッカー"@ja;
-    rdfs:label     "Jack Crocker"@en;
-    rdfs:label     "ジャック・クロッカ―"@ja;
-    rdfs:label     "レディー・ブラックンストール"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/goDown>
     rdf:type    kgc:Action;
     rdfs:label     "降りる"@ja;
@@ -7779,6 +7770,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "殺す"@ja;
     rdfs:label     "kill"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>
+    rdfs:label     "Jack Croker"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/nice>
     rdf:type    kgc:Action;
     rdfs:label     "素敵である"@ja;
@@ -7941,6 +7935,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "来る"@ja;
     rdfs:label     "come"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>
+    rdf:type    kgc:Person;
+    rdfs:label     "ジャック・クロッカー"@ja;
+    rdfs:label     "Jack Croker"@en;
+    rdfs:label     "ジャック・クロッカ―"@ja;
+    rdfs:label     "レディー・ブラックンストール"@ja.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Blinding>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "目くらまし"@ja;
@@ -7953,6 +7953,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "働く"@ja;
     rdfs:label     "work"@en.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought_of_Jack_Croker>
+    rdfs:label     "Thought of Jack Croker"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Thought>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Kitchen>
     rdf:type    kgc:Place;
     rdfs:label     "調理場"@ja;
@@ -7991,17 +7996,17 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/siblings>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Lady_Brackenstall>.
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality_of_Jack_Croker>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "ジャック・クロッカーの性格"@ja;
+    rdfs:label     "Personality of Jack Croker"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/predicate/sit>
     rdf:type    kgc:Action;
     rdfs:label     "座る"@ja;
     rdfs:label     "sit"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand_of_Jack_Crocker>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ジャック・クロッカーの手"@ja;
-    rdfs:label     "hand of Jack Crocker"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/hand>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Kent>
     rdf:type    kgc:Place;
     rdfs:label     "ケント"@ja;
@@ -8192,13 +8197,15 @@ kgc:Thought rdf:type owl:Class ;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/contact>;
     rdfs:label     "連絡しない"@ja;
     rdfs:label     "notContact"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality_of_Jack_Crocker>
+<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior_of_Jack_Croker>
     rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ジャック・クロッカーの性格"@ja;
-    rdfs:label     "Personality of Jack Crocker"@en;
+    rdfs:label     "ジャック・クロッカーの行動は"@ja;
+    rdfs:label     "Behavior of Jack Croker"@en;
     rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Personality>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
+    rdf:type    kgc:Person;
+    rdfs:label     "ジャック・クロッカーの行動"@ja;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Behavior>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Croker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/early_morning>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "朝早く"@ja;
@@ -8739,13 +8746,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "十分"@ja;
     rdfs:label     "sufficient"@en.
-<http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career_of_Jack_Crocker>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "ジャック・クロッカーの経歴"@ja;
-    rdfs:label     "Career of Jack Crocker"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Career>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/AbbeyGrange/Jack_Crocker>.
 <http://kgc.knowledge-graph.jp/data/AbbeyGrange/law_of_England>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "イングランドの法"@ja;

--- a/CrookedMan.ttl
+++ b/CrookedMan.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/CrookedMan/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -243,18 +243,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/006>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリが殺された"@ja ;
-    kgc:source  "Berkeley was killed."@en ;
+    kgc:source  "Barclay was killed."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beKilled> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/Monday> ;
     kgc:time  "1887-07-06T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1887-07-06> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/007>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリはオールダショットのロイヤル・マロウズに所属している"@ja ;
-    kgc:source  "Berkeley belongs to the Royal Mallows of Aldershot."@en ;
+    kgc:source  "Barclay belongs to the Royal Mallows of Aldershot."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/belong> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Royal_Mallows> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/Aldershot> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/008>
@@ -275,9 +275,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/010>
     rdf:type    kgc:Situation ;
     kgc:source  "月曜日の夜まで、バークリはロイヤル・マロウズを率いていた"@ja ;
-    kgc:source  "Berkeley led the Royal Mallows until Monday evening."@en ;
+    kgc:source  "Barclay led the Royal Mallows until Monday evening."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/lead> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Royal_Mallows> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/Monday_evening> ;
     kgc:time  "1887-07-06T20:00:00"^^xsd:dateTime ;
@@ -285,16 +285,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/011>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは歴戦の勇者だった"@ja ;
-    kgc:source  "Berkeley was a brave hero."@en ;
+    kgc:source  "Barclay was a brave hero."@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/hero> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/CrookedMan/012> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/012>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは初めは一兵卒だった"@ja ;
-    kgc:source  "Berkeley was a soldier at first."@en ;
+    kgc:source  "Barclay was a soldier at first."@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/soldier> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/first> ;
     kgc:time  "1856-07-06T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1856-07-06> ;
@@ -302,9 +302,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/013>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは、大反乱の活躍によって将校階級に昇進した"@ja ;
-    kgc:source  "Berkeley was promoted to a senior rank by the Indian Rebellion."@en ;
+    kgc:source  "Barclay was promoted to a senior rank by the Indian Rebellion."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/promote> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/CrookedMan/solider> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/CrookedMan/senior_rank> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/CrookedMan/Indian_Rebellion> ;
@@ -315,18 +315,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/014>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリとナンシィは結婚した"@ja ;
-    kgc:source  "Berkeley and Nancy got married."@en ;
+    kgc:source  "Barclay and Nancy got married."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:time  "1859-07-06T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1859-07-06> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/015>
     rdf:type    kgc:Situation ;
     kgc:source  "その時、バークリは軍曹だった"@ja ;
-    kgc:source  "At that time, Berkeley was a sergeant."@en ;
+    kgc:source  "At that time, Barclay was a sergeant."@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/sergeant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:time  "1859-07-06T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1859-07-06> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/016>
@@ -339,9 +339,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/017>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリとナンシィは人付き合いをできなかった"@ja ;
-    kgc:source  "Berkeley and Nancy could not get along."@en ;
+    kgc:source  "Barclay and Nancy could not get along."@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notSociable> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/018>
     rdf:type    kgc:Situation ;
@@ -397,130 +397,130 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/22b>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは幸福であった"@ja ;
-    kgc:source  "Berkeley was happy."@en ;
+    kgc:source  "Barclay was happy."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/happy> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/023>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリとナンシィは、言い争わなかった"@ja ;
     kgc:source  "Barkeley and Nancy did not argue."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notArgue> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/024>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリはナンシィを情熱的に愛していた"@ja ;
-    kgc:source  "Berkeley had loved passionately the Nancy."@en ;
+    kgc:source  "Barclay had loved passionately the Nancy."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/CrookedMan/passionately> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/025>
     rdf:type    kgc:Statement ;
     kgc:source  "ナンシィはバークリを情熱的には愛していなかった"@ja ;
-    kgc:source  "Nancy is passionate the Berkeley did not love."@en ;
+    kgc:source  "Nancy is passionate the Barclay did not love."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notLove> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/CrookedMan/passionately> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/026>
     rdf:type    kgc:Statement ;
     kgc:source  "ナンシィとバークリはロイヤル・マロウズの中で中年夫婦の理想像であった"@ja ;
-    kgc:source  "Nancy and Berkeley was the ideal image of a middle-aged couple in the Royal Mallows."@en ;
+    kgc:source  "Nancy and Barclay was the ideal image of a middle-aged couple in the Royal Mallows."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/ideal_of_middle-aged_couple> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/Royal_Mallows> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/027>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは変わった性格である"@ja ;
-    kgc:source  "Berkeley is the unusual character."@en ;
+    kgc:source  "Barclay is the unusual character."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/eccentric> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/character_of_Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/character_of_Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/028>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは快活な老兵である"@ja ;
-    kgc:source  "Berkeley is a light-hearted old soldier."@en ;
+    kgc:source  "Barclay is a light-hearted old soldier."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/old_soldier> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/029>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリはたまに凶暴になる"@ja ;
-    kgc:source  "Berkeley sometimes become violent."@en ;
+    kgc:source  "Barclay sometimes become violent."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/violent> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/sometimes> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/030>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリはたまに執念深くなる"@ja ;
-    kgc:source  "Berkeley is sometimes obsessive."@en ;
+    kgc:source  "Barclay is sometimes obsessive."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/obsessive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/sometimes> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/031>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリはナンシィに凶暴にならない"@ja ;
-    kgc:source  "Berkeley won't go bad at Nancy."@en ;
+    kgc:source  "Barclay won't go bad at Nancy."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notViolent> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/032>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリはナンシィに執念深くない"@ja ;
-    kgc:source  "Berkeley is not obsessive to Nancy."@en ;
+    kgc:source  "Barclay is not obsessive to Nancy."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/notObsessive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/033>
     rdf:type    kgc:Statement ;
     kgc:source  "何日間も、バークリは気が滅入る"@ja ;
-    kgc:source  "Berkeley feels down for many days."@en ;
+    kgc:source  "Barclay feels down for many days."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/feel_down> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/many_days> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/034>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは迷信を信じている"@ja ;
-    kgc:source  "Berkeley believe in superstition."@en ;
+    kgc:source  "Barclay believe in superstition."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/superstition> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/035>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは以下を嫌がる"@ja ;
-    kgc:source  "Berkeley dislike the following."@en ;
+    kgc:source  "Barclay dislike the following."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notLike> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/036> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/036>
     rdf:type    kgc:Situation ;
     kgc:source  "夜に、バークリは一人である"@ja ;
-    kgc:source  "At night, Berkeley is one person."@en ;
+    kgc:source  "At night, Barclay is one person."@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/alone> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/night> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/037>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは、雄々しい性格となよなよした性格"@ja ;
-    kgc:source  "Berkeley has a supple personality and heroic personality."@en ;
+    kgc:source  "Barclay has a supple personality and heroic personality."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/heroic_personallity> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/supple_personality> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/039>
     rdf:type    kgc:Situation ;
     kgc:source  "ロイヤル・マロウズ第一大隊はオールダショットに駐留している"@ja ;
@@ -531,15 +531,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/040>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは家を借りていた"@ja ;
-    kgc:source  "Berkeley had rented a house."@en ;
+    kgc:source  "Barclay had rented a house."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/rent> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/house> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/041>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリの家の名前はラシーンである"@ja ;
-    kgc:source  "The name of the house of Berkeley is a Rasheen."@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/name_of_house_of_Berkeley> ;
+    kgc:source  "The name of the house of Barclay is a Rasheen."@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/name_of_house_of_Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Rasheen> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/042>
     rdf:type    kgc:Situation ;
@@ -565,9 +565,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/045>
     rdf:type    kgc:Situation ;
     kgc:source  "御者とジェインと料理人とバークリとナンシィがラシーンに住んでいる"@ja ;
-    kgc:source  "Coachman and Jane and cooking people and Berkeley and Nancy live in Rasheen."@en ;
+    kgc:source  "Coachman and Jane and cooking people and Barclay and Nancy live in Rasheen."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/coachman> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Jane> ;
@@ -576,16 +576,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/046>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは子どもをもっていない"@ja ;
-    kgc:source  "Berkeley do not have a child."@en ;
+    kgc:source  "Barclay do not have a child."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/child> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/047>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは滅多に客を泊まらせない"@ja ;
-    kgc:source  "Berkeley is rarely not stay overnight guests."@en ;
+    kgc:source  "Barclay is rarely not stay overnight guests."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/CrookedMan/rarely> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/guest> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/048>
@@ -805,9 +805,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/075>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは食堂にいた"@ja ;
-    kgc:source  "Berkeley was in the dining room."@en ;
+    kgc:source  "Barclay was in the dining room."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/dining_room> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/076>
     rdf:type    kgc:Situation ;
@@ -819,18 +819,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/077>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは居間の部屋でナンシィに会った"@ja ;
-    kgc:source  "Berkeley met Nancy in the living room of the room."@en ;
+    kgc:source  "Barclay met Nancy in the living room of the room."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/coachman> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/078>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは居間の部屋で死んだ"@ja ;
-    kgc:source  "Berkeley died in the living room of the room."@en ;
+    kgc:source  "Barclay died in the living room of the room."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/079>
     rdf:type    kgc:Situation ;
@@ -853,15 +853,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/081>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリとナンシィが居間の部屋で言い争っていた"@ja ;
-    kgc:source  "Berkeley and Nancy had been arguing in the living room of the room."@en ;
+    kgc:source  "Barclay and Nancy had been arguing in the living room of the room."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/argue> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/082>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリとナンシィは居間の部屋のドアノックに反応しなかった"@ja ;
-    kgc:source  "Berkeley and Nancy did not respond to knocking on the room door in the living room."@en ;
+    kgc:source  "Barclay and Nancy did not respond to knocking on the room door in the living room."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/knock> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Jane> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/door_of_living_room> ;
@@ -869,7 +869,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/82a>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notRespond> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/082> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/083>
@@ -900,9 +900,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/086>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリとナンシィは言い争っていた"@ja ;
-    kgc:source  "Berkeley and Nancy had been arguing."@en ;
+    kgc:source  "Barclay and Nancy had been arguing."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/argue> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/087>
     rdf:type    kgc:Situation ;
@@ -915,9 +915,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/088>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは叫んだ"@ja ;
-    kgc:source  "Berkeley shouted."@en ;
+    kgc:source  "Barclay shouted."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shout> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/089>
     rdf:type    kgc:Situation ;
     kgc:source  "ナンシィは悲鳴をあげた"@ja ;
@@ -961,9 +961,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/095>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは炉格子の近くで死んでいた"@ja ;
-    kgc:source  "Berkeley was dead in the vicinity of the furnace lattice."@en ;
+    kgc:source  "Barclay was dead in the vicinity of the furnace lattice."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/dead> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:near   <http://kgc.knowledge-graph.jp/data/CrookedMan/furnace_lattice> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/096>
     rdf:type    kgc:Situation ;
@@ -1012,17 +1012,17 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/102>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは鈍器によって殺された"@ja ;
-    kgc:source  "Berkeley was killed by blunt weapons"@en ;
+    kgc:source  "Barclay was killed by blunt weapons"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/CrookedMan/blunt_weapon> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/103>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは後頭部に2インチの裂傷を負っていた"@ja ;
-    kgc:source  "Berkeley had suffered a two-inch laceration to the back of the head."@en ;
+    kgc:source  "Barclay had suffered a two-inch laceration to the back of the head."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/back_of_head_of_Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/back_of_head_of_Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/2-inch_tear> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/104>
     rdf:type    kgc:Situation ;
@@ -1034,17 +1034,17 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/105>
     rdf:type    kgc:Thought ;
     kgc:source  "バークリは木彫りの棍棒で殺された"@ja ;
-    kgc:source  "Berkeley was killed by a wooden carving stick."@en ;
+    kgc:source  "Barclay was killed by a wooden carving stick."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/police> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beKilled> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/CrookedMan/stick> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/106>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは出先で武器を収集していた"@ja ;
-    kgc:source  "Berkeley had collected the weapons on the go."@en ;
+    kgc:source  "Barclay had collected the weapons on the go."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collect> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/weapon> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/107>
     rdf:type    kgc:Situation ;
@@ -1056,11 +1056,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/108>
     rdf:type    kgc:Thought ;
     kgc:source  "木彫りの棍棒はバークリが収集した"@ja ;
-    kgc:source  "Wood carving of the club is Berkeley has collected."@en ;
+    kgc:source  "Wood carving of the club is Barclay has collected."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/police> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collect> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/stick> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/109>
     rdf:type    kgc:Situation ;
     kgc:source  "ジェインと御者と料理番は木彫りの棍棒を知らなかった"@ja ;
@@ -1082,9 +1082,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/111>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリとナンシィは鍵を持っていなかった"@ja ;
-    kgc:source  "Berkeley and Nancy did not have the key."@en ;
+    kgc:source  "Barclay and Nancy did not have the key."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/key_of_living_room> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/112>
@@ -1116,9 +1116,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/115>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリの顔は極度に歪んでいた"@ja ;
-    kgc:source  "Face of Berkeley was distorted in extreme."@en ;
+    kgc:source  "Face of Barclay was distorted in extreme."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/distort> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/face> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/CrookedMan/extreme> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/117>
@@ -1203,10 +1203,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/128>
     rdf:type    kgc:Thought ;
     kgc:source  "バークリとナンシィは居間の部屋の鍵を持ち出せない"@ja ;
-    kgc:source  "Berkeley and Nancy can not take out the room room key."@en ;
+    kgc:source  "Barclay and Nancy can not take out the room room key."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotTakeAway> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/key_of_living_room> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/129>
@@ -1358,7 +1358,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/149>
     rdf:type    kgc:Thought ;
     kgc:source  "男は大通りからナンシィとバークリの言い争いを見ていた"@ja ;
-    kgc:source  "The man was watching the bickering of Nancy and Berkeley from the main street."@en ;
+    kgc:source  "The man was watching the bickering of Nancy and Barclay from the main street."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/man> ;
@@ -1385,33 +1385,33 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/153>
     rdf:type    kgc:Thought ;
     kgc:source  "男はバークリを殺したかもしれない"@ja ;
-    kgc:source  "The man might have killed Berkeley."@en ;
+    kgc:source  "The man might have killed Barclay."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/man> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/155>
     rdf:type    kgc:Thought ;
     kgc:source  "バークリは男に恐怖して卒倒した"@ja ;
-    kgc:source  "Berkeley fainted with fear to the man."@en ;
+    kgc:source  "Barclay fainted with fear to the man."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/faint> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/CrookedMan/155a> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/155a>
     rdf:type    kgc:Thought ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/man> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/156>
     rdf:type    kgc:Thought ;
     kgc:source  "バークリは頭を炉格子に打ったかもしれない"@ja ;
-    kgc:source  "Berkeley might have hit his head on the furnace grid."@en ;
+    kgc:source  "Barclay might have hit his head on the furnace grid."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Barclay> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/furnace_lattice> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/157>
     rdf:type    kgc:Situation ;
@@ -1432,9 +1432,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/159>
     rdf:type    kgc:Situation ;
     kgc:source  "月曜日19時30分に、ナンシィとバークリは仲良かった"@ja ;
-    kgc:source  "Monday 19:30, Nancy and Berkeley was Nakayoka'."@en ;
+    kgc:source  "Monday 19:30, Nancy and Barclay was Nakayoka'."@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/good_friends> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/19_30_on_Monday> ;
     kgc:time  "1887-07-06T19:30:00"^^xsd:dateTime ;
@@ -1442,20 +1442,20 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/160>
     rdf:type    kgc:Situation ;
     kgc:source  "月曜日21時15分に、ナンシィはバークリを非難した"@ja ;
-    kgc:source  "Monday 15 pm 21, Nancy accused Berkeley."@en ;
+    kgc:source  "Monday 15 pm 21, Nancy accused Barclay."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/blame> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/21_15_on_Monday> ;
     kgc:time  "1887-07-06T21:15:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1887-07-06T21:15:00> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/161>
     rdf:type    kgc:Situation ;
     kgc:source  "月曜日19時30分から21時の間に、ナンシィはバークリを嫌いになった"@ja ;
-    kgc:source  "From 19:30 to 21:00 on Monday, Nancy came to hate the Berkeley."@en ;
+    kgc:source  "From 19:30 to 21:00 on Monday, Nancy came to hate the Barclay."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hate> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/From_19_30_to_21_00_on_Monday> ;
     kgc:time  "1887-07-06T19:30:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1887-07-06T19:30:00> ;
@@ -1495,10 +1495,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/165>
     rdf:type    kgc:Thought ;
     kgc:source  "バークリとモリソンは恋愛関係を持たない"@ja ;
-    kgc:source  "Berkeley and Morrison do not have a love relationship."@en ;
+    kgc:source  "Barclay and Morrison do not have a love relationship."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Morrison> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/love_relationship> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/166>
@@ -2079,7 +2079,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/229>
     rdf:type    kgc:Thought ;
     kgc:source  "ヘンリは大通りでナンシィとバークリの言い争いを見た"@ja ;
-    kgc:source  "Henry saw the bickering of Nancy and Berkeley in the main street."@en ;
+    kgc:source  "Henry saw the bickering of Nancy and Barclay in the main street."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
@@ -2378,19 +2378,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/259>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは贖罪のために自殺した"@ja ;
-    kgc:source  "Berkeley was suicide for the sake of penance."@en ;
+    kgc:source  "Barclay was suicide for the sake of penance."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/suicide> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/CrookedMan/atonement> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/260>
     rdf:type    kgc:Statement ;
     kgc:source  "ヘンリはバークリ殺害の動機を持っていた"@ja ;
-    kgc:source  "Henry had a motive for killing Berkeley."@en ;
+    kgc:source  "Henry had a motive for killing Barclay."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/motive_of_killing_Berkeley> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/motive_of_killing_Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/262>
     rdf:type    kgc:Statement ;
     kgc:source  "ヘンリは30年前、ロイヤル・マロウズの第一大隊で一番の美男だった"@ja ;
@@ -2417,10 +2417,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/264>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリとヘンリはロイヤル・マロウズの第一大隊の中隊で軍曹だった"@ja ;
-    kgc:source  "Berkeley and Henry was a sergeant in the company of the first battalion of the Royal Mallows."@en ;
+    kgc:source  "Barclay and Henry was a sergeant in the company of the first battalion of the Royal Mallows."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/sergeant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/CrookedMan/company_of_first_battalion_of_Royal_Mallows> ;
     kgc:time  "1857-07-09T00:00:00"^^xsd:dateTime ;
@@ -2447,10 +2447,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/267>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリとヘンリはナンシィを愛していた"@ja ;
-    kgc:source  "Berkeley and Henry loved the Nancy."@en ;
+    kgc:source  "Barclay and Henry loved the Nancy."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
     kgc:time  "1857-07-09T00:00:00"^^xsd:dateTime ;
@@ -2470,7 +2470,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/269>
     rdf:type    kgc:Statement ;
     kgc:source  "ナンシィとバークリは結婚を決められていた"@ja ;
-    kgc:source  "Nancy and Berkeley had been decided to get married."@en ;
+    kgc:source  "Nancy and Barclay had been decided to get married."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/decide> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/father_of_Nancy> ;
@@ -2482,7 +2482,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/270>
     rdf:type    kgc:Statement ;
     kgc:source  "ヘンリは無鉄砲だった"@ja ;
@@ -2496,20 +2496,20 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/271>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは教養を持っていた"@ja ;
-    kgc:source  "Berkeley had a liberal arts."@en ;
+    kgc:source  "Barclay had a liberal arts."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/well_educated> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:time  "1857-07-09T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1857-07-09> ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/CrookedMan/272> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/272>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは出世できた"@ja ;
-    kgc:source  "Berkeley was able to get ahead."@en ;
+    kgc:source  "Barclay was able to get ahead."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/canGetAhead> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/CrookedMan/271> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/273>
     rdf:type    kgc:Statement ;
@@ -2576,10 +2576,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/279>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリはヘンリに抜け道を教えた"@ja ;
-    kgc:source  "Berkeley taught Henri about the way around."@en ;
+    kgc:source  "Barclay taught Henri about the way around."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/teach> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/bypath> ;
     kgc:time  "1857-07-09T20:00:00"^^xsd:dateTime ;
@@ -2629,10 +2629,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/284>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリがヘンリを逆徒達へ売った"@ja ;
-    kgc:source  "Berkeley was selling Henry to Gyakuto us."@en ;
+    kgc:source  "Barclay was selling Henry to Gyakuto us."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sell> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/rebels> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/285>
@@ -2794,7 +2794,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/302>
     rdf:type    kgc:Statement ;
     kgc:source  "ヘンリはバークリに復讐したくない"@ja ;
-    kgc:source  "Henry does not want to take revenge on Berkeley."@en ;
+    kgc:source  "Henry does not want to take revenge on Barclay."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
@@ -2803,7 +2803,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/revenge> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/303>
     rdf:type    kgc:Statement ;
     kgc:source  "ヘンリはイングランドに帰りたかった"@ja ;
@@ -2884,7 +2884,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/311>
     rdf:type    kgc:Statement ;
     kgc:source  "ナンシィとヘンリはバークリの行為に気づいた"@ja ;
-    kgc:source  "Nancy and Henry noticed the act of Berkeley."@en ;
+    kgc:source  "Nancy and Henry noticed the act of Barclay."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notice> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy> ;
@@ -2902,7 +2902,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/313>
     rdf:type    kgc:Statement ;
     kgc:source  "ヘンリは大通りからナンシィとバークリの言い争いを見た"@ja ;
-    kgc:source  "Henry saw the bickering of Nancy and Berkeley from the main street."@en ;
+    kgc:source  "Henry saw the bickering of Nancy and Barclay from the main street."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
@@ -2929,10 +2929,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/317>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは逆徒にヘンリを売った"@ja ;
-    kgc:source  "Berkeley has sold Henry to Gyakuto."@en ;
+    kgc:source  "Barclay has sold Henry to Gyakuto."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sell> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/rebels> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/317>
     rdf:type    kgc:Situation ;
@@ -2943,7 +2943,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/318>
     rdf:type    kgc:Statement ;
     kgc:source  "ヘンリはナンシィとバークリの言い争いを止めようとした"@ja ;
-    kgc:source  "Henry tried to stop the bickering of Nancy and Berkeley."@en ;
+    kgc:source  "Henry tried to stop the bickering of Nancy and Barclay."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/try> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
@@ -2970,21 +2970,21 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/321>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリはヘンリを見た"@ja ;
-    kgc:source  "Berkeley saw Henry."@en ;
+    kgc:source  "Barclay saw Henry."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/CrookedMan/322> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/322>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは自殺した"@ja ;
-    kgc:source  "Berkeley was suicide."@en ;
+    kgc:source  "Barclay was suicide."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/CrookedMan/324> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/324>
     rdf:type    kgc:Statement ;
     kgc:source  "ナンシィは気絶した"@ja ;
@@ -3250,9 +3250,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/358>
     rdf:type    kgc:Situation ;
     kgc:source  "バークリは卑劣な行いをした"@ja ;
-    kgc:source  "Berkeley was a despicable deeds."@en ;
+    kgc:source  "Barclay was a despicable deeds."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/play_foul> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/359>
     rdf:type    kgc:Situation ;
     kgc:source  "ヘンリは以下を知った"@ja ;
@@ -3263,9 +3263,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/360>
     rdf:type    kgc:Situation ;
     kgc:source  "30年間、バークリは罪悪感に苦しんだ"@ja ;
-    kgc:source  "30 years, Berkeley suffered guilt."@en ;
+    kgc:source  "30 years, Barclay suffered guilt."@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/suffer> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/guilt> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/30_years> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/361>
@@ -3314,10 +3314,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/366>
     rdf:type    kgc:Statement ;
     kgc:source  "バークリは卒中で死んだ"@ja ;
-    kgc:source  "Berkeley died of stroke."@en ;
+    kgc:source  "Barclay died of stroke."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Murphy> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/CrookedMan/apoplexia> ;
     kgc:time  "1887-07-06T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/CrookedMan/1887-07-06> .
@@ -3359,11 +3359,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/371>
     rdf:type    kgc:Statement ;
     kgc:source  "デイヴィドとバークリは同じ種類の罪を犯した"@ja ;
-    kgc:source  "Davide and Berkeley had committed the same type of crime."@en ;
+    kgc:source  "Davide and Barclay had committed the same type of crime."@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sin> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Davide> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/CrookedMan/same_kind_of_sin> .
 <http://kgc.knowledge-graph.jp/data/CrookedMan/372>
     rdf:type    kgc:Statement ;
@@ -3406,13 +3406,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "聖ジョージ組合の設立"@ja;
     rdfs:label     "St. George union"@en.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/motive_of_killing_Berkeley>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "バークリ殺害の動機"@ja;
-    rdfs:label     "motive of killing Berkeley"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/motive>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/killing_Berkeley>.
 <http://kgc.knowledge-graph.jp/data/predicate/notSay>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -3453,27 +3446,22 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "夜に"@ja;
     rdfs:label     "night"@en;
     rdfs:label     "夜"@ja.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Berkeley>
-    rdfs:label     "head of Berkeley"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/head>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/predicate/Say>
     rdfs:label     "Say"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/back_of_head_of_Barclay>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "バークリの後頭部"@ja;
+    rdfs:label     "back of head of Barclay"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Barclay>;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/back>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/head>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/every_night>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "毎晩"@ja;
     rdfs:label     "every night"@en.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/name_of_house_of_Berkeley>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "バークリの家の名前"@ja;
-    rdfs:label     "name of house of Berkeley"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/house_of_Berkeley>;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/name>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/house>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/lodge>
     rdf:type    kgc:Place;
     rdfs:label     "下宿"@ja;
@@ -3594,6 +3582,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/preface>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Samuel>.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/house_of_Barclay>
+    rdfs:label     "house of Barclay"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/house>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Nancy>
     rdf:type    kgc:Person;
     rdfs:label     "ナンシィ"@ja;
@@ -3622,6 +3615,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "取る"@ja;
     rdfs:label     "take"@en.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/motive_of_killing_Barclay>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "バークリ殺害の動機"@ja;
+    rdfs:label     "motive of killing Barclay"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/motive>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/killing_Barclay>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/character>
     rdfs:label     "character"@en;
     rdf:type    kgc:Object.
@@ -4049,6 +4049,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "仇討ちをする"@ja;
     rdfs:label     "revenge"@en.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Barclay>
+    rdfs:label     "head of Barclay"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/head>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/stride_of_beast>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "獣の歩幅"@ja;
@@ -4241,6 +4246,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/progress>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/incedent>.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/character_of_Barclay>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "バークリの性格"@ja;
+    rdfs:label     "character of Barclay"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/character>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Herny>
     rdf:type    kgc:Person;
     rdfs:label     "ヘンリ"@ja;
@@ -4271,15 +4283,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "駐留する"@ja;
     rdfs:label     "station"@en.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/back_of_head_of_Berkeley>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "バークリの後頭部"@ja;
-    rdfs:label     "back of head of Berkeley"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Berkeley>;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/back>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/head>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/predicate/notLike>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4374,13 +4377,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/one>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/the_Irish_regiments>.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/character_of_Berkeley>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "バークリの性格"@ja;
-    rdfs:label     "character of Berkeley"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/character>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/predicate/notObsessive>
     rdf:type    kgc:Property;
     rdfs:label     "執念深くない"@ja;
@@ -4404,9 +4400,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Person;
     rdfs:label     "住人"@ja;
     rdfs:label     "resident"@en.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/killing_Berkeley>
-    rdfs:label     "killing Berkeley"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/over_30_years>
     rdf:type    kgc:AbstractTime;
     rdfs:label     "30年以上"@ja;
@@ -4439,6 +4432,12 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Place;
     rdfs:label     "北部キャンプから0.5マイル"@ja;
     rdfs:label     "0.5 miles from the northern camp"@en.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay>
+    rdf:type    kgc:Person;
+    rdfs:label     "バークリ"@ja;
+    rdfs:label     "Barclay"@en;
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "バークリの顔"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/notice>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4611,6 +4610,15 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/footprint>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/man>.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/name_of_house_of_Barclay>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "バークリの家の名前"@ja;
+    rdfs:label     "name of house of Barclay"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/house_of_Barclay>;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/name>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/house>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/end_of_Darjeeling>
     rdf:type    kgc:Place;
     rdfs:label     "ダージリンの先"@ja;
@@ -4735,13 +4743,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "贖罪のため"@ja;
     rdfs:label     "atonement"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Berkeley>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "頭を"@ja;
-    rdfs:label     "head of Berkeley"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/head>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/predicate/heroic_personallity>
     rdf:type    kgc:Property;
     rdfs:label     "雄々しい性格となよなよした性格"@ja;
@@ -4788,11 +4789,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/CrookedMan/stride>
     rdfs:label     "stride"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/house_of_Berkeley>
-    rdfs:label     "house of Berkeley"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/house>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/common_sense>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "常識"@ja;
@@ -4908,6 +4904,9 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/predicate/ideal>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/middle-aged_couple>.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/killing_Barclay>
+    rdfs:label     "killing Barclay"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/slave>
     rdfs:label     "slave"@en;
     rdf:type    kgc:Object.
@@ -5326,12 +5325,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "炉格子"@ja;
     rdfs:label     "furnace lattice"@en;
     rdfs:label     "炉格子に"@ja.
-<http://kgc.knowledge-graph.jp/data/CrookedMan/Berkeley>
-    rdf:type    kgc:Person;
-    rdfs:label     "バークリ"@ja;
-    rdfs:label     "Berkeley"@en;
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "バークリの顔"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/notCriminal>
     rdf:type    kgc:Property;
     rdfs:label     "犯人ではない"@ja;
@@ -5629,6 +5622,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "連れていく"@ja;
     rdfs:label     "takeAlong"@en.
+<http://kgc.knowledge-graph.jp/data/CrookedMan/head_of_Barclay>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "頭を"@ja;
+    rdfs:label     "head of Barclay"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/CrookedMan/head>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Barclay>.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Watts_Street>
     rdf:type    kgc:Place;
     rdfs:label     "ワット街"@ja;

--- a/CrookedMan.ttl
+++ b/CrookedMan.ttl
@@ -3505,7 +3505,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "小動物"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "歩き回る"@ja;
+    rdfs:label     "徘徊する"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Holmes>
     rdf:type    kgc:Person;
@@ -3646,7 +3646,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "打つ"@ja;
+    rdfs:label     "殴る"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/scare>
     rdf:type    kgc:Action;
@@ -3732,7 +3732,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "bedroom"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/turnOn>
     rdf:type    kgc:Action;
-    rdfs:label     "点灯する"@ja;
+    rdfs:label     "灯す"@ja;
     rdfs:label     "turnOn"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/boy_scout>
     rdf:type    kgc:Property;
@@ -3837,8 +3837,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/bend>
     rdf:type    kgc:Action;
     rdfs:label     "曲げる"@ja;
-    rdfs:label     "bend"@en;
-    rdfs:label     "曲がる"@ja.
+    rdfs:label     "bend"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fear>
     rdf:type    kgc:Action;
     rdfs:label     "恐れる"@ja;
@@ -4048,7 +4047,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "performance"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/revenge>
     rdf:type    kgc:Action;
-    rdfs:label     "やり返す"@ja;
+    rdfs:label     "仇討ちをする"@ja;
     rdfs:label     "revenge"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/stride_of_beast>
     rdf:type    kgc:PhysicalObject;
@@ -4088,7 +4087,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/living_room>.
 <http://kgc.knowledge-graph.jp/data/predicate/happy>
     rdf:type    kgc:Property;
-    rdfs:label     "幸福である"@ja;
+    rdfs:label     "嬉しい"@ja;
     rdfs:label     "happy"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/cook>
     rdf:type    kgc:Person;
@@ -4180,7 +4179,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/daughter_of_ensign_sergeant>
     rdf:type    kgc:Property;
@@ -4191,7 +4190,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/ensign_sergeant>.
 <http://kgc.knowledge-graph.jp/data/predicate/overlook>
     rdf:type    kgc:Action;
-    rdfs:label     "見落とす"@ja;
+    rdfs:label     "見落としている"@ja;
     rdfs:label     "overlook"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/total_length_of_beast>
     rdf:type    kgc:PhysicalObject;
@@ -4258,7 +4257,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "dead"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "依頼する"@ja;
+    rdfs:label     "要求する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/10000_rebels>
     rdf:type    kgc:Person;
@@ -4285,7 +4284,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/like>;
-    rdfs:label     "嫌いである"@ja;
+    rdfs:label     "嫌がる"@ja;
     rdfs:label     "notLike"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/entertainer>
     rdf:type    kgc:Property;
@@ -4462,7 +4461,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "抜け道で"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/please>
     rdf:type    kgc:Action;
-    rdfs:label     "喜ばせる"@ja;
+    rdfs:label     "喜ぶ"@ja;
     rdfs:label     "please"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/nose_of_beast>
     rdf:type    kgc:PhysicalObject;
@@ -4491,7 +4490,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notContradict"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪ねる"@ja;
+    rdfs:label     "訪れる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -4718,7 +4717,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "持たない"@ja;
+    rdfs:label     "not持つ"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/violent>
     rdf:type    kgc:Property;
@@ -4730,7 +4729,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "2-inch tear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "試みる"@ja;
+    rdfs:label     "しようとする"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/atonement>
     rdfs:label     "贖罪のため"@ja;
@@ -4773,7 +4772,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/CrookedMan/Henry>.
 <http://kgc.knowledge-graph.jp/data/predicate/thin>
     rdf:type    kgc:Property;
-    rdfs:label     "細い"@ja;
+    rdfs:label     "薄い"@ja;
     rdfs:label     "thin"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/obsessive>
     rdf:type    kgc:Property;
@@ -4850,7 +4849,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/reveal>
     rdf:type    kgc:Action;
-    rdfs:label     "明らかにする"@ja;
+    rdfs:label     "明かす"@ja;
     rdfs:label     "reveal"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/mongoose>
     rdf:type    kgc:Animal;
@@ -4964,7 +4963,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "kill"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/lead>
     rdf:type    kgc:Action;
-    rdfs:label     "導く"@ja;
+    rdfs:label     "率いる"@ja;
     rdfs:label     "lead"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Watson>
     rdf:type    kgc:Person;
@@ -5042,7 +5041,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "help"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pale>
     rdf:type    kgc:Property;
-    rdfs:label     "真っ青である"@ja;
+    rdfs:label     "青ざめる"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/eccentric>
     rdf:type    kgc:Property;
@@ -5216,7 +5215,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "望まない"@ja;
+    rdfs:label     "したくない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/witness>
     rdfs:label     "witness"@en;
@@ -5402,7 +5401,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上がる"@ja;
+    rdfs:label     "上る"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/die>
     rdf:type    kgc:Action;
@@ -5495,7 +5494,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "参加する"@ja;
+    rdfs:label     "立ち会う"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/161>
     rdfs:label     "161"@en;
@@ -5676,7 +5675,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "20:40 on Monday"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/CrookedMan/Wednesday_night>
     rdf:type    kgc:AbstractTime;

--- a/DancingMen.ttl
+++ b/DancingMen.ttl
@@ -2286,10 +2286,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Bad memories"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/close>
     rdf:type    kgc:Property;
-    rdfs:label     "閉まっている"@ja;
+    rdfs:label     "閉める"@ja;
     rdfs:label     "close"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "閉める"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/need>
     rdf:type    kgc:Action;
     rdfs:label     "必要とする"@ja;
@@ -2358,11 +2357,11 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "know"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/take>
     rdf:type    kgc:Action;
-    rdfs:label     "持つ"@ja;
+    rdfs:label     "取る"@ja;
     rdfs:label     "take"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "匂う"@ja;
+    rdfs:label     "嗅ぐ"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/pencil>
     rdf:type    kgc:PhysicalObject;
@@ -2378,7 +2377,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Glass window"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "打つ"@ja;
+    rdfs:label     "殴る"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Identity>
     rdfs:label     "Identity"@en;
@@ -2403,7 +2402,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Qubit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着ている"@ja;
+    rdfs:label     "着る"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Sentence_H>
     rdfs:label     "Sentence H"@en;
@@ -2523,7 +2522,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "COME"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/getOff>
     rdf:type    kgc:Action;
-    rdfs:label     "下車する"@ja;
+    rdfs:label     "飛び降りる"@ja;
     rdfs:label     "getOff"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/contain>
     rdf:type    kgc:Action;
@@ -2650,7 +2649,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/pale>
     rdf:type    kgc:Property;
-    rdfs:label     "真っ青である"@ja;
+    rdfs:label     "青ざめる"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Maid_room>
     rdf:type    kgc:Place;
@@ -2676,7 +2675,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney>.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受ける"@ja;
+    rdfs:label     "受け取る"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/face_of_Elsie>
     rdf:type    kgc:PhysicalObject;
@@ -2734,7 +2733,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/pullOut>
     rdf:type    kgc:Action;
-    rdfs:label     "引き出す"@ja;
+    rdfs:label     "引きだす"@ja;
     rdfs:label     "pullOut"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Study_room>
     rdf:type    kgc:Place;
@@ -2748,7 +2747,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "short"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/put>
     rdf:type    kgc:Action;
-    rdfs:label     "付ける"@ja;
+    rdfs:label     "置く"@ja;
     rdfs:label     "put"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/follow>
     rdf:type    kgc:Action;
@@ -3067,7 +3066,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/last_year>
     rdf:type    kgc:AbstractTime;
@@ -3160,7 +3159,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "依頼する"@ja;
+    rdfs:label     "要求する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_second_day>
     rdfs:label     "the second day"@en;
@@ -3196,11 +3195,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "留まる"@ja;
+    rdfs:label     "滞在する"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/stand>
     rdf:type    kgc:Action;
-    rdfs:label     "立てかける"@ja;
+    rdfs:label     "立つ"@ja;
     rdfs:label     "stand"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Traces>
     rdfs:label     "Traces"@en;
@@ -3432,7 +3431,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪ねる"@ja;
+    rdfs:label     "訪れる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -3475,7 +3474,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "paper"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/promise>
     rdf:type    kgc:PhysicalObject;
@@ -3483,7 +3482,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "promise"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hurt>
     rdf:type    kgc:Action;
-    rdfs:label     "怪我する"@ja;
+    rdfs:label     "傷つける"@ja;
     rdfs:label     "hurt"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Identity_of_Abe_Slaney>
     rdf:type    kgc:PhysicalObject;

--- a/DancingMen.ttl
+++ b/DancingMen.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/DancingMen/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -205,29 +205,29 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/002>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは文字の意味を知りたい"@ja ;
-    kgc:source  "Qubit wants to know the meaning of Dancing dolls A"@en ;
+    kgc:source  "Cubitt wants to know the meaning of Dancing dolls A"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/02a> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-07-27T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-07-27> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/02a>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Meaning_of_Dancing_dolls_A> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/003>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットの背は高い"@ja ;
-    kgc:source  "Qubit is tall"@en ;
+    kgc:source  "Cubitt is tall"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/tall> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/004>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは紳士である"@ja ;
-    kgc:source  "Qubit is a gentleman"@en ;
+    kgc:source  "Cubitt is a gentleman"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/gentle> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/005>
     rdf:type    kgc:Situation ;
     kgc:source  "人形が紙の上で踊っている"@ja ;
@@ -259,20 +259,20 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/009>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは昨年，結婚した"@ja ;
-    kgc:source  "Qubit was married last year"@en ;
+    kgc:source  "Cubitt was married last year"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/marry> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/last_year> ;
     kgc:time  "1897-07-01T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1897-07-01> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/010>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットはノーフォーク州の旧家である"@ja ;
-    kgc:source  "Qubit is from an old family in Norfolk"@en ;
+    kgc:source  "Cubitt is from an old family in Norfolk"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/old_family> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DancingMen/Norfolk> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/011>
     rdf:type    kgc:Situation ;
     kgc:source  "エルシィはアメリカ人である"@ja ;
@@ -282,41 +282,41 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/013>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットとエルシィはノーフォーク州に住んでいる"@ja ;
-    kgc:source  "Qubit and Elsie live in Norfolk"@en ;
+    kgc:source  "Cubitt and Elsie live in Norfolk"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DancingMen/Norfolk> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/014>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットはエルシィの過去を知らない"@ja ;
-    kgc:source  "Qubit is unware of Elsie's past"@en ;
+    kgc:source  "Cubitt is unware of Elsie's past"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notKnow> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Past_of_Elsie> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/015>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは以下を言った"@ja ;
-    kgc:source  "Qubit says the followings"@en ;
+    kgc:source  "Cubitt says the followings"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/016> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/017> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/018> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-07-27T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-07-27> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/016>
     rdf:type    kgc:Statement ;
     kgc:source  "エルシィは真面目である"@ja ;
     kgc:source  "Elsie is serious"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/serious> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/017>
     rdf:type    kgc:Statement ;
     kgc:source  "エルシィは嫌な思い出を持つ"@ja ;
     kgc:source  "Elsie has bad memories"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Bad_memories> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> .
@@ -324,16 +324,16 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "エルシィは思い出を言わない"@ja ;
     kgc:source  "Elsie does not share the memories"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notSay> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Past_of_Elsie> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/019>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは6月の末に災いの兆しを見た"@ja ;
-    kgc:source  "Qubit sees signs of the evil at the end of June"@en ;
+    kgc:source  "Cubitt sees signs of the evil at the end of June"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Signs_of_evil> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/end_of_June> ;
     kgc:time  "1898-06-30T00:00:00"^^xsd:dateTime ;
@@ -388,40 +388,40 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/026>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは約束に従った"@ja ;
-    kgc:source  "Qubit follows the promise"@en ;
+    kgc:source  "Cubitt follows the promise"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/follow> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/promise> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/027> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/027>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは黙っている"@ja ;
-    kgc:source  "Qubit shuts up"@en ;
+    kgc:source  "Cubitt shuts up"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shutUp> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/028>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは先週の火曜日、ガラス窓に踊る人形を見た"@ja ;
-    kgc:source  "Qubit saw the Dancing dolls in a glass window last Tuesday"@en ;
+    kgc:source  "Cubitt saw the Dancing dolls in a glass window last Tuesday"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DancingMen/Glass_window> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/last_Tuesday> ;
     kgc:time  "1898-07-19T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-07-19> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/029>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは以下を思った"@ja ;
-    kgc:source  "Qubit thinks of the following"@en ;
+    kgc:source  "Cubitt thinks of the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/030> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/030>
     rdf:type    kgc:Thought ;
     kgc:source  "馬番の少年が踊る人形を描いた"@ja ;
     kgc:source  "Horse boy draws the Dancing dolls"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/draw> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Horse_boy> .
@@ -452,10 +452,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/034>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは昨日の朝、庭の日時計の上に踊る人形を見た"@ja ;
-    kgc:source  "Qubit saw the Dancing dolls on a sundial in the garden yesterday morning"@en ;
+    kgc:source  "Cubitt saw the Dancing dolls on a sundial in the garden yesterday morning"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/DancingMen/sundial_of_garden> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/yesterday_morning> ;
     kgc:time  "1898-07-26T08:00:00"^^xsd:dateTime ;
@@ -463,11 +463,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/035>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットはエルシィに踊る人形を見せた"@ja ;
-    kgc:source  "Qubit shows Elsie the Dancing dolls"@en ;
+    kgc:source  "Cubitt shows Elsie the Dancing dolls"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/show> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/036> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/036>
     rdf:type    kgc:Situation ;
@@ -478,30 +478,30 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/037>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットはホームズに手紙を書いた"@ja ;
-    kgc:source  "Qubit sends the Letter X to Holmes"@en ;
+    kgc:source  "Cubitt sends the Letter X to Holmes"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Letter_X> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:at_the_same_time   <http://kgc.knowledge-graph.jp/data/DancingMen/038> ;
     kgc:time  "1898-07-26T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-07-26> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/038>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは踊る人形をホームズに送った"@ja ;
-    kgc:source  "Qubit sends a dancing doll to Holmes"@en ;
+    kgc:source  "Cubitt sends a dancing doll to Holmes"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/039>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットはエルシィに過去の話を強要しなかった"@ja ;
-    kgc:source  "Qubit does not force Elsie to discuss the past"@en ;
+    kgc:source  "Cubitt does not force Elsie to discuss the past"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notForce> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Past_of_Elsie> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/040>
     rdf:type    kgc:Situation ;
     kgc:source  "新顔が近所で現れた"@ja ;
@@ -512,26 +512,26 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/041>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはキュービットに以下を頼んだ"@ja ;
-    kgc:source  "Holmes asks Qubit the following"@en ;
+    kgc:source  "Holmes asks Cubitt the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/request> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/042> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/042>
     rdf:type    kgc:Statement ;
     kgc:source  "キュービットは踊る人形を写し取る"@ja ;
-    kgc:source  "Qubit copies the Dancing dolls"@en ;
+    kgc:source  "Cubitt copies the Dancing dolls"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/copy> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/043>
     rdf:type    kgc:Situation ;
     kgc:source  "今朝，ホームズはキュービットから電報を受け取った"@ja ;
-    kgc:source  "Holmes receives a telegram from Qubit this morning"@en ;
+    kgc:source  "Holmes receives a telegram from Cubitt this morning"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/telegram> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/this_morning> ;
     kgc:time  "1898-08-10T08:00:00"^^xsd:dateTime ;
@@ -540,9 +540,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/044>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは駅からやってきた"@ja ;
-    kgc:source  "Qubit comes from the station"@en ;
+    kgc:source  "Cubitt comes from the station"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DancingMen/station> ;
     kgc:time  "1898-08-10T14:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-10T14:00> ;
@@ -550,22 +550,22 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/045>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットはホームズを訪ねた"@ja ;
-    kgc:source  "Qubit visits Holmes"@en ;
+    kgc:source  "Cubitt visits Holmes"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/visit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:time  "1898-08-10T14:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-10T14:00> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/046>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは翌朝に踊る人形Bを見た"@ja ;
-    kgc:source  "Qubit sees the Dancing dolls B the next morning"@en ;
+    kgc:source  "Cubitt sees the Dancing dolls B the next morning"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_B> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/next_morning> ;
     kgc:time  "1898-07-28T08:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-07-28T08:00> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/047>
     rdf:type    kgc:Situation ;
     kgc:source  "踊る人形Bは物置の扉の上にチョークで描かれていた"@ja ;
@@ -606,9 +606,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/052>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは午前2時頃、窓際に腰かけていた"@ja ;
-    kgc:source  "Qubit sits by the window around 2 am"@en ;
+    kgc:source  "Cubitt sits by the window around 2 am"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/sit> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DancingMen/window> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/2_00> ;
     kgc:time  "1898-08-06T02:00:00"^^xsd:dateTime ;
@@ -633,19 +633,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/055>
     rdf:type    kgc:Situation ;
     kgc:source  "エルシィはキュービットに以下を言った"@ja ;
-    kgc:source  "Elsie says the following to Qubit"@en ;
+    kgc:source  "Elsie says the following to Cubitt"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/056> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/056>
     rdf:type    kgc:Statement ;
     kgc:source  "キュービットは寝室に帰る"@ja ;
-    kgc:source  "Qubit returns to the bedroom"@en ;
+    kgc:source  "Cubitt returns to the bedroom"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DancingMen/Bedroom> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/057>
     rdf:type    kgc:Situation ;
     kgc:source  "物置の影で何かが動いた"@ja ;
@@ -656,18 +656,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/058>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは拳銃を持った"@ja ;
-    kgc:source  "Qubit holds a handgun"@en ;
+    kgc:source  "Cubitt holds a handgun"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/take> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Handgun> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/059> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/059>
     rdf:type    kgc:Situation ;
     kgc:source  "エルシィはキュービットを止めた"@ja ;
-    kgc:source  "Elsie stops Qubit"@en ;
+    kgc:source  "Elsie stops Cubitt"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stop> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/061>
     rdf:type    kgc:Situation ;
     kgc:source  "翌朝、物置の扉の上に踊る人形Dが描かれていた"@ja ;
@@ -702,41 +702,41 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/063>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは以下を言った"@ja ;
-    kgc:source  "Qubit says the followng"@en ;
+    kgc:source  "Cubitt says the followng"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/064> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-08-10T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-10> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/064>
     rdf:type    kgc:Statement ;
     kgc:source  "エルシィは守るためにキュービットを抑えた"@ja ;
-    kgc:source  "Elsie stops Qubits to protect himself"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:source  "Elsie stops Cubitts to protect himself"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stop> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/DancingMen/64a> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/64a>
     rdf:type    kgc:Statement ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/protect> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/065>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはキュービットに以下を言った"@ja ;
-    kgc:source  "Holmes says the following to Qubit"@en ;
+    kgc:source  "Holmes says the following to Cubitt"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/066> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/066>
     rdf:type    kgc:Statement ;
     kgc:source  "キュービットは今日中に帰宅する"@ja ;
-    kgc:source  "Qubit returns home today"@en ;
+    kgc:source  "Cubitt returns home today"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DancingMen/home> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/today> ;
     kgc:time  "1898-08-10T00:00:00"^^xsd:dateTime ;
@@ -776,10 +776,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/071>
     rdf:type    kgc:Situation ;
     kgc:source  "2日目の夕べ、ホームズはキュービットから手紙を受け取った"@ja ;
-    kgc:source  "On the second evening, Holmes receives the Letter Y from Qubit"@en ;
+    kgc:source  "On the second evening, Holmes receives the Letter Y from Cubitt"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
-    kgc:from   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:from   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Letter_Y> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/evening_of_the_second_day> ;
     kgc:time  "1898-08-12T18:00:00"^^xsd:dateTime ;
@@ -833,11 +833,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/078>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットとエルシィは撃たれた"@ja ;
-    kgc:source  "Qubit and Elsie are shot"@en ;
+    kgc:source  "Cubitt and Elsie are shot"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-08-13T03:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:00> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/079>
@@ -852,11 +852,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/080>
     rdf:type    kgc:Statement ;
     kgc:source  "エルシィがキュービットを撃った"@ja ;
-    kgc:source  "Elsie shot Qubit"@en ;
+    kgc:source  "Elsie shot Cubitt"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Maid> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-08-13T03:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:00> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/081> .
@@ -924,7 +924,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/091>
     rdf:type    kgc:Statement ;
     kgc:source  "キュービットは心臓を撃ち抜かれている"@ja ;
-    kgc:source  "Qubit is shot through the heart"@en ;
+    kgc:source  "Cubitt is shot through the heart"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Local_doctor> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/090>
     rdf:type    kgc:Situation ;
@@ -932,15 +932,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/091>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/heart_of_Qubit> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/heart_of_Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/092>
     rdf:type    kgc:Situation ;
     kgc:source  "拳銃はキュービットとエルシィの間に落ちていた"@ja ;
-    kgc:source  "The handgun falls between Qubit and Elsie"@en ;
+    kgc:source  "The handgun falls between Cubitt and Elsie"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Handgun> ;
     kgc:middleOf   <http://kgc.knowledge-graph.jp/data/DancingMen/Elsie> ;
-    kgc:middleOf   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> .
+    kgc:middleOf   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/093>
     rdf:type    kgc:Situation ;
     kgc:source  "地元の医者は4時に訪れた"@ja ;
@@ -1018,18 +1018,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/103>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットが部屋の真ん中に倒れていた"@ja ;
-    kgc:source  "Qubit fell in the middle of the room"@en ;
+    kgc:source  "Cubitt fell in the middle of the room"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fall> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:middleOf   <http://kgc.knowledge-graph.jp/data/DancingMen/room> ;
     kgc:time  "1898-08-13T03:02:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:02> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/104>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは死んでいた"@ja ;
-    kgc:source  "Qubit was dead"@en ;
+    kgc:source  "Cubitt was dead"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/dead> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-08-13T03:02:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:02> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/105>
@@ -1098,10 +1098,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/112>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは寝間着だった"@ja ;
-    kgc:source  "Qubit wore nightwear"@en ;
+    kgc:source  "Cubitt wore nightwear"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wear> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-08-13T03:02:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:02> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/113>
@@ -1174,31 +1174,31 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/121>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは部屋を横切るように倒れていた"@ja ;
-    kgc:source  "Qubit is falling across the study room"@en ;
+    kgc:source  "Cubitt is falling across the study room"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fall> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:middleOf   <http://kgc.knowledge-graph.jp/data/DancingMen/study_room> ;
     kgc:time  "1898-08-13T11:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T11:00> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/122>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットの着衣は乱れていた"@ja ;
-    kgc:source  "Qubit's clothes were disordered"@en ;
+    kgc:source  "Cubitt's clothes were disordered"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/disturb> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear_of_Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear_of_Cubitt> ;
     kgc:time  "1898-08-13T11:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T11:00> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/123>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは正面から心臓を撃たれた"@ja ;
-    kgc:source  "Qubit was shot in the heart from the front"@en .
+    kgc:source  "Cubitt was shot in the heart from the front"@en .
 <http://kgc.knowledge-graph.jp/data/DancingMen/122>
     rdf:type    kgc:Situation ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Criminal> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/123>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/heart_of_Qubit> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/heart_of_Cubitt> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DancingMen/front> ;
     kgc:time  "1898-08-13T03:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:00> .
@@ -1267,9 +1267,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/133>
     rdf:type    kgc:Situation ;
     kgc:source  "キュービットは第三者を撃った"@ja ;
-    kgc:source  "Qubit shot a third party"@en ;
+    kgc:source  "Cubitt shot a third party"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Third_person> ;
     kgc:time  "1898-08-13T03:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:00> ;
@@ -1679,20 +1679,20 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/186>
     rdf:type    kgc:Statement ;
     kgc:source  "エイブ・スレイニはキュービット宅に来る"@ja ;
-    kgc:source  "Abe_Slaney comes to Qubit's home"@en ;
+    kgc:source  "Abe_Slaney comes to Cubitt's home"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/DancingMen/home_of_Qubit> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/DancingMen/home_of_Cubitt> ;
     kgc:time  "1898-08-13T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T12:00> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/188>
     rdf:type    kgc:Situation ;
     kgc:source  "エイブ・スレイニはキュービット宅に入った"@ja ;
-    kgc:source  "Abe_Slaney enters Qubit's home"@en ;
+    kgc:source  "Abe_Slaney enters Cubitt's home"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enter> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/DancingMen/home_of_Qubit> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/DancingMen/home_of_Cubitt> ;
     kgc:time  "1898-08-13T12:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T12:00> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/189>
@@ -1754,11 +1754,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/192>
     rdf:type    kgc:Statement ;
     kgc:source  "エイブ・スレイニはキュービットを撃った"@ja ;
-    kgc:source  "Ave Sureini shot Qubit"@en ;
+    kgc:source  "Ave Sureini shot Cubitt"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:time  "1898-08-13T03:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DancingMen/1898-08-13T03:00> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/194>
@@ -1788,11 +1788,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/199>
     rdf:type    kgc:Statement ;
     kgc:source  "エイブ・スレイニはキュービットを殺した"@ja ;
-    kgc:source  "Abe_Slaney killed Qubit"@en ;
+    kgc:source  "Abe_Slaney killed Cubitt"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/200> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/200>
     rdf:type    kgc:Statement ;
@@ -1971,37 +1971,37 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/222>
     rdf:type    kgc:Statement ;
     kgc:source  "キュービットはエイブ・スレイニを撃った"@ja ;
-    kgc:source  "Qubit shot Abe_Slaney"@en ;
+    kgc:source  "Cubitt shot Abe_Slaney"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/224> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/224>
     rdf:type    kgc:Statement ;
     kgc:source  "キュービットの弾はエイブ・スレイニを外れた"@ja ;
-    kgc:source  "Qubit's bullet goes out of Abe_Slaney"@en ;
+    kgc:source  "Cubitt's bullet goes out of Abe_Slaney"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHit> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/bullet_of_Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/bullet_of_Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/225> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/225>
     rdf:type    kgc:Statement ;
     kgc:source  "エイブ・スレイニはキュービットを撃った"@ja ;
-    kgc:source  "Abe_Slaney shot Qubit"@en ;
+    kgc:source  "Abe_Slaney shot Cubitt"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/226> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/226>
     rdf:type    kgc:Statement ;
     kgc:source  "キュービットは倒れた"@ja ;
-    kgc:source  "Qubit fell"@en ;
+    kgc:source  "Cubitt fell"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DancingMen/Abe_Slaney> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fall> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DancingMen/227> .
 <http://kgc.knowledge-graph.jp/data/DancingMen/227>
     rdf:type    kgc:Statement ;
@@ -2167,13 +2167,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/tube>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/bullet>.
-<http://kgc.knowledge-graph.jp/data/DancingMen/heart_of_Qubit>
+<http://kgc.knowledge-graph.jp/data/DancingMen/nightwear_of_Cubitt>
     rdf:type    kgc:PhysicalObject;
-    rdfs:label     "キュービットの心臓"@ja;
-    rdfs:label     "heart of Qubit"@en;
+    rdfs:label     "キュービットの着衣"@ja;
+    rdfs:label     "nightwear of Cubitt"@en;
     rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/heart>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>.
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Door_of_study_room>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "書斎の扉"@ja;
@@ -2206,6 +2206,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Place;
     rdfs:label     "ノリッジ"@ja;
     rdfs:label     "Norwich"@en.
+<http://kgc.knowledge-graph.jp/data/DancingMen/home_of_Cubitt>
+    rdf:type    kgc:Place;
+    rdfs:label     "キュービット宅"@ja;
+    rdfs:label     "home of Cubitt"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/home>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Someone>
     rdf:type    kgc:Person;
     rdfs:label     "何者か"@ja;
@@ -2258,6 +2265,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Place;
     rdfs:label     "4番目"@ja;
     rdfs:label     "the fourth position"@en.
+<http://kgc.knowledge-graph.jp/data/DancingMen/heart_of_Cubitt>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "キュービットの心臓"@ja;
+    rdfs:label     "heart of Cubitt"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/heart>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Signs_of_evil>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "災いの兆し"@ja;
@@ -2293,13 +2307,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "必要とする"@ja;
     rdfs:label     "need"@en.
-<http://kgc.knowledge-graph.jp/data/DancingMen/home_of_Qubit>
-    rdf:type    kgc:Place;
-    rdfs:label     "キュービット宅"@ja;
-    rdfs:label     "home of Qubit"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/home>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>.
 <http://kgc.knowledge-graph.jp/data/predicate/notSend>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -2396,10 +2403,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DancingMen/the_final_position>
     rdfs:label     "the final position"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>
-    rdf:type    kgc:Person;
-    rdfs:label     "キュービット"@ja;
-    rdfs:label     "Qubit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
     rdfs:label     "着る"@ja;
@@ -2465,13 +2468,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "普段着"@ja;
     rdfs:label     "casual wear"@en.
-<http://kgc.knowledge-graph.jp/data/DancingMen/nightwear_of_Qubit>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "キュービットの着衣"@ja;
-    rdfs:label     "nightwear of Qubit"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/nightwear>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/banknote>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "紙幣"@ja;
@@ -3272,6 +3268,13 @@ kgc:Thought rdf:type owl:Class ;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/force>;
     rdfs:label     "強要しない"@ja;
     rdfs:label     "notForce"@en.
+<http://kgc.knowledge-graph.jp/data/DancingMen/bullet_of_Cubitt>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "キュービットの弾"@ja;
+    rdfs:label     "bullet of Cubitt"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/bullet>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/One_minute_after_gunfire>
     rdfs:label     "銃声の1分後"@ja;
     rdfs:label     "One minute after gunfire"@en;
@@ -3296,13 +3299,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "踊る人形f"@ja;
     rdfs:label     "Dancing dolls F"@en;
     rdfs:label     "踊る人形F"@ja.
-<http://kgc.knowledge-graph.jp/data/DancingMen/bullet_of_Qubit>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "キュービットの弾"@ja;
-    rdfs:label     "bullet of Qubit"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DancingMen/bullet>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DancingMen/Qubit>.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Dancing_dolls_E>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "踊る人形E"@ja;
@@ -3384,6 +3380,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "暗号"@ja;
     rdfs:label     "cipher"@en.
+<http://kgc.knowledge-graph.jp/data/DancingMen/Cubitt>
+    rdf:type    kgc:Person;
+    rdfs:label     "キュービット"@ja;
+    rdfs:label     "Cubitt"@en.
 <http://kgc.knowledge-graph.jp/data/DancingMen/Neighborhood>
     rdf:type    kgc:Place;
     rdfs:label     "近所"@ja;

--- a/DevilsFoot.ttl
+++ b/DevilsFoot.ttl
@@ -4766,7 +4766,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/predicate/bring>
     rdf:type    kgc:Action;
-    rdfs:label     "連れていく"@ja;
+    rdfs:label     "持っていく"@ja;
     rdfs:label     "bring"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/living_room>
     rdfs:label     "居間"@ja;
@@ -4877,7 +4877,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/predicate/Mortimer>.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "歩き回る"@ja;
+    rdfs:label     "徘徊する"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/laws>
     rdfs:label     "laws"@en;
@@ -4968,8 +4968,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "閉める"@ja;
     rdfs:label     "close"@en;
-    rdf:type    kgc:Property;
-    rdfs:label     "閉まっている"@ja.
+    rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Crazy>
     rdfs:label     "狂気"@ja;
     rdfs:label     "Crazy"@en;
@@ -5062,10 +5061,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "carry"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/suicide>
     rdf:type    kgc:Property;
-    rdfs:label     "自殺である"@ja;
+    rdfs:label     "自殺する"@ja;
     rdfs:label     "suicide"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "自殺する"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/believe>
     rdf:type    kgc:Action;
     rdfs:label     "信じる"@ja;
@@ -5150,14 +5148,14 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/create>
     rdf:type    kgc:Action;
-    rdfs:label     "創造する"@ja;
+    rdfs:label     "練る"@ja;
     rdfs:label     "create"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/note>
     rdfs:label     "note"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/turnOn>
     rdf:type    kgc:Action;
-    rdfs:label     "点灯する"@ja;
+    rdfs:label     "灯す"@ja;
     rdfs:label     "turnOn"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/sample>
     rdfs:label     "sample"@en;
@@ -5310,7 +5308,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/1897>.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受ける"@ja;
+    rdfs:label     "受け取る"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Four_men>
     rdfs:label     "4人の男"@ja;
@@ -5476,7 +5474,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考慮する"@ja;
+    rdfs:label     "考える"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/fireplace>
     rdfs:label     "暖炉"@ja;
@@ -5510,7 +5508,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/crush>
     rdf:type    kgc:Action;
-    rdfs:label     "砕く"@ja;
+    rdfs:label     "粉砕する"@ja;
     rdfs:label     "crush"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notGenerous>
     rdf:type    kgc:Action;
@@ -5561,7 +5559,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "gravel"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/separate>
     rdf:type    kgc:Action;
-    rdfs:label     "別れる"@ja;
+    rdfs:label     "分かれる"@ja;
     rdfs:label     "separate"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/In_the_room>
     rdfs:label     "部屋の中"@ja;
@@ -5700,12 +5698,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/enter>
     rdf:type    kgc:Action;
     rdfs:label     "入る"@ja;
-    rdfs:label     "enter"@en;
-    rdfs:label     "入ってくる"@ja;
-    rdfs:label     "行く"@ja.
+    rdfs:label     "enter"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/hall>
     rdfs:label     "広間から"@ja;
@@ -5862,7 +5858,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "依頼する"@ja;
+    rdfs:label     "要求する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Behind_you>
     rdfs:label     "後ろ手で"@ja;
@@ -5936,7 +5932,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/beLocked>
     rdf:type    kgc:Action;
-    rdfs:label     "施錠される"@ja;
+    rdfs:label     "鍵がかかっている"@ja;
     rdfs:label     "beLocked"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Servant>
     rdfs:label     "使用人"@ja;
@@ -6014,7 +6010,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/rant>
     rdf:type    kgc:Action;
-    rdfs:label     "わめく"@ja;
+    rdfs:label     "叫ぶ"@ja;
     rdfs:label     "rant"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sufficient_funds>
     rdfs:label     "十分な資金"@ja;
@@ -6089,7 +6085,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Many years ago"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪ねる"@ja;
+    rdfs:label     "訪れる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -6137,7 +6133,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/left>
     rdf:type    kgc:Action;
-    rdfs:label     "出る"@ja;
+    rdfs:label     "出ていく"@ja;
     rdfs:label     "left"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/takeWalk>
     rdf:type    kgc:Action;
@@ -6146,8 +6142,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/pass>
     rdf:type    kgc:Action;
     rdfs:label     "経過している"@ja;
-    rdfs:label     "pass"@en;
-    rdfs:label     "すれ違う"@ja.
+    rdfs:label     "pass"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes>
     rdf:type    kgc:Person;
     rdfs:label     "ホームズ"@ja;
@@ -6410,7 +6405,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "持たない"@ja;
+    rdfs:label     "not持つ"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/retire>
     rdf:type    kgc:Action;
@@ -6453,7 +6448,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goDown>
     rdf:type    kgc:Action;
-    rdfs:label     "下りる"@ja;
+    rdfs:label     "降りる"@ja;
     rdfs:label     "goDown"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/10_15_past>
     rdf:type    kgc:AbstractTime;
@@ -6470,7 +6465,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/thin>
     rdf:type    kgc:Property;
-    rdfs:label     "細い"@ja;
+    rdfs:label     "薄い"@ja;
     rdfs:label     "thin"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/business>
     rdfs:label     "事業"@ja;
@@ -6505,7 +6500,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "think"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "匂う"@ja;
+    rdfs:label     "嗅ぐ"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/know>
     rdf:type    kgc:Action;
@@ -6528,10 +6523,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "sing"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着ている"@ja;
+    rdfs:label     "着る"@ja;
     rdfs:label     "wear"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "着る"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotSleep>
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
@@ -6679,7 +6673,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "cook"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/contain>
     rdf:type    kgc:Action;
-    rdfs:label     "存在する"@ja;
+    rdfs:label     "含む"@ja;
     rdfs:label     "contain"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Motivation>
     rdfs:label     "Motivation"@en;
@@ -6777,7 +6771,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Middle-aged man"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pale>
     rdf:type    kgc:Property;
-    rdfs:label     "真っ青である"@ja;
+    rdfs:label     "青ざめる"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Early_spring>
     rdfs:label     "Early spring"@en;
@@ -6787,7 +6781,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/silence>
     rdf:type    kgc:Action;
-    rdfs:label     "沈黙する"@ja;
+    rdfs:label     "黙る"@ja;
     rdfs:label     "silence"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/remember>
     rdf:type    kgc:Action;
@@ -6798,7 +6792,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/comeDown>
     rdf:type    kgc:Action;
-    rdfs:label     "降りる"@ja;
+    rdfs:label     "下りてくる"@ja;
     rdfs:label     "comeDown"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Outside_of_window>
     rdfs:label     "窓の外"@ja;
@@ -6996,7 +6990,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/the_hotel_Standale_stay_at_Plymouth>.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "集中している"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/property>
     rdfs:label     "財産"@ja;
@@ -7007,7 +7001,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/lookAround>
     rdf:type    kgc:Action;
-    rdfs:label     "見まわす"@ja;
+    rdfs:label     "ながめ回す"@ja;
     rdfs:label     "lookAround"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Emergency_message>
     rdfs:label     "緊急メッセージ"@ja;
@@ -7044,7 +7038,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/want>;
-    rdfs:label     "望まない"@ja;
+    rdfs:label     "したくない"@ja;
     rdfs:label     "notWant"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/After_death>
     rdfs:label     "After death"@en;
@@ -7077,9 +7071,8 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Person.
 <http://kgc.knowledge-graph.jp/data/predicate/burn>
     rdf:type    kgc:Action;
-    rdfs:label     "燃える"@ja;
-    rdfs:label     "burn"@en;
-    rdfs:label     "燃やされる"@ja.
+    rdfs:label     "燃やされる"@ja;
+    rdfs:label     "burn"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Toridnik_Wasa>
     rdfs:label     "トリダニック・ワーサ"@ja;
     rdfs:label     "Toridnik Wasa"@en;
@@ -7093,8 +7086,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/arrive>
     rdf:type    kgc:Action;
     rdfs:label     "到着する"@ja;
-    rdfs:label     "arrive"@en;
-    rdfs:label     "来る"@ja.
+    rdfs:label     "arrive"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottages>
     rdfs:label     "cottages"@en;
     rdf:type    kgc:Object.
@@ -7169,9 +7161,8 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda>.
 <http://kgc.knowledge-graph.jp/data/predicate/walk>
     rdf:type    kgc:Action;
-    rdfs:label     "散歩する"@ja;
-    rdfs:label     "walk"@en;
-    rdfs:label     "歩く"@ja.
+    rdfs:label     "歩く"@ja;
+    rdfs:label     "walk"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/garden_of_pastoral_hall>
     rdfs:label     "牧師館の庭"@ja;
     rdfs:label     "garden of pastoral hall"@en;
@@ -7290,7 +7281,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/George>.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上がる"@ja;
+    rdfs:label     "上る"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/die>
     rdf:type    kgc:Action;
@@ -7426,7 +7417,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "留まる"@ja;
+    rdfs:label     "滞在する"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/opinion_of_Brenda>
     rdfs:label     "ブレンダの意見"@ja;
@@ -7506,8 +7497,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
     rdfs:label     "開く"@ja;
-    rdfs:label     "open"@en;
-    rdfs:label     "開ける"@ja.
+    rdfs:label     "open"@en.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Exterior>
     rdfs:label     "Exterior"@en;
     rdf:type    kgc:Object.
@@ -7699,7 +7689,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notHear>
     rdf:type    kgc:Action;

--- a/DevilsFoot.ttl
+++ b/DevilsFoot.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -2225,59 +2225,59 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/210>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールがポルデュー湾のコテージにいた"@ja ;
-    kgc:source  "Standale was in a cottage in the Pordeux Bay"@en ;
+    kgc:source  "Sterndale was in a cottage in the Pordeux Bay"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Pordeux_Bay> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/215> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/211>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールはライオンハンターである"@ja ;
-    kgc:source  "Standale is a lion hunter"@en ;
+    kgc:source  "Sterndale is a lion hunter"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Lion_hunter> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/212>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは探険家である"@ja ;
-    kgc:source  "Standale is an explorer"@en ;
+    kgc:source  "Sterndale is an explorer"@en ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Explorer> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/213>
     rdf:type    kgc:Situation ;
     kgc:source  "コーンワルにおいて、スタンデールは隣人とつきあいを持たない"@ja ;
-    kgc:source  "In Cornwall, Standale has no contact with his neighbors"@en ;
+    kgc:source  "In Cornwall, Sterndale has no contact with his neighbors"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/neighbor> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Get_along> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cornwall> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/213a>
     rdf:type    kgc:Situation ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/live> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cornwall> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/214>
     rdf:type    kgc:Situation ;
     kgc:source  "コーンワルにおいて、スタンデールは孤立している"@ja ;
-    kgc:source  "Standale is isolated in Cornwall"@en ;
+    kgc:source  "Sterndale is isolated in Cornwall"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/isolate> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cornwall> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/215>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールがホームズに進展を聞いた"@ja ;
-    kgc:source  "Standale heard Holmes progress"@en ;
+    kgc:source  "Sterndale heard Holmes progress"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Progress> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/216> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/216>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは以下を言った"@ja ;
-    kgc:source  "Standale said the following"@en ;
+    kgc:source  "Sterndale said the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/217> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/218> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/219> ;
@@ -2292,73 +2292,73 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/217>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは地方警察を信用しない"@ja ;
-    kgc:source  "Standale does not trust local police"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale does not trust local police"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notTrust> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Local_police> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/218>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはトリジェニス家に何度も滞在した"@ja ;
-    kgc:source  "Standale stayed several times with the Trigemnis family"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale stayed several times with the Trigemnis family"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stay> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Many_times> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/House_of_Trigenis> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/219>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはトリジェニス家と親しくなった"@ja ;
-    kgc:source  "Standale was close to the Trigenis family"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale was close to the Trigenis family"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/closeTo> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/House_of_Trigenis> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/DevilsFoot/220> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/220>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはショックを受けた"@ja ;
-    kgc:source  "Standale was shocked"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale was shocked"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/shock> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DevilsFoot/221> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/221>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはオーウェンとジョージとブレンダの運命を聞いた"@ja ;
-    kgc:source  "Standale heard the fate of Owen, George, and Brenda"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale heard the fate of Owen, George, and Brenda"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/fate_of_Owen> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/fate_of_George> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/fate_of_Brenda> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/222>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはアフリカに向かっていた"@ja ;
-    kgc:source  "Standale was headed for Africa"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale was headed for Africa"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Africa> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/223> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/223>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはプリマスまで着いた"@ja ;
-    kgc:source  "Standale has arrived to Plymouth"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale has arrived to Plymouth"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/arrive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Plymouth> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/224> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/224>
     rdf:type    kgc:Statement ;
     kgc:source  "今朝、スタンデールはニュースを聞いた"@ja ;
-    kgc:source  "This morning, Standale heard the news"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "This morning, Sterndale heard the news"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/news> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/this_morning> ;
     kgc:time  "1896-03-16T09:00:00"^^xsd:dateTime ;
@@ -2367,52 +2367,52 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/225>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは帰ってきた"@ja ;
-    kgc:source  "Standale returned"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale returned"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DevilsFoot/226> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/226>
     rdf:type    kgc:Statement ;
     kgc:source  "ラウンドヘイがスタンデールに電報を送った"@ja ;
-    kgc:source  "Roundhay telegraphed Standale"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Roundhay telegraphed Sterndale"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> ;
-    kgc:whoｍ   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:whoｍ   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/telegram> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/227>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールはホームズに容疑者を聞いた"@ja ;
-    kgc:source  "Standale heard Holmes suspect"@en ;
+    kgc:source  "Sterndale heard Holmes suspect"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Suspect> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/228> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/228>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはスタンデールに答えなかった"@ja ;
-    kgc:source  "Holmes did not answer Standale"@en ;
+    kgc:source  "Holmes did not answer Sterndale"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notAnswer> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/229> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/229>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールはポルデュー湾のコテージから出ていった"@ja ;
-    kgc:source  "Standale left a cottage in the Pordeux Bay"@en ;
+    kgc:source  "Sterndale left a cottage in the Pordeux Bay"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottages_of_Pordeux_Bay> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/230> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/230>
     rdf:type    kgc:Situation ;
     kgc:source  "5分以内に、ホームズはスタンデールを追った"@ja ;
-    kgc:source  "Within 5 minutes, Holmes followed Standale"@en ;
+    kgc:source  "Within 5 minutes, Holmes followed Sterndale"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/trace> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Within_5_minutes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/231> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/231>
@@ -2479,12 +2479,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/238>
     rdf:type    kgc:Statement ;
     kgc:source  "ラウンドヘイから（スタンデールが泊まっていたプリマスのホテルの）名前を聞きだした"@ja ;
-    kgc:source  "Holmes heard my name of the hotel Standale stayed in Plymouth from Roundhay"@en ;
+    kgc:source  "Holmes heard my name of the hotel Sterndale stayed in Plymouth from Roundhay"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hear> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/name_of_the_hotel_Standale_stay_at_Plymouth> .
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/name_of_the_hotel_Sterndale_stay_at_Plymouth> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/239>
     rdf:type    kgc:Statement ;
     kgc:source  "ラウンドヘイに以下を聞いた"@ja ;
@@ -2497,27 +2497,27 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/240>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールの説明は正しい"@ja ;
-    kgc:source  "Standale's explanation is correct"@en ;
+    kgc:source  "Sterndale's explanation is correct"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/correct> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Description_of_Standale> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Description_of_Sterndale> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/241>
     rdf:type    kgc:Statement ;
     kgc:source  "昨晩、スタンデールはプリマスにいた"@ja ;
-    kgc:source  "Last night, Standale was in Plymouth"@en ;
+    kgc:source  "Last night, Sterndale was in Plymouth"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/exist> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Last_night> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Plymouth> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/242>
     rdf:type    kgc:Statement ;
     kgc:source  "午後に、スタンデールは荷物をアフリカに送った"@ja ;
-    kgc:source  "In the afternoon, Standale sent luggage to Africa"@en ;
+    kgc:source  "In the afternoon, Sterndale sent luggage to Africa"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/afternoon> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Baggage> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Africa> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/243> .
@@ -3624,30 +3624,30 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/373>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは根拠を知っている"@ja ;
-    kgc:source  "Standale knows the grounds"@en ;
+    kgc:source  "Sterndale knows the grounds"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Ground> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/374>
     rdf:type    kgc:Statement ;
     kgc:source  "今日の午後、スタンデールを呼んだ"@ja ;
-    kgc:source  "Holmes called Standale this afternoon"@en ;
+    kgc:source  "Holmes called Sterndale this afternoon"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/call> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/This_afternoon> ;
     kgc:time  "1896-03-18T14:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/1896-03-18T14> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/375>
     rdf:type    kgc:Situation ;
     kgc:source  "1時間前に、スタンデールはホームズのメモを受け取った"@ja ;
-    kgc:source  "An hour ago, Standale received Holmes' notes"@en ;
+    kgc:source  "An hour ago, Sterndale received Holmes' notes"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/1_hour_ago> ;
     kgc:time  "1896-03-18T14:30:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/1896-03-18T14:30> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/note_of_Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/376> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/376>
@@ -3695,44 +3695,44 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/377>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは所持品をアフリカに送った"@ja ;
-    kgc:source  "Standale sent his belongings to Africa"@en ;
+    kgc:source  "Sterndale sent his belongings to Africa"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Possession> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Africa> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/378> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/378>
     rdf:type    kgc:Statement ;
     kgc:source  "そして、スタンデールはプリマスから引き返した"@ja ;
-    kgc:source  "And Standale returned from Plymouth"@en ;
+    kgc:source  "And Sterndale returned from Plymouth"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Plymouth> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/379>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールが事件の要素である"@ja ;
-    kgc:source  "Standale is an element of the incident"@en ;
+    kgc:source  "Sterndale is an element of the incident"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Element_of_the_case> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/380>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはポルデュー湾のコテージに来た"@ja ;
-    kgc:source  "Standale came to a cottage in the Pordeux Bay"@en ;
+    kgc:source  "Sterndale came to a cottage in the Pordeux Bay"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Pordeux_Bay> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/381> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/381>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはホームズに容疑者を尋ねた"@ja ;
-    kgc:source  "Standale asked Holmes for the suspect"@en ;
+    kgc:source  "Sterndale asked Holmes for the suspect"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/ask> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Suspect> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/382> .
@@ -3748,54 +3748,54 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/383>
     rdf:type    kgc:Statement ;
     kgc:source  "そして、スタンデールは牧師館に行った"@ja ;
-    kgc:source  "And Standale went to the pastor"@en ;
+    kgc:source  "And Sterndale went to the pastor"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/pastoral_hall> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/384> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/384>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは外で待った"@ja ;
-    kgc:source  "Standale waited outside"@en ;
+    kgc:source  "Sterndale waited outside"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Outside> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/385> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/385>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはコテージに戻った"@ja ;
-    kgc:source  "Standale returned to the cottage"@en ;
+    kgc:source  "Sterndale returned to the cottage"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/386> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/386>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはコテージで眠れなかった"@ja ;
-    kgc:source  "Standale couldn't sleep in the cottage"@en ;
+    kgc:source  "Sterndale couldn't sleep in the cottage"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSleep> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/387> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/387>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは計画を練った"@ja ;
-    kgc:source  "Standale created a plan"@en ;
+    kgc:source  "Sterndale created a plan"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/create> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/plan> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/388>
     rdf:type    kgc:Statement ;
     kgc:source  "朝早く、スタンデールは計画を実行した"@ja ;
-    kgc:source  "Early in the morning, Standale implemented the plan"@en ;
+    kgc:source  "Early in the morning, Sterndale implemented the plan"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/execute> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/early_morning> ;
     kgc:time  "1896-03-18T05:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/1896-03-18T05> ;
@@ -3804,22 +3804,22 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/390>
     rdf:type    kgc:Statement ;
     kgc:source  "日が昇る頃に、スタンデールは部屋を出た"@ja ;
-    kgc:source  "By sunrise, Standale had left the room"@en ;
+    kgc:source  "By sunrise, Sterndale had left the room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/left> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/When_the_sun_rises> ;
     kgc:time  "1896-03-18T06:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/1896-03-18T06> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/room> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/391> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/391>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはポケットに赤砂利を詰めた"@ja ;
-    kgc:source  "Standale stuffed red gravel in his pocket"@en ;
+    kgc:source  "Sterndale stuffed red gravel in his pocket"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stuff> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/pocket> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Red_gravel> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/393> .
@@ -3834,28 +3834,28 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/393>
     rdf:type    kgc:Statement ;
     kgc:source  "そして、スタンデールは牧師館へ向かった"@ja ;
-    kgc:source  "Subsequently, Standale went to the pastor"@en ;
+    kgc:source  "Subsequently, Sterndale went to the pastor"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/pastoral_hall> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/394> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/394>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはテニスシューズをはいていた"@ja ;
-    kgc:source  "Standale wore tennis shoes"@en ;
+    kgc:source  "Sterndale wore tennis shoes"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/wear> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Tennis_shoes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/395> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/395>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはモーティマーの窓の下に行った"@ja ;
-    kgc:source  "Standale went under the Mortimer’s window"@en ;
+    kgc:source  "Sterndale went under the Mortimer’s window"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/window_of_Mortimer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/396> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/396>
@@ -3869,20 +3869,20 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/397>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはポケットから砂利を取り出した"@ja ;
-    kgc:source  "Standale took the gravel out of his pocket"@en ;
+    kgc:source  "Sterndale took the gravel out of his pocket"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/takeOut> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DevilsFoot/pocket> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/gravel> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/398> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/398>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは寝室の窓に投げつけた"@ja ;
-    kgc:source  "Standale threw the gravel into the bedroom window"@en ;
+    kgc:source  "Sterndale threw the gravel into the bedroom window"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/throw> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/window_of_Bedroom> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/399> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/399>
@@ -3896,10 +3896,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/400>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは以下を合図した"@ja ;
-    kgc:source  "Standale signaled to the following"@en ;
+    kgc:source  "Sterndale signaled to the following"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/signal> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/401> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/402> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/401>
@@ -3931,64 +3931,64 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/404>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは窓から入った"@ja ;
-    kgc:source  "Standale entered through the window"@en ;
+    kgc:source  "Sterndale entered through the window"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/enter> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DevilsFoot/window> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/405> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/405>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは部屋を徘徊した"@ja ;
-    kgc:source  "Standale looked at the room"@en ;
+    kgc:source  "Sterndale looked at the room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wander> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/room> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/406> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/406>
     rdf:type    kgc:Statement ;
     kgc:source  "それから、スタンデールは部屋を出た"@ja ;
-    kgc:source  "Then Standale left the room"@en ;
+    kgc:source  "Then Sterndale left the room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goOut> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/room> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/407> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/407>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは窓を閉めた"@ja ;
-    kgc:source  "Standale closed the window"@en ;
+    kgc:source  "Sterndale closed the window"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/close> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/window> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/408> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/408>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは芝生で立ちつくした"@ja ;
-    kgc:source  "Standale stood on the grass"@en ;
+    kgc:source  "Sterndale stood on the grass"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stand> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/lawn> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/409> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/409>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは部屋の中を観察した"@ja ;
-    kgc:source  "Standale observed the room"@en ;
+    kgc:source  "Sterndale observed the room"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/observe> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/In_the_room> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/410> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/410>
     rdf:type    kgc:Statement ;
     kgc:source  "最後に、スタンデールは引き上げていった"@ja ;
-    kgc:source  "Finally, Standale left"@en ;
+    kgc:source  "Finally, Sterndale left"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/last> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/411>
     rdf:type    kgc:Statement ;
@@ -4001,9 +4001,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/412>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは以下を言った"@ja ;
-    kgc:source  "Standale said the following"@en ;
+    kgc:source  "Sterndale said the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/413> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/414> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/415> ;
@@ -4023,72 +4023,72 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/413>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは何年もブレンダを愛してきた"@ja ;
-    kgc:source  "Standale has loved Brenda for years"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale has loved Brenda for years"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/What_year> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/DevilsFoot/415> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/414>
     rdf:type    kgc:Statement ;
     kgc:source  "ブレンダは何年もスタンデールを愛してきた"@ja ;
-    kgc:source  "Brenda has loved Standale for many years"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Brenda has loved Sterndale for many years"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/love> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/What_year> ;
     kgc:therefore   <http://kgc.knowledge-graph.jp/data/DevilsFoot/415> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/415>
     rdf:type    kgc:Statement ;
     kgc:source  "そのため、スタンデールはコーンワルで隠遁した"@ja ;
-    kgc:source  "Therefore, Standale was metaphorized in Cornwall"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Therefore, Sterndale was metaphorized in Cornwall"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hideAway> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cornwall> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/416>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは結婚をできなかった"@ja ;
-    kgc:source  "Standale couldn't get married"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale couldn't get married"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotMarry> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda> ;
     kgc:because   <http://kgc.knowledge-graph.jp/data/DevilsFoot/417> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/417>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは前妻を持っていた"@ja ;
-    kgc:source  "Standale had a former wife"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale had a former wife"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/have> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/418>
     rdf:type    kgc:Statement ;
     kgc:source  "前妻は何年も前に出ていった"@ja ;
-    kgc:source  "Standale's former wife came out many years ago"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale's former wife came out many years ago"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/leave> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife_of_Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife_of_Sterndale> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Many_years_ago> ;
     kgc:time  "1890-04-01T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/1890-04-01> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/419>
     rdf:type    kgc:Statement ;
     kgc:source  "イギリスの法律のため、スタンデールは離婚ができない"@ja ;
-    kgc:source  "Standale cannot divorce because of English law"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale cannot divorce because of English law"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotDivorce> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/DevilsFoot/laws_of_United_Kingdom> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/420> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/420>
     rdf:type    kgc:Statement ;
     kgc:source  "ブレンダは何年も結婚を待った"@ja ;
     kgc:source  "Brenda has been waiting for marriage for years"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/marriage> ;
@@ -4097,17 +4097,17 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/421>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールも何年も結婚を待った"@ja ;
-    kgc:source  "Standale also waited for marriage for years"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale also waited for marriage for years"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wait> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/marriage> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/long_year> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/422>
     rdf:type    kgc:Statement ;
     kgc:source  "ラウンドヘイは上記を知っていた"@ja ;
     kgc:source  "Roundhay knew all of the above"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/413> ;
@@ -4122,17 +4122,17 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/423>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールとブレンダはラウンドヘイを信頼していた"@ja ;
-    kgc:source  "Standale and Brenda trusted Roundhay"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale and Brenda trusted Roundhay"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/trust> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/424>
     rdf:type    kgc:Statement ;
     kgc:source  "ラウンドヘイは以下を言った"@ja ;
     kgc:source  "Roundhay said the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/425> .
@@ -4146,33 +4146,33 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/426>
     rdf:type    kgc:Statement ;
     kgc:source  "それで、ラウンドヘイはスタンデールに電報を送った"@ja ;
-    kgc:source  "So, Roundhay sent a call to Standale"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "So, Roundhay sent a call to Sterndale"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/send> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Roundhay> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/telegram> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/427>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは帰ってきた"@ja ;
-    kgc:source  "Standale returned"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale returned"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/return> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/428>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは紙包みをとりだした"@ja ;
-    kgc:source  "Standale took out the paper packet"@en ;
+    kgc:source  "Sterndale took out the paper packet"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/takeOut> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Paper_package> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/429> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/429>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは紙包みをテーブルの上に置いた"@ja ;
-    kgc:source  "Standale placed a paper packet on the table"@en ;
+    kgc:source  "Sterndale placed a paper packet on the table"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/put> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Paper_package> ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/DevilsFoot/table> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/430> .
@@ -4196,7 +4196,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "薬物は魔足根である"@ja ;
     kgc:source  "The drug is Devil's foot"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Magic_foot> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Drug> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/433> .
@@ -4204,7 +4204,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "ヨーロッパには、魔足根の見本はない"@ja ;
     kgc:source  "In Europe, there is no sample of Devil's foot"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExist> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Europe> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/sample_of_magic_foot> ;
@@ -4213,7 +4213,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "魔足根の見本は薬局や毒物学の文献に出ていない"@ja ;
     kgc:source  "No sample of Devil's foot are not found in pharmacy or toxicology literature"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExist> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/sample_of_magic_foot> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/literature_of_pharmacy> ;
@@ -4230,10 +4230,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/436>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはオーウェンとジョージと仲良かった"@ja ;
-    kgc:source  "Standale got along well with Owen and George"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale got along well with Owen and George"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/good_friends> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Owen> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/George> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/437> .
@@ -4241,7 +4241,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーは兄弟と仲直りしていた"@ja ;
     kgc:source  "Mortimer had made up with his brother"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Good_friends> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
@@ -4250,21 +4250,21 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/438>
     rdf:type    kgc:Statement ;
     kgc:source  "その後、スタンデールはオーウェンとジョージとモーティマーと会っていた"@ja ;
-    kgc:source  "Standale then met with Owen, George and Mortimer"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale then met with Owen, George and Mortimer"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Owen> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/George> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/439>
     rdf:type    kgc:Statement ;
     kgc:source  "2週間前、モーティマーがスタンデールのコテージにやってきた"@ja ;
-    kgc:source  "Two weeks ago, Mortimer came to Standale's cottage"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Two weeks ago, Mortimer came to Sterndale's cottage"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Standale> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Sterndale> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/2_weeks_ago> ;
     kgc:time  "1896-03-02T00:00:00"^^xsd:dateTime ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/1896-03-02> ;
@@ -4272,36 +4272,36 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/440>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはアフリカの珍品の一部を見せた"@ja ;
-    kgc:source  "Standale showed off some of Africa's curiosities"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale showed off some of Africa's curiosities"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/show> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/rare_object_of_Africa> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/441> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/441>
     rdf:type    kgc:Statement ;
     kgc:source  "粉薬はアフリカの珍品の一部だった"@ja ;
     kgc:source  "Powdered medicine was a rarity in Africa"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/rare_object_of_Africa> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Powder_medicine> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/442> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/442>
     rdf:type    kgc:Statement ;
     kgc:source  "そして、スタンデールはモーティマーに粉薬の性質を教えた"@ja ;
-    kgc:source  "Standale taught Mortimer the nature of powder medicine"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale taught Mortimer the nature of powder medicine"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/teach> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Nature_of_powder_medicine> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/443> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/443>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは以下をモーティマーに教えた"@ja ;
-    kgc:source  "Standale taught Mortimer the following"@en ;
+    kgc:source  "Sterndale taught Mortimer the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/teach> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/444> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/445> .
@@ -4309,27 +4309,27 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "ヨーロッパ化学は魔足根を検出しない"@ja ;
     kgc:source  "European chemistry does not detect Devil's foot"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notDetect> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/European_chemistry> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Magic_foot> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/445>
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーはスタンデールに魔足根について熱心に質問していた"@ja ;
-    kgc:source  "Mortimer  was eagerly questioning Standale about Devil's foot"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Mortimer  was eagerly questioning Sterndale about Devil's foot"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/question> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
-    kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Eagerly> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/446> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/446>
     rdf:type    kgc:Statement ;
     kgc:source  "電報を受け取るまで、スタンデールは下記について考えなかった"@ja ;
-    kgc:source  "Standale did not think the followung until he received a telegram"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale did not think the followung until he received a telegram"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/consider> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:after   <http://kgc.knowledge-graph.jp/data/DevilsFoot/426> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/439> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/440> ;
@@ -4341,16 +4341,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/447>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは以下を推測した"@ja ;
-    kgc:source  "Standale guessed the following"@en ;
+    kgc:source  "Sterndale guessed the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/guess> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/448> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/452> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/448>
     rdf:type    kgc:Thought ;
     kgc:source  "モーティマーは以下を思った"@ja ;
     kgc:source  "Mortimer thought the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/449> ;
@@ -4359,69 +4359,69 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/449>
     rdf:type    kgc:Thought ;
     kgc:source  "スタンデールが海にでた"@ja ;
-    kgc:source  "Standale went to the sea"@en ;
+    kgc:source  "Sterndale went to the sea"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/go> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sea> ;
     kgc:before   <http://kgc.knowledge-graph.jp/data/DevilsFoot/450> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/450>
     rdf:type    kgc:Thought ;
     kgc:source  "スタンデールが知らせを受け取る"@ja ;
-    kgc:source  "Standale received the news"@en ;
+    kgc:source  "Sterndale received the news"@en ;
     kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/receive> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Information> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/451>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは数年間、アフリカをさまよう"@ja ;
-    kgc:source  "Standale wandered Africa for several years"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale wandered Africa for several years"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wander> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Africa> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/For_several_years> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/452>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは以下を思った"@ja ;
-    kgc:source  "Standale thought the following"@en ;
+    kgc:source  "Sterndale thought the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/453> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/454> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/453>
     rdf:type    kgc:Situation ;
     kgc:source  "魔足根が使われた"@ja ;
     kgc:source  "The Devil's foot was used"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale_s_guess> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale_s_guess> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/beUsed> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Magic_foot> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/454>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはポルデュー湾のコテージにきた"@ja ;
-    kgc:source  "Standale came to a cottage in the Pordeux Bay"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale came to a cottage in the Pordeux Bay"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/come> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Pordeux_Bay> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/455> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/455>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはホームズと会った"@ja ;
-    kgc:source  "Standale met Holmes"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale met Holmes"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/456> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/456>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは別解釈を確かめた"@ja ;
-    kgc:source  "Standale confirmed another interpretation"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale confirmed another interpretation"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/check> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Another_interpretation> ;
     kgc:however   <http://kgc.knowledge-graph.jp/data/DevilsFoot/457> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/458> .
@@ -4429,16 +4429,16 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "しかし、別解釈はなかった"@ja ;
     kgc:source  "However, there was no other interpretation"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notExist> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Another_interpretation> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/458>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは以下を推測した"@ja ;
-    kgc:source  "Standale guessed the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale guessed the following"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/guess> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/459> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/460> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/461> .
@@ -4446,7 +4446,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Thought ;
     kgc:source  "お金のため、モーティマーが殺した"@ja ;
     kgc:source  "Mortimer killed for money"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/DevilsFoot/money> .
@@ -4454,7 +4454,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Thought ;
     kgc:source  "モーティマーは以下を思った"@ja ;
     kgc:source  "Mortimer thought the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/think> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/461> ;
@@ -4480,7 +4480,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーは魔足根でオーウェンとジョージの理性を吹き飛ばした"@ja ;
     kgc:source  "Mortimer blew away Owen and George's reason with his Devil's foot"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/blowAway> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Magic_foot> ;
@@ -4491,33 +4491,33 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーはブレンダを殺した"@ja ;
     kgc:source  "Mortimer killed Brenda"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kill> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Brenda> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/465>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは真相が分かっている"@ja ;
-    kgc:source  "Standale knows the truth"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale knows the truth"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/know> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/truth> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/466> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/466>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは以下を疑った"@ja ;
-    kgc:source  "Standale suspected the following"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale suspected the following"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/suspect> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/467> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/468> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/467>
     rdf:type    kgc:Statement ;
     kgc:source  "陪審員が空想じみた物語を信じる"@ja ;
     kgc:source  "I believe in a story that a jury has fancy"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/believe> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Jury_member> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/fantasy_story> .
@@ -4525,34 +4525,34 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "失敗は困る"@ja ;
     kgc:source  "Failure is troubled"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWant> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Failure> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/469> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/469>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは復讐を望む"@ja ;
     kgc:source  "Standell wants revenge"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/want> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/revenge> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/470> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/470>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは以下を決断した"@ja ;
-    kgc:source  "Standale made the following decisions"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale made the following decisions"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/decide> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/471> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/472> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/471>
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーはオーウェンとジョージとブレンダと同じ運命になる"@ja ;
     kgc:source  "Mortimer gets the same fate as Owen, George and Brenda"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/become> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/same_fate_of_Owen> ;
@@ -4561,19 +4561,19 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/472>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはモーティマーの罪をモーティマーに告げた"@ja ;
-    kgc:source  "Standale told Mortimer his crimes"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale told Mortimer his crimes"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:whom   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/guilt_of_Mortimer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/473> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/473>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールは以下を言った"@ja ;
-    kgc:source  "Standale said the following"@en ;
+    kgc:source  "Sterndale said the following"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/474> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/475> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/476> ;
@@ -4591,22 +4591,22 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/474>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは裁判官である"@ja ;
-    kgc:source  "Standale is the judge"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale is the judge"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Judge> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/475>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは死刑執行人である"@ja ;
-    kgc:source  "Standale is the executioner"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale is the executioner"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/Executioner> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> .
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/476>
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーはリボルバーを見た"@ja ;
     kgc:source  "Mortimer saw a revolver"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/see> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/revolver> ;
@@ -4615,7 +4615,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーは麻痺した"@ja ;
     kgc:source  "Mortimer was paralyzed"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/paralyze> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/478> .
@@ -4623,7 +4623,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Statement ;
     kgc:source  "モーティマーは椅子に崩れ落ちた"@ja ;
     kgc:source  "Mortimer fell into a chair"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/collapse> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Chair> ;
@@ -4631,70 +4631,70 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/479>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは以下のように脅した"@ja ;
-    kgc:source  "Standale threatened as follows"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale threatened as follows"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/threaten> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/DevilsFoot/480> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/482> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/480>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはモーティマーを撃つ"@ja ;
-    kgc:source  "Standale shot Mortimer"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale shot Mortimer"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/shoot> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:if   <http://kgc.knowledge-graph.jp/data/DevilsFoot/481> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/481>
     rdf:type    kgc:Statement ;
     kgc:source  "もし、モーティマーが部屋から出る"@ja ;
     kgc:source  "If the Mortimer leaves the room"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/goOut> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:from   <http://kgc.knowledge-graph.jp/data/DevilsFoot/room> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/482>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールはランプに火をつけた"@ja ;
-    kgc:source  "Standale lit the lamp"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale lit the lamp"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fire> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/DevilsFoot/lamp> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/fire> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/483> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/483>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは粉薬を乗せた"@ja ;
-    kgc:source  "Standale loaded the powder"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale loaded the powder"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/putOn> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Powder_medicine> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/484>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは窓の外に立った"@ja ;
-    kgc:source  "Standale stood out of the window"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale stood out of the window"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/stand> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Outside_of_window> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/485> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/485>
     rdf:type    kgc:Statement ;
     kgc:source  "スタンデールは銃を構えた"@ja ;
-    kgc:source  "Standale got a gun"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:source  "Sterndale got a gun"@en ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hold> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/gun> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/DevilsFoot/486> .
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/486>
     rdf:type    kgc:Statement ;
     kgc:source  "5分後、モーティマーは死んだ"@ja ;
     kgc:source  "Five minutes later, Mortimer died"@en ;
-    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale> ;
+    kgc:infoSource   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/die> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Mortimer> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Five_minutes_later> .
@@ -4717,11 +4717,11 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/489>
     rdf:type    kgc:Situation ;
     kgc:source  "スタンデールのコテージの庭で、ホームズは砂利を見つけた"@ja ;
-    kgc:source  "In the yard of Standale’s cottage, Holmes found gravel"@en ;
+    kgc:source  "In the yard of Sterndale’s cottage, Holmes found gravel"@en ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/DevilsFoot/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/DevilsFoot/gravel> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/garden_of_Cottage_of_Standale> .
+    kgc:where   <http://kgc.knowledge-graph.jp/data/DevilsFoot/garden_of_Cottage_of_Sterndale> .
 #Objectとして参照されているリソースの定義
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/House_of_Trigenis>
     rdfs:label     "トリジェニス家"@ja;
@@ -5178,6 +5178,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/1897>
     rdfs:label     "1897"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale_s_guess>
+    rdfs:label     "Sterndale's guess"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/eat>
     rdf:type    kgc:Action;
     rdfs:label     "食べる"@ja;
@@ -5467,11 +5470,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "地方警察"@ja;
     rdfs:label     "Local police"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage_of_Standale>
-    rdfs:label     "Cottage of Standale"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
     rdfs:label     "考える"@ja;
@@ -5729,8 +5727,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/night>
     rdfs:label     "night"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/the_hotel_Standale_stay_at_Plymouth>
-    rdfs:label     "the hotel Standale stay at Plymouth"@en;
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/the_hotel_Sterndale_stay_at_Plymouth>
+    rdfs:label     "the hotel Sterndale stay at Plymouth"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/send>
     rdf:type    kgc:Action;
@@ -5751,12 +5749,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "テーブル"@ja;
     rdfs:label     "table"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/Description_of_Standale>
-    rdfs:label     "スタンデールの説明"@ja;
-    rdfs:label     "Description of Standale"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Description>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/same_fate>
     rdfs:label     "same fate"@en;
     rdf:type    kgc:Object.
@@ -5913,6 +5905,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "無惨な光景"@ja;
     rdfs:label     "Miserable sight"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/Description_of_Sterndale>
+    rdfs:label     "スタンデールの説明"@ja;
+    rdfs:label     "Description of Sterndale"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Description>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/bed>
     rdfs:label     "bed"@en;
     rdf:type    kgc:Object.
@@ -6026,6 +6024,12 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/Go>
     rdfs:label     "Go"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Sterndale>
+    rdfs:label     "スタンデールのコテージ"@ja;
+    rdfs:label     "cottage of Sterndale"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale>.
 <http://kgc.knowledge-graph.jp/data/predicate/good_friends>
     rdf:type    kgc:Property;
     rdfs:label     "仲良し"@ja;
@@ -6093,6 +6097,12 @@ kgc:Thought rdf:type owl:Class ;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/exist>;
     rdfs:label     "存在しない"@ja;
     rdfs:label     "notExist"@en.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/name_of_the_hotel_Sterndale_stay_at_Plymouth>
+    rdfs:label     "（スタンデールが泊まっていたプリマスのホテルの）名前"@ja;
+    rdfs:label     "name of the hotel Sterndale stay at Plymouth"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/name>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/the_hotel_Sterndale_stay_at_Plymouth>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Garden_path>
     rdfs:label     "庭の小道"@ja;
     rdfs:label     "Garden path"@en;
@@ -6159,12 +6169,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:AbstractTime;
     rdfs:label     "現在"@ja;
     rdfs:label     "Current"@en.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife_of_Standale>
-    rdfs:label     "スタンデールの前妻"@ja;
-    rdfs:label     "Former wife of Standale"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/than_Roundhay>
     rdfs:label     "ラウンドヘイより"@ja;
     rdfs:label     "than Roundhay"@en;
@@ -6316,10 +6320,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "家"@ja;
     rdfs:label     "House"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>
-    rdfs:label     "スタンデール"@ja;
-    rdfs:label     "Standale"@en;
-    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/mentally_ill>
     rdfs:label     "精神異常者"@ja;
     rdfs:label     "mentally ill"@en;
@@ -6330,12 +6330,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Smoke_protection>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/lamp>.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage_of_Standale>
-    rdfs:label     "スタンデールのコテージ"@ja;
-    rdfs:label     "cottage of Standale"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/cottage>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/reason>
     rdfs:label     "reason"@en;
     rdf:type    kgc:Object.
@@ -6602,6 +6596,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "硬直する"@ja;
     rdfs:label     "stiffen"@en.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage_of_Sterndale>
+    rdfs:label     "Cottage of Sterndale"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/6_hours>
     rdfs:label     "6時間"@ja;
     rdfs:label     "6 hours"@en;
@@ -6749,14 +6748,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "裁判官"@ja;
     rdfs:label     "Judge"@en.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/garden_of_Cottage_of_Standale>
-    rdfs:label     "スタンデールのコテージの庭"@ja;
-    rdfs:label     "garden of Cottage of Standale"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage_of_Standale>;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/garden>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale>.
 <http://kgc.knowledge-graph.jp/data/predicate/correct>
     rdf:type    kgc:Action;
     rdfs:label     "正しい"@ja;
@@ -6982,12 +6973,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "聞く"@ja;
     rdfs:label     "hear"@en.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/name_of_the_hotel_Standale_stay_at_Plymouth>
-    rdfs:label     "（スタンデールが泊まっていたプリマスのホテルの）名前"@ja;
-    rdfs:label     "name of the hotel Standale stay at Plymouth"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/name>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/the_hotel_Standale_stay_at_Plymouth>.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
     rdfs:label     "集中している"@ja;
@@ -7318,10 +7303,24 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "作用する"@ja;
     rdfs:label     "act"@en.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife_of_Sterndale>
+    rdfs:label     "スタンデールの前妻"@ja;
+    rdfs:label     "Former wife of Sterndale"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Former_wife>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale>.
 <http://kgc.knowledge-graph.jp/data/predicate/collapse>
     rdf:type    kgc:Action;
     rdfs:label     "崩れ落ちる"@ja;
     rdfs:label     "collapse"@en.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/garden_of_Cottage_of_Sterndale>
+    rdfs:label     "スタンデールのコテージの庭"@ja;
+    rdfs:label     "garden of Cottage of Sterndale"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage_of_Sterndale>;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/DevilsFoot/garden>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale>.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Case_2>
     rdfs:label     "Case 2"@en;
     rdf:type    kgc:Object.
@@ -7490,9 +7489,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/What_year>
     rdfs:label     "何年"@ja;
     rdfs:label     "What year"@en;
-    rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/DevilsFoot/Standale_s_guess>
-    rdfs:label     "Standale's guess"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
@@ -7703,6 +7699,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/Cottage>
     rdfs:label     "コテージ"@ja;
     rdfs:label     "Cottage"@en;
+    rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/DevilsFoot/Sterndale>
+    rdfs:label     "スタンデール"@ja;
+    rdfs:label     "Sterndale"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/DevilsFoot/both_sides>
     rdfs:label     "both sides"@en;

--- a/ResidentPatient.ttl
+++ b/ResidentPatient.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################

--- a/ResidentPatient.ttl
+++ b/ResidentPatient.ttl
@@ -3309,7 +3309,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Furniture"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "歩き回る"@ja;
+    rdfs:label     "徘徊する"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Helper_boy>
     rdf:type    kgc:Property;
@@ -3407,7 +3407,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/obtain>
     rdf:type    kgc:Action;
-    rdfs:label     "手に入れる"@ja;
+    rdfs:label     "得する"@ja;
     rdfs:label     "obtain"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/police_officer>
     rdf:type    kgc:Person;
@@ -3418,7 +3418,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/close>
     rdf:type    kgc:Property;
-    rdfs:label     "閉まっている"@ja;
+    rdfs:label     "閉める"@ja;
     rdfs:label     "close"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Every_night,_same_time>
     rdfs:label     "毎晩、同じ時間"@ja;
@@ -3496,7 +3496,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/profitable>
     rdf:type    kgc:Property;
-    rdfs:label     "儲かっている"@ja;
+    rdfs:label     "利益を生む"@ja;
     rdfs:label     "profitable"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Conditions_of_the_proposed_street>
     rdfs:label     "提案通りの条件"@ja;
@@ -3761,7 +3761,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受ける"@ja;
+    rdfs:label     "受け取る"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Among_the_keyhole>
     rdf:type    kgc:Place;
@@ -3869,7 +3869,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Worthington bank Robbers"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/command>
     rdf:type    kgc:Action;
-    rdfs:label     "命令する"@ja;
+    rdfs:label     "指揮を執る"@ja;
     rdfs:label     "command"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Own_room_safe>
     rdf:type    kgc:Place;
@@ -3883,7 +3883,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/e>;
-    rdfs:label     "メモする"@ja;
+    rdfs:label     "注目する"@ja;
     rdfs:label     "note"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Chair>
     rdf:type    kgc:PhysicalObject;
@@ -3918,7 +3918,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "steal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/revenge>
     rdf:type    kgc:Action;
-    rdfs:label     "やり返す"@ja;
+    rdfs:label     "仇討ちをする"@ja;
     rdfs:label     "revenge"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Body_temperature>
     rdfs:label     "Body temperature"@en;
@@ -4025,15 +4025,14 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/enter>
     rdf:type    kgc:Action;
     rdfs:label     "入る"@ja;
-    rdfs:label     "enter"@en;
-    rdfs:label     "入れる"@ja.
+    rdfs:label     "enter"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/house>
     rdf:type    kgc:Place;
     rdfs:label     "家の中"@ja;
     rdfs:label     "house"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/living_expenses>
     rdfs:label     "living expenses"@en;
@@ -4064,8 +4063,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "混乱する"@ja;
     rdfs:label     "confuse"@en;
-    rdf:type    kgc:Property;
-    rdfs:label     "困惑する"@ja.
+    rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Stratagem>
     rdfs:label     "計略"@ja;
     rdfs:label     "Stratagem"@en;
@@ -4098,7 +4096,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "依頼する"@ja;
+    rdfs:label     "要求する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/invest>
     rdf:type    kgc:Action;
@@ -4266,7 +4264,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "black trousers"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪ねる"@ja;
+    rdfs:label     "訪れる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notExist>
     rdf:type    kgc:Action;
@@ -4352,7 +4350,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つけられない"@ja;
+    rdfs:label     "見つからない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Young_man>
     rdfs:label     "Young man"@en;
@@ -4477,7 +4475,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "持たない"@ja;
+    rdfs:label     "not持つ"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/new>
     rdf:type    kgc:Property;
@@ -4485,7 +4483,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "new"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/recognize>
     rdf:type    kgc:Property;
-    rdfs:label     "認識する"@ja;
+    rdfs:label     "わかる"@ja;
     rdfs:label     "recognize"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/refuse>
     rdf:type    kgc:Action;
@@ -4505,7 +4503,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "Pistol"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "試みる"@ja;
+    rdfs:label     "しようとする"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notListen>
     rdf:type    kgc:Action;
@@ -4552,7 +4550,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/thin>
     rdf:type    kgc:Property;
-    rdfs:label     "細い"@ja;
+    rdfs:label     "薄い"@ja;
     rdfs:label     "thin"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Room_of_Percy_Trevelyan>
     rdf:type    kgc:Place;
@@ -4591,7 +4589,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "know"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "匂う"@ja;
+    rdfs:label     "嗅ぐ"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/align>
     rdf:type    kgc:Action;
@@ -4624,11 +4622,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/reveal>
     rdf:type    kgc:Action;
-    rdfs:label     "明らかにする"@ja;
+    rdfs:label     "明かす"@ja;
     rdfs:label     "reveal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着ている"@ja;
+    rdfs:label     "着る"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Account_book>
     rdf:type    kgc:PhysicalObject;
@@ -4798,7 +4796,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/pale>
     rdf:type    kgc:Property;
-    rdfs:label     "悪い"@ja;
+    rdfs:label     "青ざめる"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/5_people>
     rdfs:label     "5人"@ja;
@@ -5013,7 +5011,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Worthingdon_bank>.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "集中している"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hear>
     rdf:type    kgc:Action;
@@ -5045,8 +5043,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "到着する"@ja;
     rdfs:label     "arrive"@en;
-    rdf:type    kgc:Property;
-    rdfs:label     "届く"@ja.
+    rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/ResidentPatient/Cigar>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "残っていた葉巻"@ja;
@@ -5207,7 +5204,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/prevent>
     rdf:type    kgc:Action;
-    rdfs:label     "防ぐ"@ja;
+    rdfs:label     "妨げる"@ja;
     rdfs:label     "prevent"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/sneak>
     rdf:type    kgc:Action;
@@ -5288,7 +5285,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上がる"@ja;
+    rdfs:label     "上る"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/irregular>
     rdf:type    kgc:Property;
@@ -5444,7 +5441,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Percy_Trevelyan>.
 <http://kgc.knowledge-graph.jp/data/predicate/attend>
     rdf:type    kgc:Action;
-    rdfs:label     "参加する"@ja;
+    rdfs:label     "立ち会う"@ja;
     rdfs:label     "attend"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/comeTrue>
     rdf:type    kgc:Property;
@@ -5477,7 +5474,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/ResidentPatient/Blessington>.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Property;
-    rdfs:label     "留まる"@ja;
+    rdfs:label     "滞在する"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/stand>
     rdf:type    kgc:Action;
@@ -5541,14 +5538,12 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "suck"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/insist>
     rdf:type    kgc:Action;
-    rdfs:label     "主張する"@ja;
+    rdfs:label     "言い張る"@ja;
     rdfs:label     "insist"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
     rdfs:label     "開く"@ja;
-    rdfs:label     "open"@en;
-    rdfs:label     "開業する"@ja;
-    rdfs:label     "開ける"@ja.
+    rdfs:label     "open"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/pretend>
     rdf:type    kgc:Action;
     rdfs:label     "振りをする"@ja;
@@ -5665,7 +5660,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fix"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Property;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en;
     rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/prospect>

--- a/SilverBlaze.ttl
+++ b/SilverBlaze.ttl
@@ -3862,9 +3862,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/bring>
     rdf:type    kgc:Action;
     rdfs:label     "持っていく"@ja;
-    rdfs:label     "bring"@en;
-    rdfs:label     "持ってくる"@ja;
-    rdfs:label     "運ぶ"@ja.
+    rdfs:label     "bring"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Disappearance>
     rdfs:label     "Disappearance"@en;
     rdf:type    kgc:Object.
@@ -3944,7 +3942,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notOrdinary"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "歩き回る"@ja;
+    rdfs:label     "徘徊する"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Fitzroy_Simpson>
     rdf:type    kgc:Person;
@@ -4128,7 +4126,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/brown_color>.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "打つ"@ja;
+    rdfs:label     "殴る"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wet>
     rdf:type    kgc:Property;
@@ -4465,7 +4463,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受ける"@ja;
+    rdfs:label     "受け取る"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/House_near_the_stables>
     rdfs:label     "厩舎付近の家"@ja;
@@ -4593,7 +4591,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考慮する"@ja;
+    rdfs:label     "考える"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Crime>
     rdf:type    kgc:PhysicalObject;
@@ -4638,7 +4636,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/crush>
     rdf:type    kgc:Action;
-    rdfs:label     "砕く"@ja;
+    rdfs:label     "粉砕する"@ja;
     rdfs:label     "crush"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Wide_space>
     rdfs:label     "広いスペース"@ja;
@@ -4697,7 +4695,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "noContact"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/move>
     rdf:type    kgc:Action;
-    rdfs:label     "移動する"@ja;
+    rdfs:label     "動く"@ja;
     rdfs:label     "move"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mantle>
     rdfs:label     "Mantle"@en;
@@ -4813,7 +4811,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "London"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Knife_that_can_not_hide>
     rdfs:label     "隠すことのできないナイフ"@ja;
@@ -4966,7 +4964,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "ask"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/request>
     rdf:type    kgc:Action;
-    rdfs:label     "依頼する"@ja;
+    rdfs:label     "要求する"@ja;
     rdfs:label     "request"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/deal>
     rdf:type    kgc:Action;
@@ -5019,12 +5017,11 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_stables_and_the_small_building_near_Tavistock>.
 <http://kgc.knowledge-graph.jp/data/predicate/notBlow>
     rdf:type    kgc:Property;
-    rdfs:label     "吹かない"@ja;
+    rdfs:label     "飛ばさない"@ja;
     rdfs:label     "notBlow"@en;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
-    kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/blow>;
-    rdfs:label     "飛ばさない"@ja.
+    kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/blow>.
 <http://kgc.knowledge-graph.jp/data/predicate/Discover>
     rdfs:label     "Discover"@en;
     rdf:type    kgc:Object.
@@ -5060,8 +5057,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/meet>
     rdf:type    kgc:Action;
     rdfs:label     "会う"@ja;
-    rdfs:label     "meet"@en;
-    rdfs:label     "出会う"@ja.
+    rdfs:label     "meet"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Figure_of_the_people>
     rdfs:label     "人の姿"@ja;
     rdfs:label     "Figure of the people"@en;
@@ -5157,15 +5153,14 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/include>
     rdf:type    kgc:Property;
-    rdfs:label     "含む"@ja;
+    rdfs:label     "含んでいる"@ja;
     rdfs:label     "include"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "含んでいる"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/notice>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/ice>;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "気づく"@ja;
     rdfs:label     "notice"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/State>
     rdfs:label     "State"@en;
@@ -5241,7 +5236,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notExist"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪ねる"@ja;
+    rdfs:label     "訪れる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wonder>
     rdf:type    kgc:Action;
@@ -5274,7 +5269,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つけられない"@ja;
+    rdfs:label     "見つからない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hire>
     rdf:type    kgc:Action;
@@ -5446,7 +5441,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "持たない"@ja;
+    rdfs:label     "not持つ"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/retire>
     rdf:type    kgc:Action;
@@ -5467,7 +5462,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/try>
     rdf:type    kgc:Action;
-    rdfs:label     "試みる"@ja;
+    rdfs:label     "しようとする"@ja;
     rdfs:label     "try"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Stables_of_Mapleton>
     rdf:type    kgc:Place;
@@ -5615,7 +5610,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "dark"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着ている"@ja;
+    rdfs:label     "着る"@ja;
     rdfs:label     "wear"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/small_knife>
     rdfs:label     "小さなナイフ"@ja;
@@ -5945,7 +5940,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/work>
     rdf:type    kgc:Action;
-    rdfs:label     "仕事をする"@ja;
+    rdfs:label     "働く"@ja;
     rdfs:label     "work"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Direction>
     rdfs:label     "Direction"@en;
@@ -5967,9 +5962,8 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "teach"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/give>
     rdf:type    kgc:Action;
-    rdfs:label     "渡す"@ja;
-    rdfs:label     "give"@en;
-    rdfs:label     "与える"@ja.
+    rdfs:label     "与える"@ja;
+    rdfs:label     "give"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/amount>
     rdfs:label     "額"@ja;
     rdfs:label     "amount"@en;
@@ -6037,7 +6031,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "集中している"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Watson>
     rdf:type    kgc:Person;
@@ -6515,8 +6509,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "開く"@ja;
     rdfs:label     "open"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "開ける"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Footprint_of_Silver_Blaze>
     rdfs:label     "白銀号の足跡"@ja;
     rdfs:label     "Footprint of Silver Blaze"@en;
@@ -6531,7 +6524,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/paper>.
 <http://kgc.knowledge-graph.jp/data/predicate/whisper>
     rdf:type    kgc:Action;
-    rdfs:label     "ささやく"@ja;
+    rdfs:label     "囁く"@ja;
     rdfs:label     "whisper"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>
     rdf:type    kgc:PhysicalObject;
@@ -6541,7 +6534,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "白銀"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/grab>
     rdf:type    kgc:Action;
-    rdfs:label     "掴む"@ja;
+    rdfs:label     "つかむ"@ja;
     rdfs:label     "grab"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/see>
     rdf:type    kgc:Action;
@@ -6657,7 +6650,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/paper>.
 <http://kgc.knowledge-graph.jp/data/predicate/fight>
     rdf:type    kgc:Action;
-    rdfs:label     "戦う"@ja;
+    rdfs:label     "格闘する"@ja;
     rdfs:label     "fight"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Betting_horse_racing>
     rdfs:label     "競馬の賭け"@ja;
@@ -6780,7 +6773,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Dent_of_wasteland>
     rdfs:label     "荒地の窪み"@ja;
@@ -6804,7 +6797,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/hear>;
-    rdfs:label     "聞かない"@ja;
+    rdfs:label     "聞こえない"@ja;
     rdfs:label     "notHear"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_pattern_of_horseshoe_of_Silver_Blaze>
     rdfs:label     "白銀号の蹄鉄の型"@ja;
@@ -6816,7 +6809,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>.
 <http://kgc.knowledge-graph.jp/data/predicate/comeOut>
     rdf:type    kgc:Action;
-    rdfs:label     "出てくる"@ja;
+    rdfs:label     "あらわにする"@ja;
     rdfs:label     "comeOut"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_name>
     rdfs:label     "The name"@en;

--- a/SilverBlaze.ttl
+++ b/SilverBlaze.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################
@@ -494,8 +494,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/034>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンはメープルトンの調馬場を管理している"@ja ;
-    kgc:source  "Cyrus Brown manages the Mapleton riding ground"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown manages the Mapleton riding ground"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/manage> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mapleton_riding_ground> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/035> .
@@ -1659,8 +1659,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/157>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンはデスボロを管理している"@ja ;
-    kgc:source  "Cyrus Brown manages Desborough"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown manages Desborough"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/manage> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Desborough> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/158> .
@@ -2169,7 +2169,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは白銀号の失踪により得する"@ja ;
     kgc:source  "Silas Brown is obtained by the disappearance of Silver Blaze"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/benefit> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/SilverBlaze/disappearance_of_Silver_Blaze> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/214> .
@@ -2177,7 +2177,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンはデスボロを調馬する"@ja ;
     kgc:source  "Silas Brown is training Desborough"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/train> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Desborough> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/215> .
@@ -2185,7 +2185,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンはデスボロに大金を賭けている"@ja ;
     kgc:source  "Silas Brown is betting a lot of money to Desborough"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/bet> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Lot_of_money> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Desborough> ;
@@ -2193,18 +2193,18 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/216>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンとジョン・ストレーカーは仲が悪い"@ja ;
-    kgc:source  "Cyrus Brown and John Straker have a bad relationship"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown and John Straker have a bad relationship"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/John_Straker> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/bad_terms> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/217> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/217>
     rdf:type    kgc:Situation ;
     kgc:source  "警察はサイラス・ブラウンの厩舎を調べた"@ja ;
-    kgc:source  "The police analyzed the stables of Cyrus Brown stables"@en ;
+    kgc:source  "The police analyzed the stables of Silas Brown stables"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/police> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/examine> ;
-    kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown_stables> ;
+    kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown_stables> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/218> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/218>
     rdf:type    kgc:Situation ;
@@ -2212,14 +2212,14 @@ kgc:Thought rdf:type owl:Class ;
     kgc:source  "The police could not find the white silver degree in Silas Brown stables"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/police> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotFind> ;
-    kgc:where   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown_stables> ;
+    kgc:where   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown_stables> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/219> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/219>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンとフィッロイ・シムソンは接点がない"@ja ;
     kgc:source  "Silas Brown and Fitzroy Simpson has no contact"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Fitzroy_Simpson> ;
     kgc:hasProperty   <http://kgc.knowledge-graph.jp/data/predicate/noContact> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/221> .
@@ -2875,10 +2875,10 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/295a>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズは明日の朝５時にサイラス・ブラウンに会う"@ja ;
-    kgc:source  "Holmes meet Cyrus Brown at 5:00 the following morning"@en ;
+    kgc:source  "Holmes meet Silas Brown at 5:00 the following morning"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/meet> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/SilverBlaze/5_00_tomorrow_morning> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/296>
     rdf:type    kgc:Situation ;
@@ -2891,57 +2891,57 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/297>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは早朝に起床する"@ja ;
-    kgc:source  "Cyrus Brown wakes up early in the morning"@en ;
+    kgc:source  "Silas Brown wakes up early in the morning"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/canMeet> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/SilverBlaze/early_morning> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/298>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは早朝に起床する"@ja ;
-    kgc:source  "Cyrus Brown wakes up early in the morning"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown wakes up early in the morning"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/wakeUp> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/SilverBlaze/early_morning> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/299> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/299>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは狼狽した"@ja ;
-    kgc:source  "Cyrus Brown was upset"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown was upset"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/upset> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/SilverBlaze/300> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/300> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/300>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはサイラス・ブラウンに囁いた"@ja ;
-    kgc:source  "Holmes whispered to Cyrus Brown"@en ;
+    kgc:source  "Holmes whispered to Silas Brown"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/whisper> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/301> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/301>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンはホームズに従った"@ja ;
-    kgc:source  "Cyrus Brown according to Holmes"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown according to Holmes"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/follow> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/302> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/302>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはサイラス・ブラウンに以下を言い伝えた"@ja ;
-    kgc:source  "Holmes legend the following to the Cyrus Brown"@en ;
+    kgc:source  "Holmes legend the following to the Silas Brown"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/205> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/303> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/303>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは悪事を働かないことを約束した"@ja ;
-    kgc:source  "Cyrus Brown has promised that does not work evil"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown has promised that does not work evil"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/promise> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/304> ;
@@ -2949,15 +2949,15 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/304>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは悪事を働かない"@ja ;
-    kgc:source  "Cyrus Brown does not work evil"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown does not work evil"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notWork> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Crime> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/305>
     rdf:type    kgc:Situation ;
     kgc:source  "競馬の時、サイラス・ブラウンは白銀号を自分の物のように扱う"@ja ;
-    kgc:source  "Time of horse racing, Cyrus Brown is dealing with the Silver issue as their own thing"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Time of horse racing, Silas Brown is dealing with the Silver issue as their own thing"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/deal> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
     kgc:how   <http://kgc.knowledge-graph.jp/data/SilverBlaze/As_your_stuff> ;
@@ -2974,8 +2974,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/307>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは白銀号を誘拐していた"@ja ;
-    kgc:source  "Cyrus Brown had kidnapped Silver Blaze"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown had kidnapped Silver Blaze"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kidnap> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/308> .
@@ -3000,38 +3000,38 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/309>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは自分の悪事を認めた"@ja ;
-    kgc:source  "Cyrus Brown admitted his wrongdoing"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown admitted his wrongdoing"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/admit> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Own_wickedness> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/SilverBlaze/310> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/310>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはサイラス・ブラウンに自身の推理を話した"@ja ;
-    kgc:source  "Holmes explained his reasoning to Cyrus Brown"@en ;
+    kgc:source  "Holmes explained his reasoning to Silas Brown"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/say> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Idea_of_Holmes> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/311>
     rdf:type    kgc:Situation ;
     kgc:source  "男の靴の跡とサイラス・ブラウンの靴は適応していた"@ja ;
-    kgc:source  "Mark and Cyrus Brown shoes of a man of the shoes had been adapted"@en ;
+    kgc:source  "Mark and Silas Brown shoes of a man of the shoes had been adapted"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Traces_of_man_s_shoes> ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown_shoes> ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown_shoes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/fit> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/312>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンの部下は白銀号を窃盗できない"@ja ;
-    kgc:source  "Of Cyrus Brown subordinates can not stealing the Silver Blaze"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Subordinates_of_Cyrus_Brown> ;
+    kgc:source  "Of Silas Brown subordinates can not stealing the Silver Blaze"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Subordinates_of_Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/cannotSteal> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/313>
     rdf:type    kgc:Situation ;
     kgc:source  "事件の翌朝、サイラス・ブラウンは荒地で白銀号を見つけた"@ja ;
-    kgc:source  "The morning following the incident, Cyrus Brown found a white silver degree in wasteland"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "The morning following the incident, Silas Brown found a white silver degree in wasteland"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/find> ;
     kgc:on   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Wasteland> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
@@ -3039,8 +3039,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/314>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは白銀号を誘拐した"@ja ;
-    kgc:source  "Cyrus Brown kidnapped Silver Blaze"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown kidnapped Silver Blaze"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/kidnap> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/315>
@@ -3060,24 +3060,24 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/317>
     rdf:type    kgc:Situation ;
     kgc:source  "ホームズはサイラス・ブラウンに以下を指示した"@ja ;
-    kgc:source  "Holmes instructed the following to Cyrus Brown"@en ;
+    kgc:source  "Holmes instructed the following to Silas Brown"@en ;
     kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Holmes> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/instruct> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/318> ;
-    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> .
+    kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/318>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンはメープルトン調馬場の厩舎に白銀号を隠す"@ja ;
-    kgc:source  "Cyrus Brown hide the Silver issue to the stables of Mapleton riding ground"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown hide the Silver issue to the stables of Mapleton riding ground"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hide> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
     kgc:where   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Mapleton_riding_ground_stables> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/319>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは罪を逃れる方法を考える"@ja ;
-    kgc:source  "Cyrus Brown think of a way to escape the sin"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown think of a way to escape the sin"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/consider> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/How_to_escape_the_sin> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/320> .
@@ -3108,8 +3108,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/323>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは白銀に細工を施した"@ja ;
-    kgc:source  "Cyrus Brown was subjected to crafted in Baiyin"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown was subjected to crafted in Baiyin"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/give> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Work> ;
     kgc:to   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
@@ -3125,16 +3125,16 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/325>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは利益を得る"@ja ;
-    kgc:source  "Cyrus Brown benefitted"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown benefitted"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/get> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Profits> ;
     kgc:when   <http://kgc.knowledge-graph.jp/data/SilverBlaze/326> .
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/326>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは白銀号を傷つける"@ja ;
-    kgc:source  "Cyrus Brown hurt Silver Blaze"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown hurt Silver Blaze"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/hurt> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/327> .
@@ -3149,8 +3149,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/328>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは、罪を軽くするために白銀を傷つけない"@ja ;
-    kgc:source  "Cyrus Brown tried to lighten the sin but did not with to damage the silvery white color."@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown tried to lighten the sin but did not with to damage the silvery white color."@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/notHurt> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze> ;
     kgc:why   <http://kgc.knowledge-graph.jp/data/SilverBlaze/329> ;
@@ -3158,8 +3158,8 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/329>
     rdf:type    kgc:Situation ;
     kgc:source  "サイラス・ブラウンは罪を軽くしようとした"@ja ;
-    kgc:source  "Cyrus Brown tried to lighten the sin"@en ;
-    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown> ;
+    kgc:source  "Silas Brown tried to lighten the sin"@en ;
+    kgc:subject   <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown> ;
     kgc:hasPredicate   <http://kgc.knowledge-graph.jp/data/predicate/mitigate> ;
     kgc:what   <http://kgc.knowledge-graph.jp/data/SilverBlaze/sin> ;
     kgc:then   <http://kgc.knowledge-graph.jp/data/SilverBlaze/330> .
@@ -4261,6 +4261,9 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Skull>
     rdfs:label     "Skull"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown>
+    rdfs:label     "Silas Brown"@en;
+    rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Dent>
     rdfs:label     "Dent"@en;
     rdf:type    kgc:Object.
@@ -4303,10 +4306,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Night>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/the_incident>.
-<http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown_shoes>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "サイラス・ブラウンの靴"@ja;
-    rdfs:label     "Cyrus Brown shoes"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/thigh>
     rdfs:label     "thigh"@en;
     rdf:type    kgc:Object.
@@ -4486,6 +4485,10 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "人気である"@ja;
     rdfs:label     "popular"@en.
+<http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown_stables>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "サイラス・ブラウンの厩舎"@ja;
+    rdfs:label     "Silas Brown stables"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/takeOut>
     rdf:type    kgc:Action;
     rdfs:label     "取り出す"@ja;
@@ -4535,6 +4538,13 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "避ける"@ja;
     rdfs:label     "avoid"@en.
+<http://kgc.knowledge-graph.jp/data/SilverBlaze/Subordinates_of_Silas_Brown>
+    rdf:type    kgc:Person;
+    rdfs:label     "サイラス・ブラウンの部下"@ja;
+    rdfs:label     "Subordinates of Silas Brown"@en;
+    rdf:type    kgc:OFobj;
+    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Subordinates>;
+    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/For_horse_racing_information_collection>
     rdfs:label     "競馬の情報収集のため"@ja;
     rdfs:label     "For horse racing information collection"@en;
@@ -4817,11 +4827,6 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "隠すことのできないナイフ"@ja;
     rdfs:label     "Knife that can not hide"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown>
-    rdf:type    kgc:Person;
-    rdfs:label     "サイラス・ブラウン"@ja;
-    rdfs:label     "Cyrus Brown"@en;
-    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Long_vividly>
     rdfs:label     "長く鮮やかに"@ja;
     rdfs:label     "Long vividly"@en;
@@ -5099,13 +5104,6 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/disappearance>
     rdfs:label     "disappearance"@en;
     rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/SilverBlaze/Subordinates_of_Cyrus_Brown>
-    rdf:type    kgc:Person;
-    rdfs:label     "サイラス・ブラウンの部下"@ja;
-    rdfs:label     "Subordinates of Cyrus Brown"@en;
-    rdf:type    kgc:OFobj;
-    kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Subordinates>;
-    kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown>.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/The_forehead>
     rdfs:label     "The forehead"@en;
     rdf:type    kgc:Object.
@@ -5366,10 +5364,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:OFobj;
     kgc:ofPart    <http://kgc.knowledge-graph.jp/data/SilverBlaze/Silver_Blaze>;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SilverBlaze/racehorses>.
-<http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown_stables>
-    rdf:type    kgc:PhysicalObject;
-    rdfs:label     "サイラス・ブラウンの厩舎"@ja;
-    rdfs:label     "Cyrus Brown stables"@en.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/cork>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "コルク"@ja;
@@ -5634,6 +5628,10 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "深く"@ja;
     rdfs:label     "deeply"@en;
     rdf:type    kgc:Object.
+<http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown_shoes>
+    rdf:type    kgc:PhysicalObject;
+    rdfs:label     "サイラス・ブラウンの靴"@ja;
+    rdfs:label     "Silas Brown shoes"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/gain>
     rdf:type    kgc:Action;
     rdfs:label     "獲得する"@ja;
@@ -6142,6 +6140,11 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Property;
     rdfs:label     "跛になる"@ja;
     rdfs:label     "lame"@en.
+<http://kgc.knowledge-graph.jp/data/SilverBlaze/Silas_Brown>
+    rdf:type    kgc:Person;
+    rdfs:label     "サイラス・ブラウン"@ja;
+    rdfs:label     "Silas Brown"@en;
+    rdf:type    kgc:PhysicalObject.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/Along_the_way>
     rdfs:label     "道中"@ja;
     rdfs:label     "Along the way"@en;
@@ -6601,9 +6604,6 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/SilverBlaze/bookmaker>
     rdfs:label     "bookmaker"@en;
-    rdf:type    kgc:Object.
-<http://kgc.knowledge-graph.jp/data/SilverBlaze/Cyrus_Brown>
-    rdfs:label     "Cyrus Brown"@en;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/cannotEnter>
     rdf:type    kgc:Action;

--- a/SpeckledBand.ttl
+++ b/SpeckledBand.ttl
@@ -5,7 +5,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix kgc: <http://kgc.knowledge-graph.jp/ontology/kgc.owl#> . 
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/metadata>
-    rdfs:comment  "作成日（2022-11-05） "@ja ;
+    rdfs:comment  "作成日（2022-11-07） "@ja ;
 	cc:attributionName "SIG-SWO, JSAI" ;
 	cc:license <https://creativecommons.org/licenses/by/4.0/> .
 #################################################################

--- a/SpeckledBand.ttl
+++ b/SpeckledBand.ttl
@@ -4161,7 +4161,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/move>;
-    rdfs:label     "動かせない"@ja;
+    rdfs:label     "動けない"@ja;
     rdfs:label     "cannotMove"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/hinges_of_shutter>
     rdf:type    kgc:PhysicalObject;
@@ -4206,7 +4206,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia’s_bedroom>.
 <http://kgc.knowledge-graph.jp/data/predicate/wander>
     rdf:type    kgc:Action;
-    rdfs:label     "歩き回る"@ja;
+    rdfs:label     "徘徊する"@ja;
     rdfs:label     "wander"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/dog_whip>
     rdf:type    kgc:PhysicalObject;
@@ -4267,10 +4267,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "suffering voice"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/close>
     rdf:type    kgc:Property;
-    rdfs:label     "閉まっている"@ja;
+    rdfs:label     "閉める"@ja;
     rdfs:label     "close"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "閉める"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/notNotice>
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
@@ -4302,7 +4301,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "leopard"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/hit>
     rdf:type    kgc:Action;
-    rdfs:label     "打つ"@ja;
+    rdfs:label     "殴る"@ja;
     rdfs:label     "hit"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/scare>
     rdf:type    kgc:Action;
@@ -4392,7 +4391,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "confirm"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/turnOn>
     rdf:type    kgc:Action;
-    rdfs:label     "点灯する"@ja;
+    rdfs:label     "灯す"@ja;
     rdfs:label     "turnOn"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/like_steam_gushing_out_of_a_medicine_can>
     rdf:type    kgc:Property;
@@ -4524,7 +4523,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "lanthanum"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/receive>
     rdf:type    kgc:Action;
-    rdfs:label     "受ける"@ja;
+    rdfs:label     "受け取る"@ja;
     rdfs:label     "receive"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/canView>
     rdf:type    kgc:Action;
@@ -4551,8 +4550,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdfs:label     "気絶する"@ja;
     rdfs:label     "faint"@en;
-    rdf:type    kgc:Property;
-    rdfs:label     "穏やかな"@ja.
+    rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/mansion_of_Roylott>
     rdf:type    kgc:Place;
     rdfs:label     "ロイロットの屋敷"@ja;
@@ -4597,10 +4595,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "calculate"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/put>
     rdf:type    kgc:Property;
-    rdfs:label     "付いている"@ja;
+    rdfs:label     "置く"@ja;
     rdfs:label     "put"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "置く"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/support>
     rdf:type    kgc:Action;
     rdfs:label     "支える"@ja;
@@ -4619,9 +4616,8 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "小皿の牛乳"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/stop>
     rdf:type    kgc:Action;
-    rdfs:label     "止まる"@ja;
-    rdfs:label     "stop"@en;
-    rdfs:label     "止める"@ja.
+    rdfs:label     "止める"@ja;
+    rdfs:label     "stop"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Move>
     rdfs:label     "Move"@en;
     rdf:type    kgc:Object.
@@ -4638,7 +4634,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/consider>
     rdf:type    kgc:Action;
-    rdfs:label     "考慮する"@ja;
+    rdfs:label     "考える"@ja;
     rdfs:label     "consider"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/house_of_Holmes>
     rdf:type    kgc:Place;
@@ -4713,7 +4709,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "sleepwear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/move>
     rdf:type    kgc:Action;
-    rdfs:label     "移動する"@ja;
+    rdfs:label     "動く"@ja;
     rdfs:label     "move"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/smell_of_oil>
     rdf:type    kgc:PhysicalObject;
@@ -4866,7 +4862,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/return>
     rdf:type    kgc:Action;
-    rdfs:label     "戻る"@ja;
+    rdfs:label     "帰る"@ja;
     rdfs:label     "return"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/narrow>
     rdf:type    kgc:Property;
@@ -4881,7 +4877,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "small"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/keep>
     rdf:type    kgc:Action;
-    rdfs:label     "維持する"@ja;
+    rdfs:label     "飼っている"@ja;
     rdfs:label     "keep"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/send>
     rdf:type    kgc:Action;
@@ -4988,8 +4984,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/suspect>
     rdf:type    kgc:Action;
     rdfs:label     "疑う"@ja;
-    rdfs:label     "suspect"@en;
-    rdfs:label     "知る"@ja.
+    rdfs:label     "suspect"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/tremble>
     rdf:type    kgc:Action;
     rdfs:label     "震える"@ja;
@@ -5152,7 +5147,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "notExist"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/visit>
     rdf:type    kgc:Action;
-    rdfs:label     "訪ねる"@ja;
+    rdfs:label     "訪れる"@ja;
     rdfs:label     "visit"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/result>
     rdfs:label     "結果"@ja;
@@ -5199,7 +5194,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/find>;
-    rdfs:label     "見つけられない"@ja;
+    rdfs:label     "見つからない"@ja;
     rdfs:label     "cannotFind"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/wrist>
     rdfs:label     "wrist"@en;
@@ -5262,7 +5257,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "clothes"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/jumpUp>
     rdf:type    kgc:Action;
-    rdfs:label     "跳び上がる"@ja;
+    rdfs:label     "飛び上がる"@ja;
     rdfs:label     "jumpUp"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/safe>
     rdf:type    kgc:PhysicalObject;
@@ -5377,7 +5372,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/have>;
-    rdfs:label     "持たない"@ja;
+    rdfs:label     "not持つ"@ja;
     rdfs:label     "notHave"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/question>
     rdfs:label     "question"@en;
@@ -5397,7 +5392,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "callBack"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/ruin>
     rdf:type    kgc:Property;
-    rdfs:label     "廃墟"@ja;
+    rdfs:label     "破滅させる"@ja;
     rdfs:label     "ruin"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/notListen>
     rdf:type    kgc:Action;
@@ -5418,7 +5413,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "limbs"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/goDown>
     rdf:type    kgc:Action;
-    rdfs:label     "下りる"@ja;
+    rdfs:label     "降りる"@ja;
     rdfs:label     "goDown"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/use>
     rdf:type    kgc:Action;
@@ -5479,7 +5474,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen>.
 <http://kgc.knowledge-graph.jp/data/predicate/smell>
     rdf:type    kgc:Action;
-    rdfs:label     "匂う"@ja;
+    rdfs:label     "嗅ぐ"@ja;
     rdfs:label     "smell"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/handgun>
     rdf:type    kgc:PhysicalObject;
@@ -5499,10 +5494,9 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "signal"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/wear>
     rdf:type    kgc:Property;
-    rdfs:label     "着ている"@ja;
+    rdfs:label     "着る"@ja;
     rdfs:label     "wear"@en;
-    rdf:type    kgc:Action;
-    rdfs:label     "着る"@ja.
+    rdf:type    kgc:Action.
 <http://kgc.knowledge-graph.jp/data/predicate/dark>
     rdf:type    kgc:Property;
     rdfs:label     "暗い"@ja;
@@ -5517,7 +5511,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "fall"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/gain>
     rdf:type    kgc:Action;
-    rdfs:label     "得る"@ja;
+    rdfs:label     "獲得する"@ja;
     rdfs:label     "gain"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/putInto>
     rdf:type    kgc:Action;
@@ -5631,7 +5625,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "contain"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/getOff>
     rdf:type    kgc:Action;
-    rdfs:label     "下車する"@ja;
+    rdfs:label     "飛び降りる"@ja;
     rdfs:label     "getOff"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/fixed>
     rdf:type    kgc:Property;
@@ -5682,7 +5676,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott>.
 <http://kgc.knowledge-graph.jp/data/predicate/pale>
     rdf:type    kgc:Property;
-    rdfs:label     "真っ青である"@ja;
+    rdfs:label     "青ざめる"@ja;
     rdfs:label     "pale"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/India>
     rdf:type    kgc:Place;
@@ -5777,7 +5771,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "毒物"@ja.
 <http://kgc.knowledge-graph.jp/data/predicate/work>
     rdf:type    kgc:Action;
-    rdfs:label     "仕事をする"@ja;
+    rdfs:label     "働く"@ja;
     rdfs:label     "work"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/by_falling_price>
     rdfs:label     "by falling price"@en;
@@ -5811,8 +5805,7 @@ kgc:Thought rdf:type owl:Class ;
 <http://kgc.knowledge-graph.jp/data/predicate/sit>
     rdf:type    kgc:Action;
     rdfs:label     "座る"@ja;
-    rdfs:label     "sit"@en;
-    rdfs:label     "存在する"@ja.
+    rdfs:label     "sit"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/central_building>
     rdf:type    kgc:PhysicalObject;
     rdfs:label     "中央部"@ja;
@@ -5837,7 +5830,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "hear"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/focus>
     rdf:type    kgc:Action;
-    rdfs:label     "注目する"@ja;
+    rdfs:label     "集中している"@ja;
     rdfs:label     "focus"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/desk>
     rdf:type    kgc:PhysicalObject;
@@ -5860,7 +5853,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Roylott’s_bedroom>.
 <http://kgc.knowledge-graph.jp/data/predicate/lookAround>
     rdf:type    kgc:Action;
-    rdfs:label     "見まわす"@ja;
+    rdfs:label     "ながめ回す"@ja;
     rdfs:label     "lookAround"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/cane>
     rdf:type    kgc:PhysicalObject;
@@ -5877,7 +5870,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/beReleased>
     rdf:type    kgc:Action;
-    rdfs:label     "放たれる"@ja;
+    rdfs:label     "存在する"@ja;
     rdfs:label     "beReleased"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/back_part>
     rdfs:label     "back part"@en;
@@ -5896,7 +5889,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "this morning"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/arrive>
     rdf:type    kgc:Action;
-    rdfs:label     "来る"@ja;
+    rdfs:label     "到着する"@ja;
     rdfs:label     "arrive"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/scar>
     rdf:type    kgc:PhysicalObject;
@@ -5943,9 +5936,8 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:CanNotAction;
     kgc:canNot    <http://kgc.knowledge-graph.jp/data/predicate/gothrough>;
-    rdfs:label     "通り抜けできない"@ja;
-    rdfs:label     "cannotGoThrough"@en;
-    rdfs:label     "通れない"@ja.
+    rdfs:label     "通れない"@ja;
+    rdfs:label     "cannotGoThrough"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/by_hitting>
     rdfs:label     "叩いて"@ja;
     rdfs:label     "by hitting"@en;
@@ -6072,7 +6064,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Julia>.
 <http://kgc.knowledge-graph.jp/data/predicate/goUp>
     rdf:type    kgc:Action;
-    rdfs:label     "上がる"@ja;
+    rdfs:label     "上る"@ja;
     rdfs:label     "goUp"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/die>
     rdf:type    kgc:Action;
@@ -6086,7 +6078,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Action;
     rdf:type    kgc:NotAction;
     kgc:Not    <http://kgc.knowledge-graph.jp/data/predicate/respond>;
-    rdfs:label     "答えない"@ja;
+    rdfs:label     "反応しない"@ja;
     rdfs:label     "notRespond"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/Sleeping_Woman>
     rdfs:label     "寝台に寝ていた女性"@ja;
@@ -6112,7 +6104,7 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "metallic sound"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/tie>
     rdf:type    kgc:Property;
-    rdfs:label     "結ばれている"@ja;
+    rdfs:label     "縛る"@ja;
     rdfs:label     "tie"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/Open>
     rdfs:label     "Open"@en;
@@ -6191,7 +6183,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/stay>
     rdf:type    kgc:Action;
-    rdfs:label     "留まる"@ja;
+    rdfs:label     "滞在する"@ja;
     rdfs:label     "stay"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/friend_of_Roylott>
     rdf:type    kgc:Property;
@@ -6270,9 +6262,8 @@ kgc:Thought rdf:type owl:Class ;
     rdfs:label     "prepare"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/open>
     rdf:type    kgc:Action;
-    rdfs:label     "開ける"@ja;
-    rdfs:label     "open"@en;
     rdfs:label     "開く"@ja;
+    rdfs:label     "open"@en;
     rdf:type    kgc:Property.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/same_place>
     rdfs:label     "同じ位置"@ja;
@@ -6350,7 +6341,7 @@ kgc:Thought rdf:type owl:Class ;
     rdf:type    kgc:Object.
 <http://kgc.knowledge-graph.jp/data/predicate/fight>
     rdf:type    kgc:Action;
-    rdfs:label     "戦う"@ja;
+    rdfs:label     "格闘する"@ja;
     rdfs:label     "fight"@en.
 <http://kgc.knowledge-graph.jp/data/predicate/VentilationHole>
     rdf:type    kgc:Property;
@@ -6396,7 +6387,7 @@ kgc:Thought rdf:type owl:Class ;
     kgc:ofWhole    <http://kgc.knowledge-graph.jp/data/SpeckledBand/Helen’s_mothers_death>.
 <http://kgc.knowledge-graph.jp/data/predicate/want>
     rdf:type    kgc:Action;
-    rdfs:label     "望む"@ja;
+    rdfs:label     "したい"@ja;
     rdfs:label     "want"@en.
 <http://kgc.knowledge-graph.jp/data/SpeckledBand/bedroom_of_housekeeper>
     rdf:type    kgc:Place;


### PR DESCRIPTION
EtoJの適用  
キャラクター英語名およびURIの修正
- ACaseOfIdentity
  - Windybank→Windibank
  - Hozma→Hosmer
- AbbeyGrange
  - Jack Crocker→Jack Croker
- CrookedMan
  - Berkeley→Barclay
- DancingMen
  - Qubit→Cubitt
- Devil'sFoot
  - Standale→Sterndale
- SilverBlaze
  - Cyrus Brown→ Silas Brown
